### PR TITLE
fix(rc18-wave1): Rule 111 self-hardening + helper extraction (ADR-0095 Wave 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # rc18 Wave 1 / ADR-0095: full history required for Gate Rule 111
+          # (architecture_refresh_defect_family_re_eval_required) freshness
+          # check — yaml file's own git commit date vs latest refresh-signal
+          # commit date. Shallow clone (default fetch-depth=1) fails the
+          # rule per fix 1h (shallow-clone fail-closed, was silent pass).
+          fetch-depth: 0
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4
@@ -89,6 +96,10 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # rc18 Wave 1 / ADR-0095: full history required for Gate Rule 111
+          # freshness check (see ci.yml comment above).
+          fetch-depth: 0
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/gate/check_architecture_sync.sh
+++ b/gate/check_architecture_sync.sh
@@ -5628,84 +5628,77 @@ if [[ $_r110_fail -eq 0 ]]; then pass_rule "prevention_rule_scope_completeness";
 # ---------------------------------------------------------------------------
 # Rule 111 — architecture_refresh_defect_family_re_eval_required (enforcers E156 E157 E158)
 #
-# Operationalises Rule G-9 (Recurring-Defect Family Truth). Enforces three
-# invariants on the recurring-defect-family ledger:
-#   .a (E156) — yaml well-formedness: docs/governance/recurring-defect-families.yaml
-#               exists, has top-level schema_version + last_updated + families,
-#               and every family entry has 9 required per-family fields.
-#   .b (E157) — freshness: yaml `last_updated:` ISO date is no older than the
-#               commit date of the most recent refresh-signal change. Signals:
-#               docs/adr/*.yaml, docs/governance/architecture-status.yaml,
-#               docs/logs/releases/*.md, CLAUDE.md.
-#   .c (E158) — yaml/md family-id parity: the set of `^  - id:` slugs in the
-#               yaml equals the set of `F-...` ids referenced in
-#               docs/governance/recurring-defect-families.md.
-# Per ADR-0094 (rc17 recurring-defect-family-truth + rule-consolidation).
+# Operationalises Rule G-9 (Recurring-Defect Family Truth). Per ADR-0095
+# rc18 Wave 1, the 3 sub-checks delegate to shared helpers in
+# gate/lib/check_recurring_families.sh — closes F-kernel-vs-implementation-
+# drift on Rule 111 itself (Wave 1 finding: fixtures and gate both invoke
+# the same code, no inline re-implementation).
 #
-# scope_surfaces: docs/governance/recurring-defect-families.yaml, docs/governance/recurring-defect-families.md, docs/adr/, docs/logs/releases/, CLAUDE.md, docs/governance/architecture-status.yaml
+# Hardening fixes (per ADR-0095):
+#   1a — yaml's own git commit date drives freshness (not hand-edited last_updated)
+#   1b — families: [] is rejected (hard non-empty assertion)
+#   1c — cleanup_status enum value validated against {closed | structurally_addressed |
+#        partial | incomplete | monitoring}
+#   1d — per-family block-bucket: each family has every required field exactly once
+#        (closes duplicate-field compensation blind spot)
+#   1e — last_updated must be ISO YYYY-MM-DD format
+#   1f — md parity anchored to ^### F- H3 headings (mirrors yaml ^  - id: anchoring,
+#        closes prose false-positives)
+#   1g — refresh-signal path filter INCLUDES docs/governance/rules/
+#   1h — shallow-clone fail-closed (was silent pass)
+#
+# Sub-checks:
+#   .a (E156) — yaml well-formedness (file + top-level keys + ISO date +
+#               non-empty + per-family field count + enum validation)
+#   .b (E157) — freshness via yaml file's own git commit date vs latest
+#               refresh-signal commit date
+#   .c (E158) — yaml/md family-id parity, both sides H3/structural-anchored
+#
+# Per ADR-0094 (rc17 introduction) + ADR-0095 (rc18 Wave 1 hardening).
+#
+# scope_surfaces: docs/governance/recurring-defect-families.yaml, docs/governance/recurring-defect-families.md, docs/adr/, docs/logs/releases/, CLAUDE.md, docs/governance/architecture-status.yaml, docs/governance/rules/, gate/lib/check_recurring_families.sh
 # ---------------------------------------------------------------------------
 _r111_yaml="docs/governance/recurring-defect-families.yaml"
 _r111_md="docs/governance/recurring-defect-families.md"
+_r111_helper="gate/lib/check_recurring_families.sh"
 _r111_fail=0
 
-# Sub-check .a — yaml well-formedness
-if [[ ! -f "$_r111_yaml" ]]; then
-  fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_yaml missing -- Rule G-9.a / E156 (ADR-0094)"
-  _r111_fail=1
+if [[ ! -f "$_r111_helper" ]]; then
+  fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_helper missing -- Rule G-9 / ADR-0095 Wave 1 helper file required"
 else
-  for _r111_topkey in schema_version last_updated families; do
-    if ! grep -qE "^${_r111_topkey}:" "$_r111_yaml" 2>/dev/null; then
-      fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_yaml missing top-level key '$_r111_topkey' -- Rule G-9.a / E156"
-      _r111_fail=1
-    fi
-  done
-  _r111_fam_count=$(grep -cE '^  - id:' "$_r111_yaml" 2>/dev/null)
-  _r111_fam_count=${_r111_fam_count:-0}
-  if [[ "$_r111_fam_count" -gt 0 ]]; then
-    for _r111_field in title first_observed_rc last_observed_rc occurrences root_cause surfaces prevention_rules cleanup_status open_residual; do
-      _r111_count=$(grep -cE "^    ${_r111_field}:" "$_r111_yaml" 2>/dev/null)
-      _r111_count=${_r111_count:-0}
-      if [[ "$_r111_count" -lt "$_r111_fam_count" ]]; then
-        fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_yaml field '$_r111_field' appears $_r111_count times but $_r111_fam_count families declared -- Rule G-9.a / E156"
-        _r111_fail=1
-      fi
-    done
-  fi
-fi
+  # Source helpers once; capture each sub-check's stdout for fail_rule emission.
+  # shellcheck disable=SC1090
+  source "$_r111_helper"
 
-# Sub-check .b — freshness: yaml last_updated >= latest refresh-signal commit date
-if [[ -f "$_r111_yaml" ]] && command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
-  _r111_yaml_date=$(awk '/^last_updated:/ { gsub(/[\"'\'']/,""); print $2; exit }' "$_r111_yaml" 2>/dev/null)
-  if [[ -n "$_r111_yaml_date" ]]; then
-    _r111_signal_date=$(git log -1 --format=%cI -- \
-      'docs/adr/' \
-      'docs/governance/architecture-status.yaml' \
-      'docs/logs/releases/' \
-      'CLAUDE.md' 2>/dev/null | cut -dT -f1)
-    if [[ -n "$_r111_signal_date" && "$_r111_signal_date" > "$_r111_yaml_date" ]]; then
-      fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_yaml last_updated=$_r111_yaml_date is older than refresh-signal commit date $_r111_signal_date -- Rule G-9.b / E157 (run /refresh-defect-archive)"
+  # Sub-check .a — yaml well-formedness (covers fixes 1b, 1c, 1d, 1e)
+  _r111_a_output=$(_check_recurring_families_yaml_wellformed "$_r111_yaml")
+  if [[ -n "$_r111_a_output" ]]; then
+    while IFS= read -r _r111_line; do
+      [[ -z "$_r111_line" ]] && continue
+      fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_line"
       _r111_fail=1
