### PR TITLE
fix(rc18-wave3): naming + dead-content cleanup (ADR-0095 Wave 3)

### DIFF
--- a/docs/governance/recurring-defect-families.md
+++ b/docs/governance/recurring-defect-families.md
@@ -28,6 +28,20 @@ authority_refs: [ADR-0094]
 > the same root cause re-fires for 4-8 rc waves before someone realises
 > it's a class, not a one-off. Rule 110 META gates the prevention-rule
 > taxonomy; this document is the human-readable mirror.
+>
+> **Vocabulary note ("Family" disambiguation, rc18 Wave 3).** The word
+> *family* is used at TWO scopes in this corpus; do not confuse them:
+> 1. **Permanent root-cause classes** — `F-<slug>` (e.g.,
+>    `F-numeric-drift`). Catalogued here; cross-wave. Eight of them.
+> 2. **Wave-local finding clusters** — Greek-letter suffix on the rc
+>    review letter (e.g., "Family A" or "L-α", "M-η" in rc14/rc15
+>    release notes). Ephemeral; specific to one review pass. Reset each
+>    wave.
+> When a release note says "Family A closed", it means the wave-local
+> cluster. When this document says "F-numeric-drift partial", it means
+> the permanent root-cause class. The two namespaces never overlap by
+> regex (Greek letters / capital letters in release notes ≠ `F-` prefix
+> here).
 
 ---
 

--- a/docs/governance/rules/README.md
+++ b/docs/governance/rules/README.md
@@ -32,9 +32,11 @@ Each R-rule bridges from a P-principle to a concrete enforcer. R-rules
 are the "ironclad" layer — most have ArchUnit / integration-test
 backing in addition to gate-script enforcement.
 
-Current: R-A, R-B, R-C, R-C.1, R-C.2, R-D, R-E, R-F, R-G, R-H, R-I,
-R-I.1, R-J, R-K, R-L, R-M (16 rules including .1/.2 sub-rules per rc17
-ADR-0094).
+Current (16 rules including `.1`/`.2` sub-rules per rc17 ADR-0094):
+R-A, R-A.c, R-B, R-C, R-C.1, R-C.2, R-D, R-E, R-F, R-G, R-H, R-I,
+R-I.1, R-J, R-K, R-L, R-M. (Rule R-A.c is a sub-clause activated post-deferral
+that retains the `.a/.b/.c` convention rather than `.1`/`.2`; see the
+Sub-Rule vs Sub-Clause table below for the rationale.)
 
 ### G-* — Gate / Meta-Governance Rules
 
@@ -65,8 +67,13 @@ wave introduces a structured split convention:
 
 - **Parent rule keeps its identifier** and retains its core sub-clauses.
 - **Extracted sub-rules get a numeric suffix** (`.1`, `.2`, ...).
-- **Filename convention**: `rule-PREFIX-NAME-N.md` (e.g.,
-  `rule-G-3-1.md` for Rule G-3.1).
+- **Filename convention**: `rule-PREFIX-NAME.N.md` with a **dot** before
+  the numeric suffix (e.g., `rule-G-3.1.md` for Rule G-3.1, matching the
+  pre-existing `rule-R-A.c.md` dotted style). Hyphenated filenames like
+  `rule-G-3-1.md` are NOT accepted by Gate Rule 99 / E143
+  (rule_namespace_authority_completeness) because the gate maps the
+  `#### Rule G-3.1` heading to a `rule-G-3.1.md` filename via dotted
+  conversion.
 - **Card frontmatter `rule_id`**: matches the dotted form (e.g.,
   `rule_id: G-3.1`).
 
@@ -100,22 +107,13 @@ The repository runs two parallel rule namespaces by design:
 
 - **Semantic namespace** (D-/R-/G-/M-): used in `CLAUDE.md` kernel,
   `docs/governance/rules/rule-*.md` card filenames, and `rule_id`
