### PR TITLE
docs: expand trustworthy architecture guidance

### DIFF
--- a/docs/trustworthy/README.md
+++ b/docs/trustworthy/README.md
@@ -32,9 +32,15 @@ not yet easy to review as one operating model.
 | Document | Purpose |
 |---|---|
 | [architecture-assessment.md](architecture-assessment.md) | Architecture issue review across trustworthy, architecture, deployment, development, and operations dimensions. |
+| [deployment-plane-contract.md](deployment-plane-contract.md) | L0 deployment-plane contract covering deployable units, state ownership, failure domains, recovery, rollback, and continuity classes. |
+| [trust-boundary-matrix.md](trust-boundary-matrix.md) | Cross-plane and cross-module trust-boundary index for caller/callee, credentials, tenant binding, replay control, audit, and AI-specific boundary rules. |
 | [l0-l1-decomposition.md](l0-l1-decomposition.md) | L0 and L1 decomposition model, with module-level trust responsibilities. |
+| [interface-contract-metadata.md](interface-contract-metadata.md) | L1 runtime metadata expected for SPI/schema contracts, including timeout, retry, idempotency, cancellation, audit, metrics, and compatibility. |
+| [ai-risk-control-map.md](ai-risk-control-map.md) | Mapping of AI-specific risk families to L0 rules, L1 module controls, and L2 evidence. |
+| [dfx-evidence-status-policy.md](dfx-evidence-status-policy.md) | Status vocabulary and release rules for turning DFX pending/deferred claims into evidence-backed states. |
 | [operating-model.md](operating-model.md) | Trustworthy lifecycle model across plan, design, build, review, release, deploy, operate, and improve. |
 | [prompt-playbook.md](prompt-playbook.md) | Copy-ready prompts for L0 design, L1 design, L2 plan/design/build/review/release, L2-to-L1 validation, L1 release, and L1-to-L0 validation. |
+| [release-validation-checklist.md](release-validation-checklist.md) | Practical PR/release checklist for L2 evidence, L2-to-L1 validation, L1 release, and L1-to-L0 validation. |
 | [verification-matrix.md](verification-matrix.md) | Evidence matrix for L2-to-L1 and L1-to-L0 validation. |
 
 ## Relationship to Existing Authority