-    fi
+    done <<< "$_r111_a_output"
   fi
-fi
 
-# Sub-check .c — yaml/md family-id parity
-if [[ -f "$_r111_yaml" && -f "$_r111_md" ]]; then
-  _r111_yaml_ids_file="$(mktemp)"
-  _r111_md_ids_file="$(mktemp)"
-  awk '/^  - id:[[:space:]]+/ {print $3}' "$_r111_yaml" 2>/dev/null | sort -u > "$_r111_yaml_ids_file"
-  grep -oE 'F-[a-z][a-z0-9-]*' "$_r111_md" 2>/dev/null | sort -u > "$_r111_md_ids_file"
-  _r111_only_yaml=$(comm -23 "$_r111_yaml_ids_file" "$_r111_md_ids_file")
-  _r111_only_md=$(comm -13 "$_r111_yaml_ids_file" "$_r111_md_ids_file")
-  if [[ -n "$_r111_only_yaml" ]]; then
-    fail_rule "architecture_refresh_defect_family_re_eval_required" "Family ids in yaml but missing from md: $(echo $_r111_only_yaml) -- Rule G-9.c / E158"
-    _r111_fail=1
+  # Sub-check .b — freshness (covers fixes 1a, 1g, 1h)
+  _r111_b_output=$(_check_recurring_families_freshness "$_r111_yaml" ".")
+  if [[ -n "$_r111_b_output" ]]; then
+    while IFS= read -r _r111_line; do
+      [[ -z "$_r111_line" ]] && continue
+      fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_line"
+      _r111_fail=1
+    done <<< "$_r111_b_output"
   fi
-  if [[ -n "$_r111_only_md" ]]; then
-    fail_rule "architecture_refresh_defect_family_re_eval_required" "Family ids in md but missing from yaml: $(echo $_r111_only_md) -- Rule G-9.c / E158"
-    _r111_fail=1
+
+  # Sub-check .c — md/yaml parity (covers fix 1f)
+  _r111_c_output=$(_check_recurring_families_md_yaml_parity "$_r111_yaml" "$_r111_md")
+  if [[ -n "$_r111_c_output" ]]; then
+    while IFS= read -r _r111_line; do
+      [[ -z "$_r111_line" ]] && continue
+      fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_line"
+      _r111_fail=1
+    done <<< "$_r111_c_output"
   fi
-  rm -f "$_r111_yaml_ids_file" "$_r111_md_ids_file"
 fi
 
 if [[ $_r111_fail -eq 0 ]]; then pass_rule "architecture_refresh_defect_family_re_eval_required"; fi