-  frontmatter. This is the **engineering rule** namespace — 31 active
-  rules counted by `architecture-status.yaml#baseline_metrics.active_engineering_rules`
-  (33 after rc17 ADR-0094 splits = 31 original + 2 net additions for
-  R-C.1 + R-C.2 + R-I.1 + G-3.1 + G-2.1 + G-9 = 37; the prior 31 minus
-  the 4 "split-from" rules R-C/R-I/G-3/G-2 are NOT removed, only refined,
-  so the count goes 31 → 37).
-
-Wait — that's wrong. Let me recompute:
-
-- R-C splits to R-C + R-C.1 + R-C.2 → net +2
-- R-I splits to R-I + R-I.1 → net +1
-- G-3 splits to G-3 + G-3.1 → net +1
-- G-2 splits to G-2 + G-2.1 → net +1
-- New: G-9 → net +1
-
-Total: 31 + 2 + 1 + 1 + 1 + 1 = **37**.
+  frontmatter. This is the **engineering rule** namespace — **37 active
+  rules** counted by `architecture-status.yaml#baseline_metrics.active_engineering_rules`.
+  The rc17 ADR-0094 split count: rc16 baseline 31 + R-C → R-C+R-C.1+R-C.2 (+2)
+  + R-I → R-I+R-I.1 (+1) + G-3 → G-3+G-3.1 (+1) + G-2 → G-2+G-2.1 (+1)
+  + new Rule G-9 (+1) = **37**. The 4 "split-from" parent rules (R-C, R-I,
+  G-3, G-2) are NOT removed — only narrowed — so the count goes up by the
+  net additions, not net replacements.
 
 - **Numeric namespace** (Gate Rule 1 ... Gate Rule 111): used in
   `gate/check_architecture_sync.sh` rule headers and self-test fixture

--- a/docs/governance/rules/rule-D-8.md
+++ b/docs/governance/rules/rule-D-8.md
@@ -25,4 +25,4 @@ When a class needs tenant scoping, scope is a **required constructor argument**.
 ## Cross-references
 
 - Rule D-7 (Concurrency / Async Resource Lifetime) — single construction is the prerequisite for an enforceable lifetime.
-- Rule R-C.e (Tenant Propagation Purity) — tenant scope as a required constructor argument is the structural enforcement that prevents request-scoped ThreadLocal leakage into runtime code.
+- Rule R-C.2 sub-clause .c (Tenant Propagation Purity; was Rule R-C.e pre-rc17 per ADR-0094) — tenant scope as a required constructor argument is the structural enforcement that prevents request-scoped ThreadLocal leakage into runtime code.

--- a/docs/governance/rules/rule-G-2.md
+++ b/docs/governance/rules/rule-G-2.md
@@ -12,9 +12,9 @@ kernel: |
   **Authority-text reality across the active corpus: `shipped: true` rows in `architecture-status.yaml` MUST have real `tests:` + `implementation:` paths and enforcer-backed prose (sub-clause .a — Architecture-Text Truth). `architecture-status.yaml#baseline_metrics` is the single source for entrypoint counts; `README.md` + `gate/README.md` numeric claims MUST point to it AND match parsed values (sub-clause .b — Baseline Metrics Single Source). Active `agent-*/ARCHITECTURE.md` path claims MUST resolve or carry historical markers (sub-clause .c). Root `ARCHITECTURE.md` module-count + path claims MUST match `pom.xml` and `architecture-status.yaml#repository_counts`; fenced tree-diagram SPI leaves MUST match `module-metadata.yaml#spi_packages` (sub-clause .d). The latest release note under `docs/logs/releases/*.md` MUST NOT contain absolute graph node/edge counts disagreeing with live values unless marked historical (sub-clause .g). Deleted-module-name leakage prevention (former sub-clauses .e/.f/.h) split to Rule G-2.1 per ADR-0094.**
 ---
 
-# Rule G-2 — Authority-Text Reality (doc / status / path / numeric / name truth)
+# Rule G-2 — Authority-Text Reality (doc / status / path / numeric truth)
 