--- a/docs/trustworthy/ai-risk-control-map.md
+++ b/docs/trustworthy/ai-risk-control-map.md
@@ -1,0 +1,57 @@
+---
+level: L0
+view: scenarios
+status: draft
+authority: "Derived from trustworthy prompt design, threat model, and module responsibility review"
+---
+
+# AI Risk Control Map
+
+## Purpose
+
+This document maps AI-specific risk families to L0 ownership, L1 module
+controls, and L2 evidence. It prevents AI risk from remaining generic guidance.
+
+## Risk Families
+
+| Risk | L0 System Rule | L1 Control Owner | L2 Evidence |
+|---|---|---|---|
+| Prompt injection | Untrusted context cannot modify policy, permissions, system prompts, tool scope, or release verdicts | `agent-service`, `agent-middleware` | input classification tests, prompt boundary tests, hook enforcement tests |
+| Tool poisoning | Tool metadata/output is untrusted until validated and authorized | `agent-middleware`, sandbox future owner | tool allowlist tests, permission-envelope checks, audit assertions |
+| Context leakage | Tenant/model/tool/memory context must not cross scope without explicit delegation | `agent-service`, graph memory starter, `agent-bus` | tenant isolation tests, redaction tests, memory scope tests |
+| Model/provider fallback bypass | Fallback cannot weaken policy, audit, tenant, budget, or safety controls | `agent-execution-engine`, `agent-service` | engine strict-match tests, fallback-denial tests |
+| Hallucinated code/config | Model-generated config/code is proposal data, not authority | governance/review flow | review checklist, schema validation, no direct privileged write |
+| Cost exhaustion | Run, tenant, skill, model, and tool usage must have budgets or saturation behavior | `agent-service`, `agent-bus`, future skill scheduler | quota tests, saturation tests, metrics |
+| Feedback poisoning | Evolution input must be opt-in, classified, retained, and poison-checked | `agent-evolve` | export-control tests, poisoning regression corpus |
+| Unsafe memory write | Business knowledge ownership must remain client-side unless delegated | graph memory starter, `agent-service` | DelegationGrant tests, placeholder preservation tests |
+| Audit omission | High-risk AI decisions must emit immutable or tamper-evident audit | `agent-service`, `agent-middleware` | audit event tests, release evidence |
+
+## Module Exposure Map
+
+| Module | AI Risk Exposure | Required Control |
+|---|---|---|
+| `agent-client` | untrusted user intent, business rules, cursor/cancellation | preserve context without gaining policy authority |
+| `agent-bus` | cross-plane request/callback routing, mailbox/backpressure | preserve tenant/correlation, prevent ordering and callback drift |
+| `agent-service` | admission, Run lifecycle, model/tool orchestration, memory SPI | classify input, enforce tenant, audit state transitions, fail closed |
+| `agent-execution-engine` | engine selection, envelope matching, orchestration SPI | strict matching, no unsafe fallback, typed failure mapping |
+| `agent-middleware` | policy/audit/telemetry hooks | mandatory high-risk hook path, deterministic outcome |
+| `agent-evolve` | offline feedback and improvement | opt-in, retention, poison detection, no production-path authority |
+| `graphmemory-starter` | optional memory adapter | disabled by default, tenant-scoped, ownership/delegation-aware |
+
+## Required Red-Team Scenarios
+
+1. Prompt asks the system to ignore tenant, policy, or tool restrictions.
+2. Tool output includes instructions to modify system prompt or credentials.
+3. Model output attempts to create shell/SQL/file actions from raw prompt text.
+4. Context from tenant A attempts to enter tenant B memory or trace.
+5. Model fallback tries to bypass engine strict matching or audit.
+6. Repeated Run creation attempts to exhaust idempotency, queue, token, or skill
+   budgets.
+7. Evolution export contains poisoned or unauthorized business facts.
+
+## Release Rule
+
+If an L2 change introduces one of these risk families and lacks a test,
+red-team note, or explicit deferred trigger, the release verdict should be
+`BLOCKED_AI_EVIDENCE_GAP`.
+