--- a/gate/lib/check_recurring_families.sh
+++ b/gate/lib/check_recurring_families.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# gate/lib/check_recurring_families.sh
+#
+# Shared helper functions for Rule G-9 / Gate Rule 111 + the 3 self-test
+# fixtures. Per ADR-0095 (rc18 Wave 1) the helper extraction closes the
+# F-kernel-vs-implementation-drift family on Rule 111 itself by ensuring
+# fixtures and gate both invoke the same logic — no inline re-implementation.
+#
+# Interface (all return 0 on pass, 1 on fail; failure messages printed to
+# stdout for fixture capture):
+#
+#   _check_recurring_families_yaml_wellformed <yaml_path>
+#       Sub-check .a (E156). Validates:
+#         - file exists
+#         - top-level schema_version, last_updated, families present
+#         - last_updated is ISO YYYY-MM-DD format (fix 1e)
+#         - families array is non-empty (fix 1b — hard assertion)
+#         - per-family block-bucket: each family has all 9 required
+#           fields exactly once (fix 1d — closes duplicate-field
+#           compensation blind spot)
+#         - cleanup_status value ∈ {closed, structurally_addressed,
+#           partial, incomplete, monitoring} (fix 1c — closes enum
+#           presence-only validation)
+#
+#   _check_recurring_families_freshness <yaml_path> <repo_root>
+#       Sub-check .b (E157). Validates:
+#         - shallow clone detection (fix 1h — fail-closed not silent)
+#         - signal commit date (git log of refresh-signal paths
+#           INCLUDING docs/governance/rules/ — fix 1g)
+#         - yaml file's own commit date (fix 1a — git mtime not
+#           hand-edited last_updated field)
+#         - signal commit date <= yaml file commit date
+#
+#   _check_recurring_families_md_yaml_parity <yaml_path> <md_path>
+#       Sub-check .c (E158). Validates:
+#         - yaml `^  - id:` slug set EQUALS
+#         - md `^### F-` H3 heading slug set (fix 1f — H3 anchoring,
+#           closes prose false-positives)
+#
+# Authority: ADR-0095 rc18 Wave 1.
+
+set -uo pipefail
+
+# Constants
+_CRF_REQUIRED_TOPKEYS="schema_version last_updated families"
+_CRF_REQUIRED_FAMILY_FIELDS="title first_observed_rc last_observed_rc occurrences root_cause surfaces prevention_rules cleanup_status open_residual"
+_CRF_CLEANUP_STATUS_ENUM="closed structurally_addressed partial incomplete monitoring"
+_CRF_REFRESH_SIGNAL_PATHS=(
+  "docs/adr/"
+  "docs/governance/architecture-status.yaml"
+  "docs/logs/releases/"
+  "docs/governance/rules/"
+  "CLAUDE.md"
+)
+
+# -----------------------------------------------------------------------------
+# Sub-check .a — yaml well-formedness
+# -----------------------------------------------------------------------------
+_check_recurring_families_yaml_wellformed() {
+  local yaml="$1"
+  local fail=0
+
+  if [[ ! -f "$yaml" ]]; then
+    printf 'FAIL [yaml-wellformed]: %s missing -- Rule G-9.a / E156\n' "$yaml"
+    return 1
+  fi
+
+  # Top-level keys present
+  local topkey
+  for topkey in $_CRF_REQUIRED_TOPKEYS; do
+    if ! grep -qE "^${topkey}:" "$yaml" 2>/dev/null; then
+      printf 'FAIL [yaml-wellformed]: %s missing top-level key %s -- Rule G-9.a / E156\n' "$yaml" "$topkey"
+      fail=1
+    fi
+  done
+
+  # Fix 1e: last_updated must be ISO YYYY-MM-DD
+  local last_updated
+  last_updated=$(awk '/^last_updated:/ { gsub(/["'\'']/,""); print $2; exit }' "$yaml" 2>/dev/null)
+  if [[ -n "$last_updated" && ! "$last_updated" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    printf 'FAIL [yaml-wellformed]: last_updated value %q is not ISO YYYY-MM-DD format -- Rule G-9.a / E156 (fix 1e)\n' "$last_updated"
+    fail=1
+  fi
+
+  # Fix 1b: families array must be non-empty (hard assertion)
+  local fam_count
+  fam_count=$(grep -cE '^  - id:' "$yaml" 2>/dev/null)
+  fam_count=${fam_count:-0}
+  if [[ "$fam_count" -eq 0 ]]; then
+    printf 'FAIL [yaml-wellformed]: families array is empty (families: [] is forbidden) -- Rule G-9.a / E156 (fix 1b)\n'
+    fail=1
+    return $fail
+  fi
+
+  # Fix 1d: per-family block-bucket — walk awk between ^  - id: boundaries,
+  # check each family has every required field exactly once + cleanup_status
+  # value is in the enum set. Closes the duplicate-field compensation blind
+  # spot AND the enum-presence-only validation gap (fix 1c).
+  local awk_output
+  awk_output=$(awk -v required="$_CRF_REQUIRED_FAMILY_FIELDS" \
+                   -v enum="$_CRF_CLEANUP_STATUS_ENUM" '
+    BEGIN {
+      n = split(required, req_arr, " ")
+      m = split(enum, enum_arr, " ")
+      cur_id = ""
+    }
+    function flush_family(id,    i, k, cnt, status_val, status_ok) {
+      if (id == "") return
+      for (i = 1; i <= n; i++) {
+        cnt = field_count[id, req_arr[i]] + 0
+        if (cnt == 0) {
+          print "MISSING|" id "|" req_arr[i]
+        } else if (cnt > 1) {
+          print "DUPLICATE|" id "|" req_arr[i] "|" cnt
+        }
+      }
+      status_val = field_value[id, "cleanup_status"]
+      if (status_val != "") {
+        status_ok = 0
+        for (k = 1; k <= m; k++) if (status_val == enum_arr[k]) status_ok = 1
+        if (!status_ok) print "ENUM|" id "|cleanup_status|" status_val
+      }
+    }
+    /^  - id:[[:space:]]+/ {
+      flush_family(cur_id)
+      cur_id = $3
+      gsub(/["'\'']/, "", cur_id)
+      seen_ids[cur_id]++
+      if (seen_ids[cur_id] > 1) print "DUPLICATE_ID|" cur_id
+      next
+    }
+    cur_id != "" && /^    [a-z_]+:/ {
+      # Field at correct indent (4 spaces under a family entry)
+      line = $0
+      sub(/^    /, "", line)
+      key = line
+      sub(/:.*/, "", key)
+      value = line
+      sub(/^[^:]*:[[:space:]]*/, "", value)
+      # strip surrounding quotes if present
+      sub(/^["'\'']/, "", value)
+      sub(/["'\'']$/, "", value)
+      field_count[cur_id, key]++
+      if (field_count[cur_id, key] == 1) field_value[cur_id, key] = value
+    }
+    END { flush_family(cur_id) }
+  ' "$yaml")
+
+  if [[ -n "$awk_output" ]]; then
+    local line kind id field detail
+    while IFS= read -r line; do
+      kind="${line%%|*}"
+      case "$kind" in
+        MISSING)
+          IFS='|' read -r _ id field <<< "$line"
+          printf 'FAIL [yaml-wellformed]: family %s missing required field %s -- Rule G-9.a / E156 (fix 1d)\n' "$id" "$field"
+          fail=1
+          ;;
+        DUPLICATE)
+          IFS='|' read -r _ id field detail <<< "$line"
+          printf 'FAIL [yaml-wellformed]: family %s declares field %s %s times (must be exactly 1) -- Rule G-9.a / E156 (fix 1d)\n' "$id" "$field" "$detail"
+          fail=1
+          ;;
+        DUPLICATE_ID)
+          IFS='|' read -r _ id <<< "$line"
+          printf 'FAIL [yaml-wellformed]: family id %s declared more than once -- Rule G-9.a / E156 (fix 1d)\n' "$id"
+          fail=1
+          ;;
+        ENUM)
+          IFS='|' read -r _ id field detail <<< "$line"
+          printf 'FAIL [yaml-wellformed]: family %s field %s value %q not in enum {%s} -- Rule G-9.a / E156 (fix 1c)\n' "$id" "$field" "$detail" "$_CRF_CLEANUP_STATUS_ENUM"
+          fail=1
+          ;;
+      esac
+    done <<< "$awk_output"
+  fi
+
+  return $fail
+}
+
+# -----------------------------------------------------------------------------
+# Sub-check .b — freshness (yaml file's git mtime vs refresh-signal mtime)
+# -----------------------------------------------------------------------------
+_check_recurring_families_freshness() {
+  local yaml="$1"
+  local repo_root="${2:-$(pwd)}"
+  local fail=0
+
+  if [[ ! -f "$yaml" ]]; then
+    # Subsumed by sub-check .a; don't double-fail
+    return 0
+  fi
+
+  if ! command -v git >/dev/null 2>&1; then
+    # No git available — can't check; skip silently in non-git contexts
+    return 0
+  fi
+  if ! ( cd "$repo_root" && git rev-parse --git-dir >/dev/null 2>&1 ); then
+    return 0
+  fi
+
+  # Fix 1h: shallow-clone fail-closed (not silent pass)
+  local is_shallow
+  is_shallow=$( cd "$repo_root" && git rev-parse --is-shallow-repository 2>/dev/null )
+  if [[ "$is_shallow" == "true" ]]; then
+    printf 'FAIL [freshness]: cannot evaluate freshness on shallow clone (run git fetch --unshallow in CI) -- Rule G-9.b / E157 (fix 1h)\n'
+    return 1
+  fi
+
+  # Fix 1g: refresh-signal paths INCLUDE docs/governance/rules/
+  # Fix 1a: compare yaml FILE's own commit date (not hand-edited last_updated)
+  local signal_date yaml_commit_date
+  signal_date=$( cd "$repo_root" && git log -1 --format=%cI -- "${_CRF_REFRESH_SIGNAL_PATHS[@]}" 2>/dev/null | cut -dT -f1 )
+  yaml_commit_date=$( cd "$repo_root" && git log -1 --format=%cI -- "$yaml" 2>/dev/null | cut -dT -f1 )
+
+  if [[ -z "$yaml_commit_date" ]]; then
+    # yaml has never been committed — that's a wave 1 bootstrap state.
+    # Don't fail; let .a catch the missing-file case.
+    return 0
+  fi
+
+  if [[ -z "$signal_date" ]]; then
+    # No refresh signals committed yet (impossible in a real repo, but
+    # defensive). Treat as pass.
+    return 0
+  fi
+
+  # signal_date > yaml_commit_date means a refresh-signal commit landed
+  # AFTER the family yaml was last touched — author failed to sync.
+  # String comparison works for ISO YYYY-MM-DD.
+  if [[ "$signal_date" > "$yaml_commit_date" ]]; then
+    printf 'FAIL [freshness]: yaml commit date %s is older than refresh-signal commit date %s -- Rule G-9.b / E157 (run /refresh-defect-archive then commit; fix 1a)\n' "$yaml_commit_date" "$signal_date"
+    fail=1
+  fi
+
+  return $fail
+}
+
+# -----------------------------------------------------------------------------
+# Sub-check .c — yaml/md family-id parity
+# -----------------------------------------------------------------------------
+_check_recurring_families_md_yaml_parity() {
+  local yaml="$1"
+  local md="$2"
+  local fail=0
+
+  if [[ ! -f "$yaml" || ! -f "$md" ]]; then
+    return 0
+  fi
+
+  local yaml_ids_file md_ids_file
+  yaml_ids_file=$(mktemp)
+  md_ids_file=$(mktemp)
+
+  # yaml side: structural ^  - id: rows only
+  awk '/^  - id:[[:space:]]+/ {gsub(/["'\'']/, "", $3); print $3}' "$yaml" 2>/dev/null | sort -u > "$yaml_ids_file"
+
+  # Fix 1f: md side: ONLY ^### F- H3 headings (mirror yaml anchoring;
+  # closes prose F-... false-positive matches like "see F-deprecated-thing
+  # in the table above")
+  grep -oE '^### F-[a-z][a-z0-9-]*' "$md" 2>/dev/null | sed 's/^### //' | sort -u > "$md_ids_file"
+
+  local only_yaml only_md
+  only_yaml=$(comm -23 "$yaml_ids_file" "$md_ids_file")
+  only_md=$(comm -13 "$yaml_ids_file" "$md_ids_file")
+
+  if [[ -n "$only_yaml" ]]; then
+    printf 'FAIL [md-yaml-parity]: family ids in yaml but missing from md ^### F- headings: %s -- Rule G-9.c / E158\n' "$(echo $only_yaml)"
+    fail=1
+  fi
+  if [[ -n "$only_md" ]]; then
+    printf 'FAIL [md-yaml-parity]: family ids in md ^### F- headings but missing from yaml: %s -- Rule G-9.c / E158\n' "$(echo $only_md)"
+    fail=1
+  fi
+
+  rm -f "$yaml_ids_file" "$md_ids_file"
+  return $fail
+}
+
+# -----------------------------------------------------------------------------
+# Wrapper: run all three sub-checks. Used by both Gate Rule 111 and by
+# fixture #4 (test_rule_111_all_clean_pos).
+# -----------------------------------------------------------------------------
+_check_recurring_families_all() {
+  local yaml="$1"
+  local md="$2"
+  local repo_root="${3:-$(pwd)}"
+  local fail=0
+  _check_recurring_families_yaml_wellformed "$yaml" || fail=1
+  _check_recurring_families_freshness "$yaml" "$repo_root" || fail=1
+  _check_recurring_families_md_yaml_parity "$yaml" "$md" || fail=1
+  return $fail
+}

--- a/gate/rules/rule-111.sh
+++ b/gate/rules/rule-111.sh
@@ -5,84 +5,77 @@
 
 # Rule 111 — architecture_refresh_defect_family_re_eval_required (enforcers E156 E157 E158)
 #
-# Operationalises Rule G-9 (Recurring-Defect Family Truth). Enforces three
-# invariants on the recurring-defect-family ledger:
-#   .a (E156) — yaml well-formedness: docs/governance/recurring-defect-families.yaml
-#               exists, has top-level schema_version + last_updated + families,
-#               and every family entry has 9 required per-family fields.
-#   .b (E157) — freshness: yaml `last_updated:` ISO date is no older than the
-#               commit date of the most recent refresh-signal change. Signals:
-#               docs/adr/*.yaml, docs/governance/architecture-status.yaml,
-#               docs/logs/releases/*.md, CLAUDE.md.
-#   .c (E158) — yaml/md family-id parity: the set of `^  - id:` slugs in the
-#               yaml equals the set of `F-...` ids referenced in
-#               docs/governance/recurring-defect-families.md.
-# Per ADR-0094 (rc17 recurring-defect-family-truth + rule-consolidation).
+# Operationalises Rule G-9 (Recurring-Defect Family Truth). Per ADR-0095
+# rc18 Wave 1, the 3 sub-checks delegate to shared helpers in
+# gate/lib/check_recurring_families.sh — closes F-kernel-vs-implementation-
+# drift on Rule 111 itself (Wave 1 finding: fixtures and gate both invoke
+# the same code, no inline re-implementation).
 #
-# scope_surfaces: docs/governance/recurring-defect-families.yaml, docs/governance/recurring-defect-families.md, docs/adr/, docs/logs/releases/, CLAUDE.md, docs/governance/architecture-status.yaml
+# Hardening fixes (per ADR-0095):
+#   1a — yaml's own git commit date drives freshness (not hand-edited last_updated)
+#   1b — families: [] is rejected (hard non-empty assertion)
+#   1c — cleanup_status enum value validated against {closed | structurally_addressed |
+#        partial | incomplete | monitoring}
+#   1d — per-family block-bucket: each family has every required field exactly once
+#        (closes duplicate-field compensation blind spot)
+#   1e — last_updated must be ISO YYYY-MM-DD format
+#   1f — md parity anchored to ^### F- H3 headings (mirrors yaml ^  - id: anchoring,
+#        closes prose false-positives)
+#   1g — refresh-signal path filter INCLUDES docs/governance/rules/
+#   1h — shallow-clone fail-closed (was silent pass)
+#
+# Sub-checks:
+#   .a (E156) — yaml well-formedness (file + top-level keys + ISO date +
+#               non-empty + per-family field count + enum validation)
+#   .b (E157) — freshness via yaml file's own git commit date vs latest
+#               refresh-signal commit date
+#   .c (E158) — yaml/md family-id parity, both sides H3/structural-anchored
+#
+# Per ADR-0094 (rc17 introduction) + ADR-0095 (rc18 Wave 1 hardening).
+#
+# scope_surfaces: docs/governance/recurring-defect-families.yaml, docs/governance/recurring-defect-families.md, docs/adr/, docs/logs/releases/, CLAUDE.md, docs/governance/architecture-status.yaml, docs/governance/rules/, gate/lib/check_recurring_families.sh
 # ---------------------------------------------------------------------------
 _r111_yaml="docs/governance/recurring-defect-families.yaml"
 _r111_md="docs/governance/recurring-defect-families.md"
+_r111_helper="gate/lib/check_recurring_families.sh"
 _r111_fail=0
 
-# Sub-check .a — yaml well-formedness
-if [[ ! -f "$_r111_yaml" ]]; then
-  fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_yaml missing -- Rule G-9.a / E156 (ADR-0094)"
-  _r111_fail=1
+if [[ ! -f "$_r111_helper" ]]; then
+  fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_helper missing -- Rule G-9 / ADR-0095 Wave 1 helper file required"
 else
-  for _r111_topkey in schema_version last_updated families; do
-    if ! grep -qE "^${_r111_topkey}:" "$_r111_yaml" 2>/dev/null; then
-      fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_yaml missing top-level key '$_r111_topkey' -- Rule G-9.a / E156"
-      _r111_fail=1
-    fi
-  done
-  _r111_fam_count=$(grep -cE '^  - id:' "$_r111_yaml" 2>/dev/null)
-  _r111_fam_count=${_r111_fam_count:-0}
-  if [[ "$_r111_fam_count" -gt 0 ]]; then
-    for _r111_field in title first_observed_rc last_observed_rc occurrences root_cause surfaces prevention_rules cleanup_status open_residual; do
-      _r111_count=$(grep -cE "^    ${_r111_field}:" "$_r111_yaml" 2>/dev/null)
-      _r111_count=${_r111_count:-0}
-      if [[ "$_r111_count" -lt "$_r111_fam_count" ]]; then
-        fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_yaml field '$_r111_field' appears $_r111_count times but $_r111_fam_count families declared -- Rule G-9.a / E156"
-        _r111_fail=1
-      fi
-    done
-  fi
-fi
+  # Source helpers once; capture each sub-check's stdout for fail_rule emission.
+  # shellcheck disable=SC1090
+  source "$_r111_helper"
 
-# Sub-check .b — freshness: yaml last_updated >= latest refresh-signal commit date
-if [[ -f "$_r111_yaml" ]] && command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
-  _r111_yaml_date=$(awk '/^last_updated:/ { gsub(/[\"'\'']/,""); print $2; exit }' "$_r111_yaml" 2>/dev/null)
-  if [[ -n "$_r111_yaml_date" ]]; then
-    _r111_signal_date=$(git log -1 --format=%cI -- \
-      'docs/adr/' \
-      'docs/governance/architecture-status.yaml' \
-      'docs/logs/releases/' \
-      'CLAUDE.md' 2>/dev/null | cut -dT -f1)
-    if [[ -n "$_r111_signal_date" && "$_r111_signal_date" > "$_r111_yaml_date" ]]; then
-      fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_yaml last_updated=$_r111_yaml_date is older than refresh-signal commit date $_r111_signal_date -- Rule G-9.b / E157 (run /refresh-defect-archive)"
+  # Sub-check .a — yaml well-formedness (covers fixes 1b, 1c, 1d, 1e)
+  _r111_a_output=$(_check_recurring_families_yaml_wellformed "$_r111_yaml")
+  if [[ -n "$_r111_a_output" ]]; then
+    while IFS= read -r _r111_line; do
+      [[ -z "$_r111_line" ]] && continue
+      fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_line"
       _r111_fail=1
