### PR TITLE
Introduce dedicated run-dispatch Executor and wire it into RunController

### DIFF
--- a/agent-service/src/main/java/com/huawei/ascend/service/platform/web/runs/RunController.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/platform/web/runs/RunController.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Executor;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -54,13 +56,18 @@ import java.util.concurrent.CompletableFuture;
 public class RunController {
 
     private static final Logger LOG = LoggerFactory.getLogger(RunController.class);
+    static final String RUN_DISPATCH_EXECUTOR_BEAN = "runDispatchExecutor";
 
     private final RunRepository repository;
     private final AsyncRunDispatcher dispatcher;
+    private final Executor runDispatchExecutor;
 
-    public RunController(RunRepository repository, AsyncRunDispatcher dispatcher) {
+    public RunController(RunRepository repository,
+                         AsyncRunDispatcher dispatcher,
+                         @Qualifier(RUN_DISPATCH_EXECUTOR_BEAN) Executor runDispatchExecutor) {
         this.repository = repository;
         this.dispatcher = dispatcher;
+        this.runDispatchExecutor = runDispatchExecutor;
     }
 
     @PostMapping(produces = "application/json", consumes = "application/json")
@@ -104,7 +111,7 @@ public class RunController {
         // regardless of how long the underlying work takes.
         AsyncRunDispatcher fixedDispatcher = dispatcher;
         Run dispatched = saved;
-        CompletableFuture.runAsync(() -> fixedDispatcher.dispatch(dispatched));
+        CompletableFuture.runAsync(() -> fixedDispatcher.dispatch(dispatched), runDispatchExecutor);
         return ResponseEntity.status(HttpStatus.ACCEPTED)
                 .body(RunCursorResponse.from(saved, baseUrl(httpRequest)));
     }

--- a/agent-service/src/main/java/com/huawei/ascend/service/platform/web/runs/RunDispatchExecutorConfiguration.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/platform/web/runs/RunDispatchExecutorConfiguration.java
@@ -28,10 +28,6 @@ public class RunDispatchExecutorConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(RunDispatchExecutorConfiguration.class);
 
-    private static final int CORE_THREADS = 4;
-    private static final int MAX_THREADS = 16;
-    private static final int QUEUE_CAPACITY = 256;
-
     private final MeterRegistry meterRegistry;
     private final RunDispatchProperties properties;
 
@@ -44,16 +40,19 @@ public class RunDispatchExecutorConfiguration {
     @Bean(name = RunController.RUN_DISPATCH_EXECUTOR_BEAN, destroyMethod = "shutdown")
     public Executor runDispatchExecutor() {
         RunDispatchProperties.RejectionPolicy policy = properties.getRejectionPolicy();
+        int coreThreads = Math.max(1, properties.getCoreThreads());
+        int maxThreads = Math.max(coreThreads, properties.getMaxThreads());
+        int queueCapacity = Math.max(1, properties.getQueueCapacity());
         Counter rejectedCounter = Counter.builder("springai_ascend_run_dispatch_rejected_total")
                 .description("Total run-dispatch tasks rejected by the dedicated executor")
                 .tag("policy", policy.name())
                 .register(meterRegistry);
         ThreadPoolExecutor executor = new ThreadPoolExecutor(
-                CORE_THREADS,
-                MAX_THREADS,
+                coreThreads,
+                maxThreads,
                 60L,
                 TimeUnit.SECONDS,
-                new ArrayBlockingQueue<>(QUEUE_CAPACITY),
+                new ArrayBlockingQueue<>(queueCapacity),
                 runnable -> {
                     Thread t = new Thread(runnable);
                     t.setName("run-dispatch-" + t.threadId());
@@ -72,7 +71,7 @@ public class RunDispatchExecutorConfiguration {
                 .tag("policy", policy.name())
                 .register(meterRegistry);
         LOG.info("Run dispatch executor initialized: coreThreads={} maxThreads={} queueCapacity={} rejectionPolicy={}",
-                CORE_THREADS, MAX_THREADS, QUEUE_CAPACITY, policy);
+                coreThreads, maxThreads, queueCapacity, policy);
         return executor;
     }
 

--- a/agent-service/src/main/java/com/huawei/ascend/service/platform/web/runs/RunDispatchExecutorConfiguration.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/platform/web/runs/RunDispatchExecutorConfiguration.java
@@ -1,0 +1,96 @@
+package com.huawei.ascend.service.platform.web.runs;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Isolated executor for run dispatch fan-out from {@link RunController}.
+ *
+ * <p>Why not ForkJoin common pool? Under bursty POST /v1/runs traffic, sharing
+ * the global async pool can amplify tail latency for unrelated tasks. This pool
+ * keeps run-dispatch workload bounded and visible.
+ */
+@Configuration
+@EnableConfigurationProperties(RunDispatchProperties.class)
+public class RunDispatchExecutorConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RunDispatchExecutorConfiguration.class);
+
+    private static final int CORE_THREADS = 4;
+    private static final int MAX_THREADS = 16;
+    private static final int QUEUE_CAPACITY = 256;
+
+    private final MeterRegistry meterRegistry;
+    private final RunDispatchProperties properties;
+
+    public RunDispatchExecutorConfiguration(MeterRegistry meterRegistry,
+                                            RunDispatchProperties properties) {
+        this.meterRegistry = meterRegistry;
+        this.properties = properties;
+    }
+
+    @Bean(name = RunController.RUN_DISPATCH_EXECUTOR_BEAN, destroyMethod = "shutdown")
+    public Executor runDispatchExecutor() {
+        RunDispatchProperties.RejectionPolicy policy = properties.getRejectionPolicy();
+        Counter rejectedCounter = Counter.builder("springai_ascend_run_dispatch_rejected_total")
+                .description("Total run-dispatch tasks rejected by the dedicated executor")
+                .tag("policy", policy.name())
+                .register(meterRegistry);
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(
+                CORE_THREADS,
+                MAX_THREADS,
+                60L,
+                TimeUnit.SECONDS,
+                new ArrayBlockingQueue<>(QUEUE_CAPACITY),
+                runnable -> {
+                    Thread t = new Thread(runnable);
+                    t.setName("run-dispatch-" + t.threadId());
+                    t.setDaemon(true);
+                    return t;
+                },
+                rejectionHandler(policy, rejectedCounter));
+
+        Gauge.builder("springai_ascend_run_dispatch_executor_active_threads", executor, ThreadPoolExecutor::getActiveCount)
+                .description("Active threads in run-dispatch executor")
+                .tag("policy", policy.name())
+                .register(meterRegistry);
+        Gauge.builder("springai_ascend_run_dispatch_executor_queue_depth", executor,
+                        e -> e.getQueue().size())
+                .description("Queue depth of run-dispatch executor")
+                .tag("policy", policy.name())
+                .register(meterRegistry);
+        LOG.info("Run dispatch executor initialized: coreThreads={} maxThreads={} queueCapacity={} rejectionPolicy={}",
+                CORE_THREADS, MAX_THREADS, QUEUE_CAPACITY, policy);
+        return executor;
+    }
+
+    private RejectedExecutionHandler rejectionHandler(RunDispatchProperties.RejectionPolicy policy,
+                                                      Counter rejectedCounter) {
+        RejectedExecutionHandler fallback = switch (policy) {
+            case ABORT -> new ThreadPoolExecutor.AbortPolicy();
+            case CALLER_RUNS -> new ThreadPoolExecutor.CallerRunsPolicy();
+        };
+        return (runnable, executor) -> {
+            rejectedCounter.increment();
+            if (policy == RunDispatchProperties.RejectionPolicy.ABORT) {
+                LOG.warn("Run dispatch task rejected (policy=ABORT): activeThreads={} queueDepth={} queueRemainingCapacity={}",
+                        executor.getActiveCount(),
+                        executor.getQueue().size(),
+                        executor.getQueue().remainingCapacity());
+            }
+            fallback.rejectedExecution(runnable, executor);
+        };
+    }
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/platform/web/runs/RunDispatchProperties.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/platform/web/runs/RunDispatchProperties.java
@@ -1,0 +1,29 @@
+package com.huawei.ascend.service.platform.web.runs;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration for run-dispatch executor overload behavior.
+ */
+@ConfigurationProperties(prefix = "app.runs.dispatch")
+public class RunDispatchProperties {
+
+    public enum RejectionPolicy {
+        CALLER_RUNS,
+        ABORT
+    }
+
+    /**
+     * Overload rejection policy for the dedicated run-dispatch executor.
+     * Default keeps current behavior for backward compatibility.
+     */
+    private RejectionPolicy rejectionPolicy = RejectionPolicy.CALLER_RUNS;
+
+    public RejectionPolicy getRejectionPolicy() {
+        return rejectionPolicy;
+    }
+
+    public void setRejectionPolicy(RejectionPolicy rejectionPolicy) {
+        this.rejectionPolicy = rejectionPolicy;
+    }
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/platform/web/runs/RunDispatchProperties.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/platform/web/runs/RunDispatchProperties.java
@@ -19,11 +19,39 @@ public class RunDispatchProperties {
      */
     private RejectionPolicy rejectionPolicy = RejectionPolicy.CALLER_RUNS;
 
+    private int coreThreads = 4;
+    private int maxThreads = 16;
+    private int queueCapacity = 256;
+
     public RejectionPolicy getRejectionPolicy() {
         return rejectionPolicy;
     }
 
     public void setRejectionPolicy(RejectionPolicy rejectionPolicy) {
         this.rejectionPolicy = rejectionPolicy;
+    }
+
+    public int getCoreThreads() {
+        return coreThreads;
+    }
+
+    public void setCoreThreads(int coreThreads) {
+        this.coreThreads = coreThreads;
+    }
+
+    public int getMaxThreads() {
+        return maxThreads;
+    }
+
+    public void setMaxThreads(int maxThreads) {
+        this.maxThreads = maxThreads;
+    }
+
+    public int getQueueCapacity() {
+        return queueCapacity;
+    }
+
+    public void setQueueCapacity(int queueCapacity) {
+        this.queueCapacity = queueCapacity;
     }
 }

--- a/agent-service/src/main/resources/application.yml
+++ b/agent-service/src/main/resources/application.yml
@@ -112,6 +112,9 @@ app:
     allow-in-memory: false
   runs:
     dispatch:
+      core-threads: 4
+      max-threads: 16
+      queue-capacity: 256
       # Overload fallback for dedicated run-dispatch executor.
       # CALLER_RUNS keeps current behavior; ABORT fails fast on saturation.
       rejection-policy: CALLER_RUNS

--- a/agent-service/src/main/resources/application.yml
+++ b/agent-service/src/main/resources/application.yml
@@ -110,3 +110,8 @@ app:
   idempotency:
     ttl: PT24H
     allow-in-memory: false
+  runs:
+    dispatch:
+      # Overload fallback for dedicated run-dispatch executor.
+      # CALLER_RUNS keeps current behavior; ABORT fails fast on saturation.
+      rejection-policy: CALLER_RUNS

--- a/agent-service/src/test/java/com/huawei/ascend/service/platform/web/runs/RunDispatchExecutorConfigurationTest.java
+++ b/agent-service/src/test/java/com/huawei/ascend/service/platform/web/runs/RunDispatchExecutorConfigurationTest.java
@@ -52,4 +52,21 @@ class RunDispatchExecutorConfigurationTest {
                 .tag("policy", "ABORT").counter()).isNotNull();
         executor.shutdownNow();
     }
+
+    @Test
+    void threadPoolSizesRespectConfiguredBounds() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RunDispatchProperties properties = new RunDispatchProperties();
+        properties.setCoreThreads(8);
+        properties.setMaxThreads(4);
+        properties.setQueueCapacity(0);
+
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) new RunDispatchExecutorConfiguration(registry, properties)
+                .runDispatchExecutor();
+
+        assertThat(executor.getCorePoolSize()).isEqualTo(8);
+        assertThat(executor.getMaximumPoolSize()).isEqualTo(8);
+        assertThat(executor.getQueue().remainingCapacity() + executor.getQueue().size()).isEqualTo(1);
+        executor.shutdownNow();
+    }
 }

--- a/agent-service/src/test/java/com/huawei/ascend/service/platform/web/runs/RunDispatchExecutorConfigurationTest.java
+++ b/agent-service/src/test/java/com/huawei/ascend/service/platform/web/runs/RunDispatchExecutorConfigurationTest.java
@@ -1,0 +1,55 @@
+package com.huawei.ascend.service.platform.web.runs;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RunDispatchExecutorConfigurationTest {
+
+    @Test
+    void registersExecutorMetricsAndRejectionCounter() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RunDispatchProperties properties = new RunDispatchProperties();
+        RunDispatchExecutorConfiguration configuration = new RunDispatchExecutorConfiguration(registry, properties);
+
+        Executor executor = configuration.runDispatchExecutor();
+        assertThat(executor).isInstanceOf(ThreadPoolExecutor.class);
+
+        assertThat(registry.find("springai_ascend_run_dispatch_rejected_total").counter()).isNotNull();
+        assertThat(registry.find("springai_ascend_run_dispatch_rejected_total")
+                .tag("policy", "CALLER_RUNS").counter()).isNotNull();
+        assertThat(registry.find("springai_ascend_run_dispatch_executor_active_threads").gauge()).isNotNull();
+        assertThat(registry.find("springai_ascend_run_dispatch_executor_queue_depth").gauge()).isNotNull();
+
+        ((ThreadPoolExecutor) executor).shutdownNow();
+    }
+
+    @Test
+    void abortPolicyRejectsAndIncrementsCounter() {
+        SimpleMeterRegistry registry = new SimpleMeterRegistry();
+        RunDispatchProperties properties = new RunDispatchProperties();
+        properties.setRejectionPolicy(RunDispatchProperties.RejectionPolicy.ABORT);
+        RunDispatchExecutorConfiguration configuration = new RunDispatchExecutorConfiguration(registry, properties);
+
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) configuration.runDispatchExecutor();
+        executor.shutdown();
+
+        try {
+            executor.execute(() -> {
+            });
+        } catch (RejectedExecutionException expected) {
+            // expected for ABORT policy
+        }
+
+        assertThat(registry.get("springai_ascend_run_dispatch_rejected_total").counter().count())
+                .isEqualTo(1.0d);
+        assertThat(registry.find("springai_ascend_run_dispatch_rejected_total")
+                .tag("policy", "ABORT").counter()).isNotNull();
+        executor.shutdownNow();
+    }
+}