--- a/docs/trustworthy/deployment-plane-contract.md
+++ b/docs/trustworthy/deployment-plane-contract.md
@@ -1,0 +1,116 @@
+---
+level: L0
+view: physical
+status: draft
+authority: "Derived from ARCHITECTURE.md, module-metadata.yaml, DFX YAML, and financial readiness review"
+---
+
+# Deployment Plane Contract
+
+## Purpose
+
+This document turns the L0 logical planes into production deployment
+obligations. A plane is not only a diagram element. For trustworthy
+architecture review, each plane must declare its deployable boundary, failure
+boundary, state ownership, recovery expectation, and release evidence.
+
+## Plane Contract Rules
+
+1. A module may belong to one primary deployment plane only.
+2. A cross-plane route must have an owning contract or SPI.
+3. Any plane that owns durable state must define recovery and replay behavior.
+4. Any customer-facing plane must define SLO, RTO, RPO, rollback, and
+   emergency-disable expectations.
+5. Design-only or deferred runtime semantics must not be used as shipped HA
+   evidence.
+
+## Deployment Plane Matrix
+
+| Plane | Current Modules | Primary Role | State Ownership | Failure Boundary | Current Evidence | Gap |
+|---|---|---|---|---|---|---|
+| `edge` | `agent-client` | Client-side access, cursor/correlation propagation, future SDK | No authoritative server state | Client retry and credential misuse must not affect server correctness | `agent-client/module-metadata.yaml`, `docs/dfx/agent-client.yaml` | SDK runtime contract is still skeleton/pending |
+| `compute_control` | `agent-service`, `agent-execution-engine`, `agent-middleware` | HTTP admission, Run lifecycle, orchestration SPI, engine selection, hook policy | Run/idempotency/checkpoint state, depending on wave | Runtime worker failure, request admission failure, engine mismatch, hook bypass | L0 architecture, module L1 docs, OpenAPI, engine contracts, DFX | `agent-service` is still broad as one production role |
+| `bus_state` | `agent-bus`, `spring-ai-ascend-graphmemory-starter` | C2S ingress, S2C callback, future three-track bus/state hub, optional memory adapter | Bus cursor/mailbox/callback state; optional graph memory adapter state | Central control-route saturation, callback mismatch, mailbox backlog, memory tenant bleed | Ingress/S2C contracts, bus DFX, GraphMemory SPI | Runtime bus semantics and HA evidence are mostly deferred |
+| `sandbox` | future sandbox executor | Bounded tool/action execution | Sandbox-local temp state only unless explicitly delegated | Escape, credential leakage, filesystem/network abuse | ADR-0018, DFX references | Runtime sandbox enforcement is deferred |
+| `evolution` | `agent-evolve` | Offline improvement loop and evolution exports | Offline datasets, feedback, candidate improvements | Poisoned feedback, unauthorized export, retention drift | `agent-evolve` L1/DFX | Skeleton; needs opt-in and export-control evidence |
+| `none` | `spring-ai-ascend-dependencies` | BOM and dependency alignment | None | Supply-chain drift | parent POM, dependency module | Automated SCA gate deferred |
+
+## Minimum Contract Per Plane
+
+Each plane should maintain the following fields in either this document, a
+future YAML contract, or promoted L0/L1 authority:
+
+| Field | Required Meaning |
+|---|---|
+| `deployable_unit` | What can be deployed, scaled, restarted, and rolled back independently |
+| `state_owner` | Which state is authoritative in this plane |
+| `ingress` | Allowed inbound routes and callers |
+| `egress` | Allowed outbound routes and callees |
+| `secret_scope` | Which credentials can be present in this plane |
+| `data_classification` | Data categories the plane may process or persist |
+| `scaling_model` | Horizontal/vertical scaling model and tenant fairness rule |
+| `failure_domain` | What can fail without taking down other planes |
+| `degradation_mode` | How the system behaves when this plane is impaired |
+| `recovery_model` | Replay, reconciliation, sweep, DLQ, checkpoint, or fail-closed behavior |
+| `rollback_model` | How a bad release or config can be reverted |
+| `slo_class` | Customer-facing, operator-critical, internal async, or offline |
+| `evidence` | Tests, gates, metrics, runbooks, drills, and release notes |
+
+## Suggested Continuity Classes
+
+| Class | Use | Example Capabilities | Required Evidence |
+|---|---|---|---|
+| `C0_customer_critical` | Customer-visible critical path | Run create/query/cancel, admission rejection correctness | SLO, RTO/RPO, idempotency, HA test, rollback, audit |
+| `C1_operator_critical` | Operator or recovery path | audit search, sweeper, incident replay, emergency-disable | runbook, alert, drill, tamper-evident audit |
+| `C2_internal_async` | Internal async or deferred path | bus delivery, callback retry, evolution export queue | backlog metric, DLQ, retry budget, replay |
+| `C3_offline` | Offline analysis and improvement | evolution training, benchmark generation | opt-in, retention, poisoning checks, export control |
+
+## Plane-Specific Recommendations
+
+### Edge
+
+- Treat `agent-client` as untrusted even if it is platform-owned.
+- Require trace propagation, timeout, retry, cancellation, and idempotency
+  behavior before SDK release.
+- Do not allow edge code to bypass `IngressGateway`.
+
+### Compute Control
+
+- Split `agent-service` into explicit runtime roles in documentation even if
+  it remains one Maven module:
+  - API admission;
+  - Run lifecycle owner;
+  - runtime worker/reference adapter;
+  - durable state adapter.
+- Require every role to state failure isolation and rollback behavior.
+
+### Bus State
+
+- Make the three-track bus contract testable:
+  - control;
+  - data;
+  - rhythm/heartbeat.
+- Define ordering, retry, DLQ, terminal-event preservation, saturation, and
+  recovery behavior per track.
+
+### Sandbox
+
+- Production posture must fail closed when untrusted tools require a sandbox
+  but only a NoOp sandbox exists.
+- Sandbox events must be auditable.
+
+### Evolution
+
+- Keep evolution opt-in and offline by default.
+- Require poisoning, retention, redaction, and export-control checks before
+  runtime activation.
+
+## L0 Review Questions
+
+1. Did a module move to a different plane?
+2. Did a plane gain new durable state?
+3. Did a plane gain new credential, network, model, tool, or data scope?
+4. Did a cross-plane route bypass its owning SPI or contract?
+5. Can this plane fail without violating the declared continuity class?
+6. Are degraded behavior and recovery evidence documented?
+