-    fi
+    done <<< "$_r111_a_output"
   fi
-fi
 
-# Sub-check .c — yaml/md family-id parity
-if [[ -f "$_r111_yaml" && -f "$_r111_md" ]]; then
-  _r111_yaml_ids_file="$(mktemp)"
-  _r111_md_ids_file="$(mktemp)"
-  awk '/^  - id:[[:space:]]+/ {print $3}' "$_r111_yaml" 2>/dev/null | sort -u > "$_r111_yaml_ids_file"
-  grep -oE 'F-[a-z][a-z0-9-]*' "$_r111_md" 2>/dev/null | sort -u > "$_r111_md_ids_file"
-  _r111_only_yaml=$(comm -23 "$_r111_yaml_ids_file" "$_r111_md_ids_file")
-  _r111_only_md=$(comm -13 "$_r111_yaml_ids_file" "$_r111_md_ids_file")
-  if [[ -n "$_r111_only_yaml" ]]; then
-    fail_rule "architecture_refresh_defect_family_re_eval_required" "Family ids in yaml but missing from md: $(echo $_r111_only_yaml) -- Rule G-9.c / E158"
-    _r111_fail=1
+  # Sub-check .b — freshness (covers fixes 1a, 1g, 1h)
+  _r111_b_output=$(_check_recurring_families_freshness "$_r111_yaml" ".")
+  if [[ -n "$_r111_b_output" ]]; then
+    while IFS= read -r _r111_line; do
+      [[ -z "$_r111_line" ]] && continue
+      fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_line"
+      _r111_fail=1
+    done <<< "$_r111_b_output"
   fi