--- a/agent-service/src/test/java/com/huawei/ascend/service/platform/web/runs/RunDispatchExecutorPerformanceTest.java
+++ b/agent-service/src/test/java/com/huawei/ascend/service/platform/web/runs/RunDispatchExecutorPerformanceTest.java
@@ -1,0 +1,84 @@
+package com.huawei.ascend.service.platform.web.runs;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Performance-safety proof for run dispatch executor isolation.
+ *
+ * <p>Scenario: saturate ForkJoin common pool workers with blocking tasks, then
+ * submit one probe task to common pool and one probe task to the dedicated run
+ * dispatch executor. The dedicated executor should run promptly while the common
+ * pool probe waits for blocked workers to free up.
+ */
+class RunDispatchExecutorPerformanceTest {
+
+    @Test
+    void dedicatedExecutorStartsProbeEarlierThanSaturatedCommonPool() throws Exception {
+        int commonParallelism = ForkJoinPool.getCommonPoolParallelism();
+        assertThat(commonParallelism)
+                .as("common pool must expose at least one worker")
+                .isGreaterThan(0);
+
+        CountDownLatch blockersStarted = new CountDownLatch(commonParallelism);
+        CountDownLatch releaseBlockers = new CountDownLatch(1);
+        List<CompletableFuture<Void>> blockers = new ArrayList<>();
+
+        for (int i = 0; i < commonParallelism; i++) {
+            blockers.add(CompletableFuture.runAsync(() -> {
+                blockersStarted.countDown();
+                try {
+                    releaseBlockers.await(2, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }));
+        }
+
+        assertThat(blockersStarted.await(1, TimeUnit.SECONDS))
+                .as("all common-pool workers should be occupied by blockers")
+                .isTrue();
+
+        Executor dedicated = new RunDispatchExecutorConfiguration(
+                new SimpleMeterRegistry(),
+                new RunDispatchProperties()).runDispatchExecutor();
+
+        long commonStart = System.nanoTime();
+        CompletableFuture<Long> commonProbe = CompletableFuture.supplyAsync(System::nanoTime);
+
+        long dedicatedStart = System.nanoTime();
+        CompletableFuture<Long> dedicatedProbe = CompletableFuture.supplyAsync(System::nanoTime, dedicated);
+
+        long dedicatedNanos = dedicatedProbe.get(500, TimeUnit.MILLISECONDS) - dedicatedStart;
+
+        // common probe should not finish while blockers still occupy all workers.
+        assertThat(commonProbe.isDone()).isFalse();
+
+        releaseBlockers.countDown();
+        CompletableFuture.allOf(blockers.toArray(new CompletableFuture[0])).join();
+        long commonNanos = commonProbe.get(2, TimeUnit.SECONDS) - commonStart;
+
+        assertThat(Duration.ofNanos(dedicatedNanos))
+                .as("dedicated run-dispatch executor should schedule promptly")
+                .isLessThan(Duration.ofMillis(200));
+        assertThat(commonNanos)
+                .as("common pool probe should be delayed while pool is saturated")
+                .isGreaterThan(dedicatedNanos);
+
+        if (dedicated instanceof ThreadPoolExecutor tpe) {
+            tpe.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent run-dispatch fan-out from amplifying tail latency on the global async pool by isolating that workload on a dedicated executor.

### Description

- Add `RunDispatchExecutorConfiguration` which exposes a named `Executor` bean `RunController.RUN_DISPATCH_EXECUTOR_BEAN` backed by a `ThreadPoolExecutor` with configurable rejection policy and metrics registration. 
- Add `RunDispatchProperties` (`app.runs.dispatch.rejection-policy`) to control overload behavior with default `CALLER_RUNS`. 
- Wire the executor into `RunController` (inject with `@Qualifier`) and use it in `CompletableFuture.runAsync(..., runDispatchExecutor)` when dispatching runs. 
- Register metrics (`springai_ascend_run_dispatch_rejected_total`, `springai_ascend_run_dispatch_executor_active_threads`, `springai_ascend_run_dispatch_executor_queue_depth`) and add logging and sensible thread naming; update `application.yml` with the new config key. 
- Add tests `RunDispatchExecutorConfigurationTest` and `RunDispatchExecutorPerformanceTest` to validate metrics, rejection counting, and executor isolation behavior.

### Testing

- Ran `RunDispatchExecutorConfigurationTest` which verifies executor type, registered metrics, and that the reject counter increments for `ABORT`; tests passed. 
- Ran `RunDispatchExecutorPerformanceTest` which asserts the dedicated executor schedules a probe task promptly while the ForkJoin common pool is saturated; test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bbe7173cc832e806e9b2c0114da34)