--- a/docs/trustworthy/dfx-evidence-status-policy.md
+++ b/docs/trustworthy/dfx-evidence-status-policy.md
@@ -1,0 +1,69 @@
+---
+level: L1
+view: process
+status: draft
+authority: "Derived from docs/dfx/*.yaml and L1 trustworthy review"
+---
+
+# DFX Evidence Status Policy
+
+## Purpose
+
+The repository already maintains DFX YAML per module. This policy tightens DFX
+status vocabulary so DFX cannot become a vague compliance placeholder.
+
+## Status Vocabulary
+
+| Status | Meaning | May Support Production Claim? |
+|---|---|---|
+| `implemented` | Implementation exists, but evidence may be limited | only with cited evidence |
+| `test_verified` | Implementation has runnable tests or gate evidence | yes |
+| `design_only` | Architecture/design is accepted, runtime is not shipped | no |
+| `deferred_with_trigger` | Deferred with owner, trigger, wave, and impact | no |
+| `not_applicable_with_reason` | Not applicable and reason is explicit | yes, for exclusion only |
+| `blocked_evidence_gap` | Required evidence is missing | no |
+
+Avoid open-ended `pending` for any production-facing path.
+
+## Required Fields For Deferred Items
+
+Every deferred DFX claim must state:
+
+- owner;
+- target wave or trigger;
+- reason for deferral;
+- production impact;
+- release blocker status;
+- evidence required for promotion;
+- related ADR/rule/contract.
+
+## DFX Promotion Rules
+
+1. `design_only` can move to `implemented` only after code path exists.
+2. `implemented` can move to `test_verified` only after runnable evidence is
+   cited.
+3. `deferred_with_trigger` must not be described as shipped.
+4. `pending` must be converted before L1 release.
+5. Production-facing modules cannot pass L1 release with `blocked_evidence_gap`.
+
+## Current High-Priority Conversions
+
+| Module | Current Concern | Suggested Conversion |
+|---|---|---|
+| `agent-bus` | multiple pending availability/resilience/observability fields | `design_only` or `deferred_with_trigger` until runtime bus lands |
+| `agent-client` | SDK skeleton pending retry/timeout/cancel/trace | `deferred_with_trigger` tied to W3 SDK release |
+| `agent-evolve` | skeleton pending offline controls | `deferred_with_trigger` tied to first evolution activation |
+| `agent-service` | audit/hook/durable readiness deferred | split by field into `implemented`, `design_only`, or `deferred_with_trigger` |
+| graph memory starter | adapter/data governance deferred | `design_only` until real adapter evidence exists |
+
+## L1 Release Gate
+
+An L1 release should reject:
+
+- vague `pending` on customer-facing or operator-critical paths;
+- DFX claims with no evidence link;
+- design-only controls used as runtime controls;
+- deferred controls without trigger, owner, or production impact;
+- observability claims that are only logs but not metrics/audit where audit is
+  required.
+

