### PR TITLE
docs(rc19-wave3): cleanup — README count + schema enum + rc18 zero-correctives prose

### DIFF
--- a/docs/governance/recurring-defect-families.yaml
+++ b/docs/governance/recurring-defect-families.yaml
@@ -30,7 +30,7 @@
 #     surfaces               - list of paths/globs where the family manifests
 #     prevention_rules       - list of Rule IDs (D-/R-/G-/M-/Rule-N) authored
 #                              as prevention; in order of introduction
-#     cleanup_status         - enum: closed | structurally_addressed | partial | incomplete
+#     cleanup_status         - enum: closed | structurally_addressed | partial | incomplete | monitoring
 #     open_residual          - one-paragraph remaining risk (empty if closed)
 #
 # Authority: ADR-0094 (rc17 recurring-defect-family-truth + rule-consolidation).

--- a/docs/governance/rules/README.md
+++ b/docs/governance/rules/README.md
@@ -32,11 +32,12 @@ Each R-rule bridges from a P-principle to a concrete enforcer. R-rules
 are the "ironclad" layer — most have ArchUnit / integration-test
 backing in addition to gate-script enforcement.
 
-Current (16 rules including `.1`/`.2` sub-rules per rc17 ADR-0094):
+Current (17 rules including `.1`/`.2` sub-rules per rc17 ADR-0094 +
+the R-A.c hybrid):
 R-A, R-A.c, R-B, R-C, R-C.1, R-C.2, R-D, R-E, R-F, R-G, R-H, R-I,
-R-I.1, R-J, R-K, R-L, R-M. (Rule R-A.c is a sub-clause activated post-deferral
-that retains the `.a/.b/.c` convention rather than `.1`/`.2`; see the
-Sub-Rule vs Sub-Clause table below for the rationale.)
+R-I.1, R-J, R-K, R-L, R-M. (Rule R-A.c is a sub-clause activated post-
+deferral that retains the `.a/.b/.c` convention rather than `.1`/`.2`;
+see the Sub-Rule vs Sub-Clause table below for the rationale.)
 
 ### G-* — Gate / Meta-Governance Rules
 

--- a/docs/logs/releases/2026-05-21-l0-rc18-comprehensive-hardening.en.md
+++ b/docs/logs/releases/2026-05-21-l0-rc18-comprehensive-hardening.en.md
@@ -29,10 +29,13 @@ Wave 1 by helper extraction + 8 hardening fixes.
 
 **Methodology:** Wave 1 fixes the urgent recursive-irony. Waves 3 and 4
 run in parallel (independent files). Wave 2 follows on cross-rule pattern
-sweep. Wave 5 finalizes ADR + release note + baseline. **Zero corrective
-commits across all 5 waves** (vs rc17 which needed 3) — the
-4-surface-lockstep lesson from rc17 (`feedback_lockstep_baseline_surfaces.md`)
-is now institutionalised.
+sweep. Wave 5 finalizes ADR + release note + baseline. **Zero post-merge
+corrective commits on `main`** (vs rc17 which needed 3) — Wave 1 had 1
+in-branch CI corrective (`fetch-depth: 0` for Rule 111.b); Wave 5 had 2
+in-branch CI correctives (Rule 97 stale graph numbers in release-note
+prose; rc19 Wave 3 amends this claim to match the visible git log
+truth — `feedback_lockstep_baseline_surfaces.md` rules apply at merge
+boundary, not within-branch refinement).
 
 ## Family taxonomy (cited findings → wave assignments)
 


### PR DESCRIPTION
Wave 3 of rc19 multi-wave plan. Pure doc cleanup. Closes reviewer findings Maint MAINT-rc18-3 / -8 / -9 + Arch Q7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)