### PR TITLE
feat(rc23-scaffold): agent-service SPI scaffold + 5-component sub-package declarations (rebased after #42)

### DIFF
--- a/agent-service/module-metadata.yaml
+++ b/agent-service/module-metadata.yaml
@@ -14,9 +14,15 @@ spi_packages:
   - com.huawei.ascend.service.runtime.memory.spi
   - com.huawei.ascend.service.runtime.resilience.spi
   - com.huawei.ascend.service.runtime.runs.spi   # RunRepository ownership consolidated here per ADR-0088
+  - com.huawei.ascend.service.engine.spi          # rc23 — StatelessEngine SPI per ADR-0100
+  - com.huawei.ascend.service.session.spi         # rc23 — ContextProjector SPI per ADR-0100
+  - com.huawei.ascend.service.task.spi            # rc23 — TaskStateStore SPI per ADR-0100
 allowed_dependencies:
   - agent-execution-engine    # engine SPI + orchestration SPI (RunMode, RunContext, SuspendSignal, ...) per ADR-0088
   - agent-bus                 # S2cCallbackTransport SPI + IngressGateway SPI per ADR-0088 + ADR-0089
   - agent-middleware
 forbidden_dependencies: []
 deployment_plane: compute_control
+deployment_loci:
+  - platform_centric    # mode_a default per ADR-0101
+  - business_centric    # mode_b — agent-service co-deploys with agent-execution-engine on business side per ADR-0101

--- a/agent-service/src/main/java/com/huawei/ascend/service/dispatcher/package-info.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/dispatcher/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Polymorphic Dispatcher component per ADR-0100 (rc22).
+ *
+ * <p>Unified entry point for BOTH local function-call and remote
+ * bus-call invocations. Component #1 of the agent-service 5-component
+ * runtime-role decomposition.
+ *
+ * <p>Implementation lands in rc23 (agent-service Java refactor moves
+ * the in-process dispatcher logic here from
+ * {@code com.huawei.ascend.service.runtime.orchestration.inmemory}).
+ *
+ * <p>Cross-package boundary (rc23 ArchUnit
+ * {@code AgentServiceComponentBoundaryArchTest}):
+ * dispatcher → may call orchestrator, task, session.
+ * Reverse direction forbidden.
+ */
+package com.huawei.ascend.service.dispatcher;

--- a/agent-service/src/main/java/com/huawei/ascend/service/engine/adapter/package-info.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/engine/adapter/package-info.java
@@ -1,0 +1,25 @@
+/**
+ * Execution Engine Adapter component per ADR-0100 (rc22).
+ *
+ * <p>Masks Workflow vs ReAct engine differences; pure-function compute
+ * injection. Component #5 of the agent-service 5-component runtime-role
+ * decomposition.
+ *
+ * <p>Implementation lands in rc24:
+ * <ul>
+ *   <li>{@code InMemoryStatelessEngine} — wraps existing GRAPH +
+ *       AGENT_LOOP executors as a {@link com.huawei.ascend.service.engine.spi.StatelessEngine}.</li>
+ * </ul>
+ *
+ * <p>Cross-package boundary (rc23 ArchUnit
+ * {@code AgentServiceComponentBoundaryArchTest}):
+ * engine.adapter → may call engine.spi.
+ * Reverse direction forbidden.
+ *
+ * <p>Relationship with {@code com.huawei.ascend.engine.spi.ExecutorAdapter}
+ * (in the {@code agent-execution-engine} module): the Service-level
+ * adapter here CONSUMES the engine-module ExecutorAdapter to materialize
+ * StatelessEngine pure-function semantics over the existing dispatch-
+ * based executor adapters. Resolved in rc23 per ADR-0100 §non_goals.
+ */
+package com.huawei.ascend.service.engine.adapter;

--- a/agent-service/src/main/java/com/huawei/ascend/service/engine/spi/AgentInvokeRequest.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/engine/spi/AgentInvokeRequest.java
@@ -1,0 +1,38 @@
+package com.huawei.ascend.service.engine.spi;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service-to-Engine invocation request per ADR-0100 (rc22).
+ *
+ * <p>Wire contract:
+ * {@code docs/contracts/agent-invoke-request.v1.yaml} (status:
+ * design_only at rc22; runtime impl in rc24).
+ *
+ * <p>Service is the Read-Modify-Write closure boundary; Engine is the
+ * Pure-Function compute boundary. See ADR-0100 §decision.
+ *
+ * <p>This is an SPI surface placeholder. Fields are documented to mirror
+ * the YAML contract; concrete record fields land in rc24 alongside the
+ * reference impl.
+ *
+ * @param runId           the Run this invocation belongs to.
+ * @param taskId          the Task this Run materializes (decoupled from sessionId per ADR-0100).
+ * @param sessionId       the Session whose context this invocation reads.
+ * @param tenantId        mandatory per Rule R-C.c.
+ * @param sessionContext  projected SessionContext from ContextProjector SPI.
+ * @param injectedSkills  pre-resolved skill IDs (capacity already approved per Rule R-K).
+ * @param taskMetadata    task control state at invocation time.
+ * @param traceId         W3C trace-id propagated from inbound request.
+ */
+public record AgentInvokeRequest(
+        String runId,
+        String taskId,
+        String sessionId,
+        String tenantId,
+        Map<String, Object> sessionContext,
+        List<String> injectedSkills,
+        Map<String, Object> taskMetadata,
+        String traceId) {
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/engine/spi/StateDelta.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/engine/spi/StateDelta.java
@@ -1,0 +1,29 @@
+package com.huawei.ascend.service.engine.spi;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Engine-produced compute result per ADR-0100 (rc22).
+ *
+ * <p>Returned by {@link StatelessEngine#execute(AgentInvokeRequest)}.
+ * The orchestrator merges the delta into Run + Task + Session state.
+ *
+ * <p>{@code runStatusTransition} hints the requested Run state
+ * transition. {@code SUSPENDED} happens only via the checked-exception
+ * flow ({@code SuspendSignal}); {@code YIELDED} uses the ON_YIELD hook
+ * + this hint (cooperative scheduling, no state-machine transition).
+ *
+ * @param runStatusTransition  requested transition hint (no_change | succeeded | failed | suspended | yielded).
+ * @param taskStateDelta       patches to Task control state.
+ * @param sessionStateDelta    patches to Session context.
+ * @param memoryWriteIntents   memory write operations (routed through GraphMemoryRepository).
+ * @param metrics              engine-reported metrics (tokens, tool calls, ...).
+ */
+public record StateDelta(
+        String runStatusTransition,
+        Map<String, Object> taskStateDelta,
+        Map<String, Object> sessionStateDelta,
+        List<Map<String, Object>> memoryWriteIntents,
+        Map<String, Object> metrics) {
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/engine/spi/StatelessEngine.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/engine/spi/StatelessEngine.java
@@ -1,0 +1,43 @@
+package com.huawei.ascend.service.engine.spi;
+
+/**
+ * Stateless engine SPI per ADR-0100 (rc22) agent-service runtime-role decomposition.
+ *
+ * <p>Pure-function compute boundary: the engine receives the projected
+ * task metadata + injected context and returns a state delta. The engine
+ * MUST NOT hold persistent state; the Reactive Orchestrator owns the
+ * Read-Modify-Write closure.
+ *
+ * <p>Authority: ADR-0100. Wire contract:
+ * {@code docs/contracts/agent-invoke-request.v1.yaml} (status:
+ * design_only at rc22; runtime impl in rc24).
+ *
+ * <p>Coexistence with {@code com.huawei.ascend.engine.spi.ExecutorAdapter}:
+ * per ADR-0100, the relationship between {@code StatelessEngine} and the
+ * existing {@code ExecutorAdapter} is reconciled in rc23 (sibling SPIs
+ * vs single-interface decision documented in ADR-0100 §non_goals).
+ *
+ * <p>Yield + SuspendSignal coexistence (per ADR-0100):
+ * <ul>
+ *   <li>{@link com.huawei.ascend.engine.orchestration.spi.SuspendSignal}
+ *       (checked exception) remains canonical for state-machine
+ *       suspension.</li>
+ *   <li>{@code HookPoint.ON_YIELD} (added to engine-hooks.v1.yaml in
+ *       rc22) is the cooperative-scheduling hint when the engine asks
+ *       to be rescheduled without a state-machine transition.</li>
+ * </ul>
+ */
+public interface StatelessEngine {
+
+    /**
+     * Pure-function execution: compute a state delta from task metadata
+     * and the projected context. Engine MUST NOT mutate persistent
+     * state; the orchestrator merges the returned delta back into Run +
+     * Task + Session.
+     *
+     * @param request the AgentInvokeRequest carrying RunID + SessionContext
+     *                + InjectedSkills + task metadata.
+     * @return the StateDelta describing requested transitions + writes.
+     */
+    StateDelta execute(AgentInvokeRequest request);
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/engine/spi/package-info.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/engine/spi/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Stateless engine SPI per ADR-0100 (rc22).
+ *
+ * <p>Contains pure-function compute surface for the Execution Engine
+ * Adapter component (per ADR-0100 5-component decomposition of
+ * agent-service). The {@link com.huawei.ascend.service.engine.spi.StatelessEngine}
+ * interface is the contract; {@link com.huawei.ascend.service.engine.spi.AgentInvokeRequest}
+ * and {@link com.huawei.ascend.service.engine.spi.StateDelta} are the carrier records.
+ *
+ * <p>Wire contract:
+ * {@code docs/contracts/agent-invoke-request.v1.yaml} (status:
+ * design_only at rc22; reference impl in rc24).
+ *
+ * <p>SPI purity (Rule R-D): imports only {@code java.*} and own
+ * siblings. Concrete adapters land in
+ * {@code com.huawei.ascend.service.engine.adapter}.
+ */
+package com.huawei.ascend.service.engine.spi;

--- a/agent-service/src/main/java/com/huawei/ascend/service/orchestrator/package-info.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/orchestrator/package-info.java
@@ -1,0 +1,34 @@
+/**
+ * Reactive Orchestrator component per ADR-0100 (rc22).
+ *
+ * <p>Task tempo control, backpressure request handling, A2A protocol
+ * envelope packaging. Component #2 of the agent-service 5-component
+ * runtime-role decomposition.
+ *
+ * <p>Owns the Read-Modify-Write closure: invokes
+ * {@link com.huawei.ascend.service.engine.spi.StatelessEngine#execute(com.huawei.ascend.service.engine.spi.AgentInvokeRequest)}
+ * and merges the returned {@link com.huawei.ascend.service.engine.spi.StateDelta}
+ * back into Run + Task + Session state.
+ *
+ * <p>Implementation lands in rc23 + rc24:
+ * <ul>
+ *   <li>rc23: Java refactor moves orchestrator logic here from
+ *       {@code com.huawei.ascend.service.runtime.orchestration.inmemory}.</li>
+ *   <li>rc24: {@code Orchestrator.invoke(AgentInvokeRequest) → Mono<StateDelta>}
+ *       reactive wiring + BackpressureRequest channel consumer.</li>
+ * </ul>
+ *
+ * <p>Cross-package boundary (rc23 ArchUnit
+ * {@code AgentServiceComponentBoundaryArchTest}):
+ * orchestrator → may call engine.adapter, task, session.
+ * Reverse direction forbidden.
+ *
+ * <p>Yield + SuspendSignal coexistence (per ADR-0100):
+ * <ul>
+ *   <li>{@link com.huawei.ascend.engine.orchestration.spi.SuspendSignal}
+ *       checked-exception flow → state-machine suspension.</li>
+ *   <li>{@code HookPoint.ON_YIELD} hook → cooperative reschedule
+ *       without state-machine transition.</li>
+ * </ul>
+ */
+package com.huawei.ascend.service.orchestrator;

--- a/agent-service/src/main/java/com/huawei/ascend/service/session/spi/ContextProjector.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/session/spi/ContextProjector.java
@@ -1,0 +1,37 @@
+package com.huawei.ascend.service.session.spi;
+
+import java.util.Map;
+
+/**
+ * Session context projection SPI per ADR-0100 (rc22).
+ *
+ * <p>Projects a {@code SessionContext} view from full Session history
+ * via a configurable truncation / summarization policy. The Engine
+ * sees only what the projector exposed; it never reads full Session
+ * history directly.
+ *
+ * <p>Authority: ADR-0100 (Session Manager component). Reference impl
+ * ({@code InMemoryContextProjector}) lands in rc24 per ADR-0100
+ * implementation timeline.
+ *
+ * <p>SPI purity per Rule R-D: imports only {@code java.*} + own
+ * siblings.
+ */
+public interface ContextProjector {
+
+    /**
+     * Project a SessionContext from full Session history.
+     *
+     * <p>The {@code projectionPolicy} name (e.g., {@code "last_n"},
+     * {@code "summary_v1"}, {@code "hybrid_v1"}) is carried in the
+     * returned context so downstream observability can trace which
+     * strategy was applied.
+     *
+     * @param sessionId       the Session whose history to project.
+     * @param tenantId        mandatory per Rule R-C.c.
+     * @param projectionPolicy the named strategy to apply.
+     * @return the projected context as a map; carries
+     *         {@code messages}, {@code variables}, {@code projection_policy}.
+     */
+    Map<String, Object> project(String sessionId, String tenantId, String projectionPolicy);
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/session/spi/package-info.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/session/spi/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Session Manager SPI per ADR-0100 (rc22).
+ *
+ * <p>Contains the {@link com.huawei.ascend.service.session.spi.ContextProjector}
+ * interface for projecting SessionContext from full Session history.
+ *
+ * <p>The Session Manager component (per ADR-0100 5-component
+ * decomposition of agent-service) is responsible for middle/long-context
+ * data management; this SPI is the projection surface that compute
+ * nodes consume.
+ *
+ * <p>Reference impl ({@code InMemoryContextProjector}) lands in rc24
+ * per ADR-0100 implementation timeline.
+ *
+ * <p>SPI purity per Rule R-D: imports only {@code java.*} + own
+ * siblings.
+ */
+package com.huawei.ascend.service.session.spi;

--- a/agent-service/src/main/java/com/huawei/ascend/service/task/spi/TaskStateStore.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/task/spi/TaskStateStore.java
@@ -1,0 +1,44 @@
+package com.huawei.ascend.service.task.spi;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Task control-state persistence SPI per ADR-0100 (rc22).
+ *
+ * <p>The Task Center component (per ADR-0100 5-component decomposition
+ * of agent-service) is responsible for TaskControlState persistence.
+ * {@code Task} is the control-state layer in the Run ≤ Task ≤ Session ≤
+ * Memory lifecycle hierarchy.
+ *
+ * <p>TaskID and SessionID are logically decoupled: one Session may
+ * concurrently execute multiple Tasks; one Task may drift across
+ * multiple Sessions. See ADR-0100 §decision.
+ *
+ * <p>Reference impl ({@code InMemoryTaskStateStore}) lands in rc24;
+ * JDBC impl ({@code JdbcTaskStateStore}) + Flyway migration land in
+ * rc25 with RLS per Rule R-J.a.
+ *
+ * <p>SPI purity per Rule R-D: imports only {@code java.*} + own
+ * siblings.
+ */
+public interface TaskStateStore {
+
+    /**
+     * Persist or update a task's control state.
+     *
+     * @param taskId   the Task ID.
+     * @param tenantId mandatory per Rule R-C.c.
+     * @param state    control-state map (step_number, why_stopped, task_kind, a2a_state, ...).
+     */
+    void save(String taskId, String tenantId, Map<String, Object> state);
+
+    /**
+     * Load a task's current control state.
+     *
+     * @param taskId   the Task ID.
+     * @param tenantId mandatory per Rule R-C.c (must match owning tenant; return empty on mismatch).
+     * @return the control-state map, or empty if not found / cross-tenant.
+     */
+    Optional<Map<String, Object>> load(String taskId, String tenantId);
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/task/spi/package-info.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/task/spi/package-info.java
@@ -1,0 +1,17 @@
+/**
+ * Task Center SPI per ADR-0100 (rc22).
+ *
+ * <p>Contains the {@link com.huawei.ascend.service.task.spi.TaskStateStore}
+ * interface for TaskControlState persistence.
+ *
+ * <p>The Task Center component (per ADR-0100 5-component decomposition
+ * of agent-service) owns the control-state layer of the Run ≤ Task ≤
+ * Session ≤ Memory lifecycle hierarchy.
+ *
+ * <p>Reference impl ({@code InMemoryTaskStateStore}) lands in rc24;
+ * JDBC impl + Flyway migration with RLS per Rule R-J.a land in rc25.
+ *
+ * <p>SPI purity per Rule R-D: imports only {@code java.*} + own
+ * siblings.
+ */
+package com.huawei.ascend.service.task.spi;

--- a/docs/dfx/agent-service.yaml
+++ b/docs/dfx/agent-service.yaml
@@ -15,6 +15,9 @@ spi_packages:
   - com.huawei.ascend.service.runtime.memory.spi
   - com.huawei.ascend.service.runtime.resilience.spi   # promoted per ADR-0080 (rc5 review P1-2 closure, 2026-05-18)
   - com.huawei.ascend.service.runtime.runs.spi          # rc13: RunRepository ownership consolidated here per ADR-0088
+  - com.huawei.ascend.service.engine.spi                # rc23: StatelessEngine SPI per ADR-0100
+  - com.huawei.ascend.service.session.spi               # rc23: ContextProjector SPI per ADR-0100
+  - com.huawei.ascend.service.task.spi                  # rc23: TaskStateStore SPI per ADR-0100
 
 releasability:
   artifact_coords: "io.github.springai-ascend:agent-service"


### PR DESCRIPTION
Rebased onto main after #36 + #42 merged (old #38 auto-closed when base branch deleted). Lightweight scaffold per ADR-0100 5-component decomposition: 3 new SPI interfaces (StatelessEngine, ContextProjector, TaskStateStore) + 5 sub-package skeletons + module-metadata/DFX updates. No Java refactor of existing classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)