--- a/docs/trustworthy/interface-contract-metadata.md
+++ b/docs/trustworthy/interface-contract-metadata.md
@@ -1,0 +1,108 @@
+---
+level: L1
+view: logical
+status: draft
+authority: "Derived from docs/contracts, module-metadata.yaml, DFX YAML, and L1 readiness review"
+---
+
+# Interface Contract Metadata
+
+## Purpose
+
+The repository already has schema-first contracts. This document defines the
+additional runtime metadata expected for financial-grade L1 interfaces.
+
+Schema shape answers "what is the message?" Contract metadata answers "how is
+the message safely operated?"
+
+## Required Metadata Fields
+
+| Field | Required Meaning |
+|---|---|
+| `owner_module` | L1 module accountable for this contract |
+| `exposure_tier` | external, edge, internal-control, internal-data, extension, offline |
+| `data_classification` | tenant, operational, audit, model, tool, memory, public |
+| `authn` | identity source and verification method |
+| `authz` | policy or permission boundary |
+| `tenant_binding` | where tenant id comes from and how mismatch is rejected |
+| `idempotency_key` | required, optional, or not applicable with reason |
+| `ordering_key` | ordering scope if messages can race |
+| `timeout_budget` | caller timeout and callee expectation |
+| `retry_budget` | max retries, backoff, and retryable errors |
+| `cancellation` | cancellation propagation and terminal behavior |
+| `error_taxonomy` | typed error families and compatibility rules |
+| `audit_event` | audit event name and required fields |
+| `metric` | metric name and labels |
+| `compatibility` | backward/forward compatibility expectation |
+| `deprecation` | deprecation and removal policy |
+| `rollback` | behavior if a new contract version is disabled |
+
+## Initial Contract Metadata Sketch
+
+| Contract | Owner | Exposure | Critical Metadata To Add |
+|---|---|---|---|
+| `openapi-v1.yaml` | `agent-service` | external / customer-facing | authn/authz, tenant binding, idempotency, error taxonomy, audit event per endpoint |
+| `ingress-envelope.v1.yaml` | `agent-bus` | edge to bus | idempotency key, cursor semantics, ordering key, retry budget, audit fields |
+| `s2c-callback.v1.yaml` | `agent-bus` | bus to client callback | callback id, timeout, retry, terminal behavior, cancellation, audit |
+| `engine-envelope.v1.yaml` | `agent-execution-engine` | internal extension | strict matching, no fallback reinterpretation, failure taxonomy, metric |
+| `engine-hooks.v1.yaml` | `agent-middleware` | internal extension | mandatory hook points, hook outcome semantics, audit/telemetry emission |
+| `plan-projection.v1.yaml` | future planner/bus owner | design-only | runtime binding, state ownership, recovery, versioning |
+
+## Contract Metadata Template
+
+```yaml
+contract: ""
+version: ""
+owner_module: ""
+exposure_tier: ""
+data_classification: []
+authn: ""
+authz: ""
+tenant_binding:
+  source: ""
+  mismatch_behavior: ""
+idempotency_key:
+  required: true
+  scope: ""
+ordering_key:
+  required: false
+  scope: ""
+timeout_budget: ""
+retry_budget:
+  max_attempts: 0
+  retryable_errors: []
+  backoff: ""
+cancellation: ""
+error_taxonomy: []
+audit_event:
+  name: ""
+  required_fields: []
+metric:
+  name: ""
+  labels: []
+compatibility: ""
+deprecation: ""
+rollback: ""
+evidence:
+  tests: []
+  gates: []
+  docs: []
+```
+
+## L2 Change Triggers
+
+An L2 change must trigger L2-to-L1 validation when it changes:
+
+- public SPI method signature;
+- schema field, enum, requiredness, or compatibility;
+- error taxonomy;
+- idempotency behavior;
+- timeout, retry, ordering, or cancellation behavior;
+- tenant, data, credential, model, tool, or network scope;
+- audit event, metric, or log field used as release evidence.
+
+## Acceptance Rule
+
+A contract may be design-complete but not production-ready. Production-facing
+L1 release requires both schema truth and metadata truth.
+