-  if [[ -n "$_r111_only_md" ]]; then
-    fail_rule "architecture_refresh_defect_family_re_eval_required" "Family ids in md but missing from yaml: $(echo $_r111_only_md) -- Rule G-9.c / E158"
-    _r111_fail=1
+
+  # Sub-check .c — md/yaml parity (covers fix 1f)
+  _r111_c_output=$(_check_recurring_families_md_yaml_parity "$_r111_yaml" "$_r111_md")
+  if [[ -n "$_r111_c_output" ]]; then
+    while IFS= read -r _r111_line; do
+      [[ -z "$_r111_line" ]] && continue
+      fail_rule "architecture_refresh_defect_family_re_eval_required" "$_r111_line"
+      _r111_fail=1
+    done <<< "$_r111_c_output"
   fi
-  rm -f "$_r111_yaml_ids_file" "$_r111_md_ids_file"
 fi
 
 if [[ $_r111_fail -eq 0 ]]; then pass_rule "architecture_refresh_defect_family_re_eval_required"; fi

--- a/gate/test_architecture_sync_gate.sh
+++ b/gate/test_architecture_sync_gate.sh
@@ -5705,14 +5705,21 @@ SHEOF
   fi
 }
 
-test_rule_111_yaml_wellformed_pos() {
-  _r111_pos_root="$scratch/r111_pos_a"
-  mkdir -p "$_r111_pos_root"
-  cat > "$_r111_pos_root/recurring-defect-families.yaml" <<'YEOF'
-schema_version: 1
-last_updated: 2026-05-21
-families:
-  - id: F-test-family
+# -----------------------------------------------------------------------------
+# Rule 111 fixtures — rc18 Wave 1 (ADR-0095) helper-ised
+#
+# Fixtures invoke the REAL gate logic via gate/lib/check_recurring_families.sh
+# helpers; no inline re-implementation. Closes F-kernel-vs-implementation-drift
+# on Rule 111 itself (Wave 1 finding from PR #15 reviewer pass).
+# -----------------------------------------------------------------------------
+
+_r111_helper_path="$repo_root/gate/lib/check_recurring_families.sh"
+
+_r111_make_yaml() {
+  local out="$1"
+  local body="${2:-}"
+  if [[ -z "$body" ]]; then
+    body='  - id: F-test-family
     title: Test
     first_observed_rc: rc1
     last_observed_rc: rc2
@@ -5722,30 +5729,27 @@ families:
       - x
     prevention_rules: [Rule X]
     cleanup_status: closed
-    open_residual: ""
-YEOF
-  _fam_count=$(grep -cE '^  - id:' "$_r111_pos_root/recurring-defect-families.yaml")
-  _missing=0
-  for f in title first_observed_rc last_observed_rc occurrences root_cause surfaces prevention_rules cleanup_status open_residual; do
-    _c=$(grep -cE "^    ${f}:" "$_r111_pos_root/recurring-defect-families.yaml")
-    [[ "$_c" -lt "$_fam_count" ]] && _missing=1
-  done
-  if [[ "$_missing" -eq 0 && "$_fam_count" -ge 1 ]]; then
-    ok "rule_111_yaml_wellformed_pos" "Rule 111.a accepts well-formed yaml with all 9 required per-family fields"
+    open_residual: ""'
+  fi
+  printf 'schema_version: 1\nlast_updated: 2026-05-21\nfamilies:\n%s\n' "$body" > "$out"
+}
+
+test_rule_111_a_wellformed_pos() {
+  local root="$scratch/r111_a_pos"
+  mkdir -p "$root"
+  _r111_make_yaml "$root/families.yaml"
+  ( source "$_r111_helper_path"; _check_recurring_families_yaml_wellformed "$root/families.yaml" >/dev/null )
+  if [[ $? -eq 0 ]]; then
+    ok "rule_111_a_wellformed_pos" "Rule 111.a accepts well-formed yaml (1 valid family)"
   else
-    fail "rule_111_yaml_wellformed_pos" "expected well-formed yaml to pass, got fam_count=$_fam_count missing=$_missing"
+    fail "rule_111_a_wellformed_pos" "helper failed on well-formed yaml"
   fi
 }
 
-test_rule_111_yaml_wellformed_neg() {
-  _r111_neg_root="$scratch/r111_neg_a"
-  mkdir -p "$_r111_neg_root"
-  # Family missing the `open_residual` field
-  cat > "$_r111_neg_root/recurring-defect-families.yaml" <<'YEOF'
-schema_version: 1
-last_updated: 2026-05-21
-families:
-  - id: F-broken-family
+test_rule_111_a_wellformed_neg_missing_field() {
+  local root="$scratch/r111_a_neg_missing"
+  mkdir -p "$root"
+  _r111_make_yaml "$root/families.yaml" '  - id: F-broken
     title: Broken
     first_observed_rc: rc1
     last_observed_rc: rc2
@@ -5754,37 +5758,151 @@ families:
     surfaces:
       - x
     prevention_rules: [Rule X]
-    cleanup_status: closed
-YEOF
-  _fam_count=$(grep -cE '^  - id:' "$_r111_neg_root/recurring-defect-families.yaml")
-  _residual_count=$(grep -cE "^    open_residual:" "$_r111_neg_root/recurring-defect-families.yaml")
-  if [[ "$_residual_count" -lt "$_fam_count" ]]; then
-    ok "rule_111_yaml_wellformed_neg" "Rule 111.a catches missing open_residual ($_residual_count/$_fam_count)"
+    cleanup_status: partial'
+  local out
+  out=$( source "$_r111_helper_path"; _check_recurring_families_yaml_wellformed "$root/families.yaml" )
+  if echo "$out" | grep -q "F-broken missing required field open_residual"; then
+    ok "rule_111_a_wellformed_neg_missing_field" "Rule 111.a catches missing open_residual"
   else
-    fail "rule_111_yaml_wellformed_neg" "expected missing field caught, got count=$_residual_count fam=$_fam_count"
+    fail "rule_111_a_wellformed_neg_missing_field" "expected missing-open_residual fail, got: $out"
   fi
 }
 
-test_rule_111_md_yaml_parity_neg() {
-  _r111_parity_root="$scratch/r111_neg_c"
-  mkdir -p "$_r111_parity_root"
-  cat > "$_r111_parity_root/families.yaml" <<'YEOF'
+test_rule_111_a_wellformed_neg_empty_families() {
+  # Fix 1b: families: [] is forbidden
+  local root="$scratch/r111_a_neg_empty"
+  mkdir -p "$root"
+  cat > "$root/families.yaml" <<'YEOF'
+schema_version: 1
+last_updated: 2026-05-21
+families: []
+YEOF
+  local out
+  out=$( source "$_r111_helper_path"; _check_recurring_families_yaml_wellformed "$root/families.yaml" )
+  if echo "$out" | grep -q "families array is empty"; then
+    ok "rule_111_a_wellformed_neg_empty_families" "Rule 111.a (fix 1b) catches families: [] empty array"
+  else
+    fail "rule_111_a_wellformed_neg_empty_families" "expected empty-families fail, got: $out"
+  fi
+}
+
+test_rule_111_a_wellformed_neg_garbage_enum() {
+  # Fix 1c: cleanup_status enum value validated
+  local root="$scratch/r111_a_neg_enum"
+  mkdir -p "$root"
+  _r111_make_yaml "$root/families.yaml" '  - id: F-pizza
+    title: Pizza
+    first_observed_rc: rc1
+    last_observed_rc: rc2
+    occurrences: [rc1, rc2]
+    root_cause: synthetic
+    surfaces:
+      - x
+    prevention_rules: [Rule X]
+    cleanup_status: pizza
+    open_residual: ""'
+  local out
+  out=$( source "$_r111_helper_path"; _check_recurring_families_yaml_wellformed "$root/families.yaml" )
+  if echo "$out" | grep -q "cleanup_status value pizza not in enum"; then
+    ok "rule_111_a_wellformed_neg_garbage_enum" "Rule 111.a (fix 1c) rejects cleanup_status value not in enum"
+  else
+    fail "rule_111_a_wellformed_neg_garbage_enum" "expected enum-violation fail, got: $out"
+  fi
+}
+
+test_rule_111_a_wellformed_neg_duplicate_field() {
+  # Fix 1d: per-family block-bucket catches duplicate fields (closes compensation blind spot)
+  local root="$scratch/r111_a_neg_dup"
+  mkdir -p "$root"
+  _r111_make_yaml "$root/families.yaml" '  - id: F-dup
+    title: First
+    title: Duplicate
+    first_observed_rc: rc1
+    last_observed_rc: rc2
+    occurrences: [rc1, rc2]
+    root_cause: synthetic
+    surfaces:
+      - x
+    prevention_rules: [Rule X]
+    cleanup_status: partial
+    open_residual: ""'
+  local out
+  out=$( source "$_r111_helper_path"; _check_recurring_families_yaml_wellformed "$root/families.yaml" )
+  if echo "$out" | grep -q "declares field title 2 times"; then
+    ok "rule_111_a_wellformed_neg_duplicate_field" "Rule 111.a (fix 1d) catches duplicate field (closes compensation blind spot)"
+  else
+    fail "rule_111_a_wellformed_neg_duplicate_field" "expected duplicate-field fail, got: $out"
+  fi
+}
+
+test_rule_111_a_wellformed_neg_nonisodate() {
+  # Fix 1e: last_updated must be ISO YYYY-MM-DD
+  local root="$scratch/r111_a_neg_date"
+  mkdir -p "$root"
+  cat > "$root/families.yaml" <<'YEOF'
+schema_version: 1
+last_updated: two weeks ago
+families:
+  - id: F-x
+    title: X
+    first_observed_rc: rc1
+    last_observed_rc: rc2
+    occurrences: [rc1, rc2]
+    root_cause: synthetic
+    surfaces:
+      - x
+    prevention_rules: [Rule X]
+    cleanup_status: partial
+    open_residual: ""
+YEOF
+  local out
+  out=$( source "$_r111_helper_path"; _check_recurring_families_yaml_wellformed "$root/families.yaml" )
+  if echo "$out" | grep -q "is not ISO YYYY-MM-DD format"; then
+    ok "rule_111_a_wellformed_neg_nonisodate" "Rule 111.a (fix 1e) rejects non-ISO last_updated"
+  else
+    fail "rule_111_a_wellformed_neg_nonisodate" "expected ISO-format fail, got: $out"
+  fi
+}
+
+test_rule_111_c_md_yaml_parity_pos_ignores_prose() {
+  # Fix 1f: md parity uses ^### F- H3 headings only; prose F- mentions ignored
+  local root="$scratch/r111_c_pos_prose"
+  mkdir -p "$root"
+  cat > "$root/families.yaml" <<'YEOF'
+families:
+  - id: F-real
+YEOF
+  cat > "$root/families.md" <<'MEOF'
+### F-real — Real Family
+prose mentioning F-fake-family-in-text should be ignored.
+also F-another-one cited inline doesn't trigger parity break.
+MEOF
+  ( source "$_r111_helper_path"; _check_recurring_families_md_yaml_parity "$root/families.yaml" "$root/families.md" >/dev/null )
+  if [[ $? -eq 0 ]]; then
+    ok "rule_111_c_md_yaml_parity_pos_ignores_prose" "Rule 111.c (fix 1f) ignores prose F-, only ### F- H3 counts"
+  else
+    fail "rule_111_c_md_yaml_parity_pos_ignores_prose" "helper falsely flagged prose F- as parity break"
+  fi
+}
+
+test_rule_111_c_md_yaml_parity_neg() {
+  local root="$scratch/r111_c_neg"
+  mkdir -p "$root"
+  cat > "$root/families.yaml" <<'YEOF'
 families:
   - id: F-only-in-yaml
   - id: F-shared
 YEOF
-  cat > "$_r111_parity_root/families.md" <<'MEOF'
-### F-only-in-md
-### F-shared
+  cat > "$root/families.md" <<'MEOF'
+### F-only-in-md — One
+### F-shared — Two
 MEOF
-  _yaml_ids=$(awk '/^  - id:[[:space:]]+/ {print $3}' "$_r111_parity_root/families.yaml" | sort -u)
-  _md_ids=$(grep -oE 'F-[a-z][a-z0-9-]*' "$_r111_parity_root/families.md" | sort -u)
-  _only_yaml=$(comm -23 <(echo "$_yaml_ids") <(echo "$_md_ids"))
-  _only_md=$(comm -13 <(echo "$_yaml_ids") <(echo "$_md_ids"))
-  if [[ -n "$_only_yaml" || -n "$_only_md" ]]; then
-    ok "rule_111_md_yaml_parity_neg" "Rule 111.c catches yaml-only=$(echo $_only_yaml) md-only=$(echo $_only_md)"
+  local out
+  out=$( source "$_r111_helper_path"; _check_recurring_families_md_yaml_parity "$root/families.yaml" "$root/families.md" )
+  if echo "$out" | grep -q "F-only-in-yaml" && echo "$out" | grep -q "F-only-in-md"; then
+    ok "rule_111_c_md_yaml_parity_neg" "Rule 111.c flags both yaml-only and md-only parity breaks"
   else
-    fail "rule_111_md_yaml_parity_neg" "expected parity break to be caught, got equal sets"
+    fail "rule_111_c_md_yaml_parity_neg" "expected both directions caught, got: $out"
   fi
 }
 


### PR DESCRIPTION
## Summary

PR #15 (rc17) reviewers found Rule G-9 / Gate Rule 111 — the new "prevent recurring-defect-family from recurring" META rule — was itself vulnerable to 6/8 defect patterns it was supposed to prevent. This wave closes the recursive-irony.

**Wave 1 of rc18 multi-wave plan** (5 waves total; this wave is the most urgent and highest severity).

## Hardening fixes shipped (8 of 9 sub-tasks; 1i = helper extraction is the delivery mechanism)

| Sub-task | Fix |
|---|---|
| **1a** | yaml file's own git commit date drives freshness (not hand-edited `last_updated:`) |
| **1b** | `families: []` hard rejection (empty array forbidden) |
| **1c** | `cleanup_status` enum value validated (no more `pizza` accepted) |
| **1d** | per-family block-bucket field count (closes duplicate-field compensation blind spot) |
| **1e** | `last_updated` ISO YYYY-MM-DD format validation |
| **1f** | md parity restricted to `^### F-` H3 headings (closes prose false-positives) |
| **1g** | refresh-signal path filter includes `docs/governance/rules/` |
| **1h** | shallow-clone fail-closed (was silent pass) |
| **1i** | helper extraction → `gate/lib/check_recurring_families.sh` |

## Test plan

- [x] Self-test 207/210 on Windows (3 pre-existing `rule_e2_ndjson_*` env issues; CI Linux should be 210/210)
- [x] All 8 Rule 111 fixtures PASS (3 old rewritten + 5 new edge cases)
- [x] Smoke test: 6 synthetic broken yamls all caught correctly
- [x] Graph regen: 407 nodes / 643 edges unchanged
- [ ] CI green (Maven build + integration tests + quickstart smoke)

## What did NOT ship this wave (intentional scope)

- Rule 107/108/109/110 helper extraction → moved to Wave 2 (combined with 13 legacy fixture rewrites)
- baseline_metrics updates → Wave 5 single-commit lockstep (avoid rc17's 3 corrective commits)
- ADR-0095 + rc18 release note → Wave 5 finalize

## Multi-wave context

| Wave | Status | Branch |
|---|---|---|
| 1 (Rule 111 hardening) | **THIS PR** | rc18/wave-1-rule-111-hardening |
| 2 (cross-rule pattern sweep + 21 fixture helper-isation) | pending | rc18/wave-2-pattern-sweep |
| 3 (naming + dead-content cleanup, 43 findings) | pending | rc18/wave-3-naming-cleanup |
| 4 (enforcer constraint_ref normalize + migration doc) | pending | rc18/wave-4-enforcer-normalize |
| 5 (META + ADR + release note + baseline lockstep) | pending | rc18/wave-5-finalize |

🤖 Generated with [Claude Code](https://claude.com/claude-code)