-Operationalises across 8 sub-clauses. See `## Sub-clauses` below for the per-sub-clause assertion + enforcer mapping. Authority: [ADR-0043, ADR-0047, ADR-0078, ADR-0082, ADR-0083, ADR-0084, ADR-0085].
+Operationalises across 5 sub-clauses (.a/.b/.c/.d/.g). The deleted-module-name leakage sub-clauses (.e/.f/.h) split to Rule G-2.1 in rc17 per ADR-0094. Authority: [ADR-0043, ADR-0047, ADR-0078, ADR-0082, ADR-0083, ADR-0085, ADR-0094].
 
 ## Sub-clauses
 

--- a/docs/governance/rules/rule-M-1.md
+++ b/docs/governance/rules/rule-M-1.md
@@ -27,7 +27,7 @@ The 2026-05-18 rc4 cross-constraint architecture review (finding P0-2 in `docs/l
 - `docs/governance/architecture-status.yaml:12,20` said T2.B2 was deferred.
 - `agent-execution-engine/pom.xml:5–7` carried a "code is still to be extracted" comment alongside dependencies on `agent-runtime-core` and `agent-middleware` for the extracted engine implementation.
 
-A contributor following the root L0 architecture would treat `agent-execution-engine` as an empty workspace while the reactor already built it as the owner of the engine surface. This undermined Rule R-C.b (Independent Module Evolution) and Rule G-1 sub-clause .a (Layered 4+1 Discipline) because module identity, module architecture, and physical code stopped agreeing.
+A contributor following the root L0 architecture would treat `agent-execution-engine` as an empty workspace while the reactor already built it as the owner of the engine surface. This undermined Rule R-C.1 (Independent Module Evolution; was Rule R-C.b pre-rc17 per ADR-0094) and Rule G-1 sub-clause .a (Layered 4+1 Discipline) because module identity, module architecture, and physical code stopped agreeing.
 
 Rule M-1 prevents the re-occurrence: a module can carry a `skeleton` status in its L1 ARCHITECTURE.md only when its production Java tree literally contains no production types beyond `package-info.java` (or ADR-waived placeholder stubs).
 
@@ -64,7 +64,7 @@ Activated 2026-05-18 by the v2.0.0-rc4 cross-constraint architecture review resp
 
 ## Cross-references
 
-- Rule R-C.b (Independent Module Evolution) — Rule M-1 protects Rule R-C.b's invariant that every module has a coherent identity (metadata + ARCHITECTURE.md + actual Java tree).
+- Rule R-C.1 (Independent Module Evolution; was Rule R-C.b pre-rc17 per ADR-0094) — Rule M-1 protects Rule R-C.1's invariant that every module has a coherent identity (metadata + ARCHITECTURE.md + actual Java tree).
 - Rule R-D sub-clause .a (SPI + DFX + TCK Co-Design) — placeholder SPI stubs survive Rule R-D sub-clause .a only via the ADR waiver Rule M-1 enforces.
 - Rule G-1 sub-clause .a (Layered 4+1 Discipline) — module-level L1 architecture status is one of the artefacts Rule G-1 sub-clause .a freezes; Rule M-1 guards the truthfulness of the status token.
 - Rule R-D sub-clause .b (SPI Packages Populated) — companion rule for the metadata side; placeholder-with-ADR shape is shared.

--- a/docs/governance/rules/rule-R-A.md
+++ b/docs/governance/rules/rule-R-A.md
@@ -18,7 +18,7 @@ Rule R-A is the in-repo enforceable expression of governing principle P-A (Busin
 
 ## Details
 
-Enforced by E48 (`SpiPurityGeneralizedArchTest`) and Gate Rule R-C.b (`quickstart_present`).
+Enforced by E48 (`SpiPurityGeneralizedArchTest`) and Rule R-A.c (`quickstart_present`; CI quickstart smoke job per ADR-0064 + W4 activation).
 
 ## Cross-references
 

--- a/docs/governance/rules/rule-R-C.md
+++ b/docs/governance/rules/rule-R-C.md
@@ -12,13 +12,20 @@ kernel: |
   **Every active normative constraint in the platform corpus MUST be enforced by code, registered in `docs/governance/enforcers.yaml`, and reach ≥1 of: an ArchUnit test, a `gate/check_architecture_sync.sh` rule, an integration test, a storage-layer schema constraint (NOT NULL / UNIQUE / CHECK / PRIMARY KEY), or a compile-time check (`@ConfigurationProperties + @Valid`, sealed types, package-info enforcement). Module-evolution invariants split to Rule R-C.1; run-spine invariants split to Rule R-C.2 per ADR-0094.**
 ---
 
-# Rule R-C — Code-as-Contract + Independent Module Evolution + Run Contract Spine
+# Rule R-C — Code-as-Contract
 
-Operationalises principle **P-C** (Code-as-Everything, Rapid Evolution, Independent Modules) across five sub-clauses.
+Operationalises principle **P-C** (Code-as-Everything, Rapid Evolution, Independent Modules) on its single remaining sub-clause `.a` — every active normative constraint must be enforced by code AND registered in `docs/governance/enforcers.yaml`. Per ADR-0094 (rc17), the original sub-clauses .b/.c/.d/.e were extracted to sibling sub-rules:
 
-## Sub-clauses
+| Was (in R-C, pre-rc17) | Now (post-rc17 ADR-0094) | Card |
+|---|---|---|
+| .b — Independent Module Evolution | **Rule R-C.1** | [`rule-R-C.1.md`](rule-R-C.1.md) |
+| .c — Contract Spine Completeness | **Rule R-C.2** sub-clause .a | [`rule-R-C.2.md`](rule-R-C.2.md) |
+| .d — Run State Transition Validity | **Rule R-C.2** sub-clause .b | [`rule-R-C.2.md`](rule-R-C.2.md) |
+| .e — Tenant Propagation Purity | **Rule R-C.2** sub-clause .c | [`rule-R-C.2.md`](rule-R-C.2.md) |
 
-### .a — Code-as-Contract (was Rule 28)
+Readers seeking those invariants should consult the sibling cards above; this card is now bounded to the Code-as-Contract obligation only.
+
+## Sub-clause .a — Code-as-Contract (was legacy Rule 28)
 
 **Enforcers**: E15, E16, E17, E18, E19, E27, E28, E29, E30.
 
@@ -30,35 +37,10 @@ Every active normative constraint MUST be enforced by code, registered in `docs/
 4. A schema constraint (NOT NULL / UNIQUE / CHECK / PRIMARY KEY) at the storage layer.
 5. A compile-time check (`@ConfigurationProperties` + `@Valid`, sealed types, package-info enforcement).
 
-### .b — Independent Module Evolution (was Rule 31)
-
-**Enforcer**: E31.
-
-Every reactor module under `<module>/pom.xml` MUST own a sibling `<module>/module-metadata.yaml` declaring `module`, `kind ∈ {platform | domain | starter | bom | sample}`, `version`, and `semver_compatibility`. Each module MUST build and test in isolation via `mvn -pl <module> -am test`. Inter-module dependency direction is governed by Rule D-6 (`module_dep_direction`).
-
-### .c — Contract Spine Completeness (was Rule 11)
-
-**Enforcers**: E2, E11.
-
-Every persistent record class committed under `agent-service/src/main/java/ascend/springai/service/runtime/{runs,idempotency}/**/*.java` (relocated from `agent-runtime-core/src/main/java/ascend/springai/service/runtime/**/*.java` per ADR-0088 rc13 dissolution) MUST declare a `String tenantId` component validated by `Objects.requireNonNull(tenantId, "tenantId is required")` in its compact constructor. Process-internal value objects exempt themselves with a `// scope: process-internal` reason comment. Activated 2026-05-18 (Wave 4 Track B) — trigger met by `Run` and `IdempotencyRecord` carrying tenantId.
-
-### .d — Run State Transition Validity (was Rule 20)
-
-**Enforcer**: E9 (RunStatusTransitionIT).
-
-Every `Run.withStatus(newStatus)` mutation MUST call `RunStateMachine.validate(this.status, newStatus)` before constructing the updated record. Illegal transitions MUST throw `IllegalStateException`.
-
-### .e — Tenant Propagation Purity (was Rule 21)
-
-**Enforcers**: E2, E4.
-
-No production class under `ascend.springai.service.runtime..` (main sources) may import any class under `ascend.springai.service.platform..`. The original narrow case — no import of `TenantContextHolder` — remains the specific instance most likely to be violated and is asserted independently as defence-in-depth.
-
 ## Cross-references
 
 - ADR-0064 — Layer-0 Governing Principles authority.
-- ADR-0066 — Independent Module Evolution authority.
-- ADR-0078 — Phase C consolidation (resolves which "successor module" sub-clause .c refers to).
-- ADR-0079 — Engine extraction to agent-runtime-core (superseded by ADR-0088).
-- ADR-0088 — agent-runtime-core dissolution; runs / idempotency relocated back to agent-service (rc13).
-- Companion: Rule R-J.a (Storage-Engine Tenant Isolation — sub-clause .e is the application-layer dual).
+- ADR-0094 — rc17 rule-consolidation authority (R-C three-way split).
+- **Rule R-C.1** — Independent Module Evolution (sibling extracted).
+- **Rule R-C.2** — Run Contract Spine: tenantId + RunStateMachine + tenant-purity (sibling extracted).
+- Companion: Rule R-J.a (Storage-Engine Tenant Isolation — R-C.2.c is the application-layer dual).

--- a/docs/governance/rules/rule-R-D.md
+++ b/docs/governance/rules/rule-R-D.md
@@ -35,7 +35,7 @@ Enforced by E48 (`SpiPurityGeneralizedArchTest`), Gate Rule R-E (`dfx_yaml_prese
 - Architecture reference: §4 #63.
 - Deferred sub-clauses 32.b (TCK module scaffolding), 32.c (TCK conformance content), 32.d (vulnerability-scanner integration).
 - Rule R-A (Business/Platform Decoupling Enforcement) — co-enforced by E48 on the SPI purity side.
-- Rule R-C.b (Independent Module Evolution) — the `module-metadata.yaml` that declares `kind: domain` is the same artefact Rule R-D sub-clause .a reads.
+- Rule R-C.1 (Independent Module Evolution; was Rule R-C.b pre-rc17 per ADR-0094) — the `module-metadata.yaml` that declares `kind: domain` is the same artefact Rule R-D sub-clause .a reads.
 
 ## Deferred sub-clauses
 

--- a/docs/governance/rules/rule-R-I.md
+++ b/docs/governance/rules/rule-R-I.md
@@ -19,18 +19,11 @@ The L0 motivation (LucioIT W1 §7.1): workloads with different characteristics
 sandbox code) MUST NOT share infrastructure. Interference between them produces
 the avalanche failure mode that costs production AI platforms most uptime.
 
-Sub-clause .b operationalises the plane-boundary invariant for the edge ↔
-compute_control surface specifically. Today (rc13 — 2026-05-20) agent-client
-is skeleton (0 java files). Locking the positive topology contract NOW —
-before any SDK code lands — prevents the future SDK from picking the most-
-convenient HTTP path (direct to agent-service /v1/runs) by default. The
-constraint composes with ADR-0088's relocation of S2cCallbackTransport to
-agent-bus: after both ADRs, agent-bus owns the entirety of cross-plane traffic
-in both directions.
+This card scopes to sub-clause .a (the five-plane manifest invariant). The
+edge↔compute ingress routing invariant that was sub-clause .b pre-rc17 was
+split out to its own card [`rule-R-I.1.md`](rule-R-I.1.md) per ADR-0094.
 
-## Sub-clauses
-
-### .a — Five-Plane Manifest (the original Rule R-I body)
+## Sub-clause .a — Five-Plane Manifest
 
 **Enforcer**: E68 (`deployment_plane_in_module_metadata`).
 
@@ -38,33 +31,12 @@ Every reactor module's `module-metadata.yaml` declares
 `deployment_plane: edge | compute_control | bus_state | sandbox | evolution | none`.
 Gate-script schema check fails closed if missing.
 
-### .b — Edge↔Compute Ingress Routing (added rc13, ADR-0089)
-
-**Enforcers**: E143 (ArchUnit `EdgeToComputeDirectLinkArchTest`) + gate
-Rule 105 (`edge_no_direct_compute_link`).
-
-For every module whose `deployment_plane` is `edge`:
-1. No production source under `<module>/src/main/java/**/*.java` may
-   `import` any class under `ascend.springai.service..`,
-   `ascend.springai.engine..`, or `ascend.springai.middleware..`.
-2. No production source may construct a `RestTemplate` or `WebClient`
-   targeting a host other than the bus ingress endpoint.
-3. The positive contract — what traffic IS allowed — is the
-   `ascend.springai.bus.spi.ingress.IngressGateway` SPI, whose wire schema
-   is `docs/contracts/ingress-envelope.v1.yaml`.
-
-Contract status today is `design_only` (no runtime binding); W3+ SDK landing
-promotes to `runtime_enforced` per ADR-0089's `deferred_runtime_binding`.
-
-Deferred sub-clauses .c–.z (W2+ runtime-binding follow-ups) are catalogued
-in `docs/CLAUDE-deferred.md`.
-
 ## Cross-references
 
-- Enforced by Gate Rule 49 (`deployment_plane_in_module_metadata`) for .a.
-- Enforced by Gate Rule 105 (`edge_no_direct_compute_link`) for .b.
+- Enforced by Gate Rule 49 (`deployment_plane_in_module_metadata`) for sub-clause .a.
+- For the edge↔compute ingress routing invariant (was sub-clause .b pre-rc17), see [`rule-R-I.1.md`](rule-R-I.1.md) per ADR-0094.
 - Architecture reference: ADR-0069 (Layer-0 ironclad rules), ADR-0089 (Edge-Plane Ingress Gateway Mandate).
-- Companion rule: Rule R-C.b ([`rule-R-C.md`](rule-R-C.md)) — Independent Module Evolution (module-metadata.yaml ownership).
+- Companion rule: Rule R-C.1 ([`rule-R-C.1.md`](rule-R-C.1.md)) — Independent Module Evolution (was Rule R-C.b pre-rc17 per ADR-0094; module-metadata.yaml ownership).
 - Companion rule: Rule R-E ([`rule-R-E.md`](rule-R-E.md)) — Three-Track Channel Isolation (the data channel carries the bus-side forward of an ingress envelope).
 - Companion rule: Rule R-F ([`rule-R-F.md`](rule-R-F.md)) — Cursor Flow Mandate (IngressResponse.cursor is the Task Cursor for RUN_CREATE).
 - Companion rule: Rule R-L ([`rule-R-L.md`](rule-R-L.md)) — Sandbox Permission Subsumption (the `sandbox` plane's physical enforcement boundary).

--- a/docs/governance/rules/rule-R-J.md
+++ b/docs/governance/rules/rule-R-J.md
@@ -31,7 +31,7 @@ Every Flyway migration that creates a table with a `tenant_id` column MUST enabl
 - Architecture reference: ADR-0069 / LucioIT W1 §7.2.
 - Grandfather list: `gate/rls-baseline-grandfathered.txt` (V1/V2 migrations grandfathered).
 - Grandfather retrofit deferred to W2 per `CLAUDE-deferred.md` 40.b.
-- Companion clause: Rule R-C.e (Tenant Propagation Purity — application-layer tenant identity discipline; RLS is the storage-layer defence-in-depth).
+- Companion clause: Rule R-C.2 sub-clause .c (Tenant Propagation Purity; was Rule R-C.e pre-rc17 per ADR-0094 — application-layer tenant identity discipline; RLS is the storage-layer defence-in-depth).
 
 ### .b — RunLifecycle Re-Authorization (cancel-only at W1) (was Rule 24)
 

--- a/docs/governance/rules/rule-R-M.md
+++ b/docs/governance/rules/rule-R-M.md
@@ -43,7 +43,7 @@ Authority: ADR-0072 / P-M. Part of the W2.x Engine Contract Structural Wave that
 - Enforced by Gate Rule 56 (`engine_registry_covers_all_known_engines` — bidirectional yaml↔ENGINE_TYPE consistency, enforcer E77) and integration test E75 (`EngineMatchingStrictnessIT`).
 - Additional enforcer E88 (W2.x post-release closure work) tightens registry-boot validation.
 - Companion rule: Rule R-M sub-clause .a ([`rule-R-M.md`](rule-R-M.md)) — Engine Envelope Single Authority.
-- Companion rule: Rule R-C.d ([`rule-R-C.md`](rule-R-C.md)) — Run State Transition Validity (`engine_mismatch` is a legal RUNNING → FAILED transition).
+- Companion rule: Rule R-C.2 sub-clause .b ([`rule-R-C.2.md`](rule-R-C.2.md)) — Run State Transition Validity (was Rule R-C.d pre-rc17 per ADR-0094; `engine_mismatch` is a legal RUNNING → FAILED transition).
 - Deferred sub-clauses: Rule R-M sub-clause .b.b (Run.engineType field persistence), Rule R-M sub-clause .b.c (parent-run propagation on child failure) — see `docs/CLAUDE-deferred.md`. Rule G-3 sub-clause .d (`kernel_deferred_clause_coherence`, rc9 / ADR-0083) asserts the bidirectional link between this active rule and each deferred sub-clause.
 
 ### .c — (was sub-clause .c)
@@ -89,7 +89,7 @@ The Phase 3a cross-rule co-design audit matrix in [`docs/logs/reviews/2026-05-16
 - Runtime ResilienceContract integration for `s2c.client.callback` skill capacity deferred to Rule R-M sub-clause .d.b (W2) per ADR-0074 §Consequences and `docs/CLAUDE-deferred.md` 46.b.
 - Deferred sub-clauses (canonical names — aligned with `docs/CLAUDE-deferred.md` 2026-05-19 rc9 wave): 46.b (`ResilienceContract s2c.client.callback` runtime admission wiring — W2), 46.c (non-blocking lifecycle for the W2.x synchronous bridge — W2 async orchestrator). Invalid-response handling itself is **already shipped at L1.x** through the kernel's `BEFORE-resume` validation clause and is enforced by `S2cCallbackEnvelopeValidationTest` (enforcer E89) — it is not a deferred sub-clause.
 - Schema source: `docs/contracts/s2c-callback.v1.yaml`.
-- Inter-rule cross-citations: Rule R-C.d (`SuspendReason.AwaitClientCallback` as a legal RUNNING → SUSPENDED transition), Rule R-E (S2C traffic rides the `data` channel by default with control intents on `control`), Rule R-H (no Thread.sleep — checked-suspension variant), Rule R-K (`s2c.client.callback` skill capacity), Rule R-L (logical-to-physical authority discipline at the callback boundary).
+- Inter-rule cross-citations: Rule R-C.2 sub-clause .b (was Rule R-C.d pre-rc17 per ADR-0094; `SuspendReason.AwaitClientCallback` as a legal RUNNING → SUSPENDED transition), Rule R-E (S2C traffic rides the `data` channel by default with control intents on `control`), Rule R-H (no Thread.sleep — checked-suspension variant), Rule R-K (`s2c.client.callback` skill capacity), Rule R-L (logical-to-physical authority discipline at the callback boundary).
 
 ### .e — (was sub-clause .e)
 


### PR DESCRIPTION
Wave 3 of rc18 multi-wave plan. Pure documentation cleanup; zero gate-implementation changes.

## Sub-tasks delivered

| ID | Fix |
|---|---|
| 3a | README.md filename convention (hyphen→dot) clarified |
| 3b | README.md scratch math deleted |
| 3c | R-rule count 15→16, R-A.c hybrid acknowledged |
| 3e | rule-R-C.md dead sub-clauses replaced with pointer table |
| 3f | rule-G-2.md title drops 'name truth' (migrated to G-2.1) |
| 3g | 7 rule cards cross-reference rot fixed |
| 3i | Family terminology disambiguation |

## Deferred to other waves

- 3d (R-A.c→R-A.1 rename) — too invasive
- 3h (surfaces→scope_surfaces) — touches Wave 1 helper; Wave 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)