--- a/docs/trustworthy/release-validation-checklist.md
+++ b/docs/trustworthy/release-validation-checklist.md
@@ -1,0 +1,96 @@
+---
+level: L0
+view: process
+status: draft
+authority: "Derived from verification-matrix.md and trustworthy prompt playbook"
+---
+
+# Release Validation Checklist
+
+## Purpose
+
+This checklist turns the verification matrix into a practical PR/release flow.
+Use it to decide whether evidence can move upward:
+
+- L2 evidence validates a feature.
+- L2-to-L1 validation decides whether the module contract still holds.
+- L1 evidence validates a module/interface.
+- L1-to-L0 validation decides whether system claims still hold.
+
+## L2 PR Checklist
+
+- [ ] Layer is declared as L2.
+- [ ] Related L1 module/interface/schema is named.
+- [ ] Scope and non-scope are explicit.
+- [ ] Public SPI/schema/enum/config/error taxonomy changes are declared.
+- [ ] Tenant, data, credential, network, model, tool, and memory scope changes
+      are declared.
+- [ ] Timeout, retry, cancellation, idempotency, ordering, and rollback behavior
+      are covered or marked not applicable.
+- [ ] Happy, negative, contract, security, and recovery tests are present or
+      explicitly deferred with reason.
+- [ ] AI-specific risk families are assessed.
+- [ ] Verification commands are recorded.
+- [ ] Release verdict is `PASS`, `PARTIAL`, or `BLOCKED`.
+
+## L2-to-L1 Validation Checklist
+
+- [ ] L2 stayed inside the L1 responsibility boundary.
+- [ ] Public contract metadata still matches implementation.
+- [ ] Module dependencies still satisfy allowed/forbidden rules.
+- [ ] DFX claims are updated when behavior changes.
+- [ ] Security/privacy controls are still valid.
+- [ ] AI risk controls are still valid.
+- [ ] Release note does not overclaim L1 readiness.
+- [ ] Verdict is `PASS`, `PASS_WITH_L1_UPDATES_REQUIRED`, or `BLOCKED`.
+
+## L1 Release Checklist
+
+- [ ] Module responsibility and non-responsibility are current.
+- [ ] Runtime role and deployment plane are current.
+- [ ] SPI/schema/catalog/module metadata agree.
+- [ ] Interface contract metadata is complete for production-facing surfaces.
+- [ ] DFX statuses use approved vocabulary.
+- [ ] Boundary, dependency, security, AI risk, and observability evidence is
+      cited.
+- [ ] Included L2 releases passed L2-to-L1 validation.
+- [ ] Rollback and compatibility are documented.
+
+## L1-to-L0 Validation Checklist
+
+- [ ] Module still maps to the same L0 capability block.
+- [ ] Deployment plane and cross-plane routes did not silently change.
+- [ ] Trust boundary, failure boundary, and data boundary did not silently
+      expand.
+- [ ] Continuity class and SLO/RTO/RPO assumptions still hold.
+- [ ] Governance surfaces are synchronized: ADR, rule, DFX, contract, graph,
+      release note.
+- [ ] No design-only/deferred control is represented as shipped.
+- [ ] Verdict is `PASS`, `PASS_WITH_L0_UPDATES_REQUIRED`, or `BLOCKED`.
+
+## Release Verdict Definitions
+
+| Verdict | Meaning |
+|---|---|
+| `PASS` | Evidence is sufficient for the stated layer and scope |
+| `PARTIAL` | Evidence is useful but cannot support full release claim |
+| `PASS_WITH_L1_UPDATES_REQUIRED` | L2 is acceptable, but L1 docs/contracts/DFX must update |
+| `PASS_WITH_L0_UPDATES_REQUIRED` | L1 is acceptable, but L0/ADR/rule/release surfaces must update |
+| `BLOCKED` | Critical evidence or contract alignment is missing |
+
+## Minimal PR Comment Template
+
+```text
+Layer:
+Scope:
+Related L1 contract:
+Public contract changes:
+Trust boundary changes:
+DFX impact:
+AI risk impact:
+Tests / verification:
+Deferred evidence:
+Rollback:
+Upward validation verdict:
+```
+

--- a/docs/trustworthy/trust-boundary-matrix.md
+++ b/docs/trustworthy/trust-boundary-matrix.md
@@ -1,0 +1,86 @@
+---
+level: L0
+view: physical
+status: draft
+authority: "Derived from ARCHITECTURE.md threat model, contracts, DFX YAML, and trustworthy review"
+---
+
+# Trust Boundary Matrix
+
+## Purpose
+
+This matrix makes cross-plane and cross-module trust boundaries reviewable in
+one place. It does not replace the contract catalog or module architecture
+documents. It indexes the boundaries that must be enforced by L1 contracts and
+proved by L2 evidence.
+
+## Boundary Classification
+
+| Class | Meaning | Default Rule |
+|---|---|---|
+| `external_untrusted` | User, client app, browser, external business system | parse, authenticate, authorize, rate-limit, audit |
+| `platform_edge` | Platform-owned edge SDK or gateway surface | still untrusted for policy decisions |
+| `internal_control` | Cross-plane control traffic | signed/correlated, tenant-bound, replay-controlled |
+| `internal_data` | Payload or artifact movement | pointer preferred, classify data, redact where needed |
+| `runtime_extension` | SPI, middleware, engine adapter, memory adapter | no hidden authority; least privilege |
+| `offline_evolution` | training/evaluation/improvement path | opt-in, retention-bound, poisoning-aware |
+| `operator_control` | admin/runbook/emergency action | strong identity, approval, immutable audit |
+
+## Current Boundary Matrix
+
+| Boundary | Caller | Callee | Class | Required Controls | Evidence Today | Gap |
+|---|---|---|---|---|---|---|
+| Client request to ingress | external caller / SDK | `IngressGateway` / HTTP edge | `external_untrusted` | authn, authz, tenant binding, idempotency, replay control, audit | OpenAPI, ingress envelope, filters | SDK-side runtime evidence pending |
+| Edge to bus ingress | `agent-client` | `agent-bus.spi.ingress` | `platform_edge` | cursor, correlation, tenant, timeout, retry budget | ingress contract | W3 SDK contract pending |
+| Bus to compute control | `agent-bus` | `agent-service` / runtime | `internal_control` | route ownership, ordering, cancellation, saturation, audit | ADRs/contracts | runtime bus implementation deferred |
+| Compute to engine | `agent-service` | `agent-execution-engine` | `runtime_extension` | engine envelope, strict matching, no fallback reinterpretation | engine-envelope schema, EngineRegistry tests | failure-to-Run-state mapping needs integrated evidence |
+| Compute to middleware | runtime paths | `agent-middleware` | `runtime_extension` | mandatory hook emission, deterministic hook outcome, audit/telemetry path | hook SPI, engine-hooks schema | conformance coverage must grow with W2 runtime |
+| Compute to S2C callback | `agent-service` / `agent-bus` | client callback transport | `internal_control` | tenant/correlation, callback id, retry, cancellation, audit | S2C schema | delivery semantics pending |
+| Runtime to memory | `agent-service` | GraphMemory SPI/starter | `runtime_extension` | tenant scope, data classification, retention, redaction | GraphMemoryRepository SPI, DFX | real adapter data-governance evidence pending |
+| Runtime to tools/sandbox | compute control | sandbox executor / tool | `runtime_extension` | sandbox, permission envelope, output isolation, audit | ADR-0018, DFX | production sandbox deferred |
+| Runtime to evolution | compute control | `agent-evolve` | `offline_evolution` | explicit export, opt-in, retention, poisoning checks | evolution-scope schema | skeleton; runtime evidence absent |
+| Operator action | human/operator | platform control surfaces | `operator_control` | strong identity, approval, tamper-evident audit, runbook | runbooks exist | audit vertical not fully runtime-enforced |
+
+## Required Metadata Per Boundary
+
+Every boundary should eventually declare:
+
+- caller and callee;
+- owning L1 module;
+- public contract or SPI;
+- trust class;
+- credential type;
+- authorization policy;
+- tenant binding rule;
+- data classification;
+- timeout and retry budget;
+- idempotency or replay control;
+- cancellation behavior;
+- error taxonomy;
+- metric name;
+- audit event;
+- redaction/retention rule;
+- release evidence path.
+
+## AI-Specific Boundary Rules
+
+1. Untrusted context must not modify policy, permissions, system prompts, tool
+   scope, release verdicts, or audit conclusions.
+2. Model output must be treated as data until parsed, validated, and bound to
+   an approved action.
+3. Tool input must be derived from validated state, not raw prompt text.
+4. Fallback to another model/provider/engine must preserve tenant, policy,
+   audit, budget, and safety controls.
+5. Any context crossing into memory or evolution must carry classification,
+   retention, redaction, and provenance.
+
+## L1 Review Questions
+
+1. Did this module add a new boundary?
+2. Did this module widen credential, network, tenant, data, model, or tool
+   scope?
+3. Is the boundary represented in contract catalog, schema, DFX, or module
+   metadata?
+4. Is there at least one negative/security test for the boundary?
+5. Is the boundary auditable in production posture?
+


### PR DESCRIPTION
## Summary
- Add trustworthy deployment plane contract
- Add trust boundary matrix and interface contract metadata guidance
- Add AI risk control map, DFX evidence status policy, and release validation checklist
- Update `docs/trustworthy/README.md` document map

## Scope
- Documentation only
- Updates `docs/trustworthy` without deleting the local folder
- Does not include generated reports or output artifacts
