### PR TITLE
fix(rc31): orphan-paren Javadoc cleanup (4th-round review ADV4-1..3)

### DIFF
--- a/agent-service/src/main/java/com/huawei/ascend/service/engine/adapter/InMemoryStatelessEngine.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/engine/adapter/InMemoryStatelessEngine.java
@@ -37,10 +37,10 @@ public class InMemoryStatelessEngine implements StatelessEngine {
         // service.engine.adapter sub-package as adapters over
         // ExecutorAdapter (from agent-execution-engine).
         //
-        // use HashMap instead of Map.of(...). The runId is
-        // already non-null per the AgentInvokeRequest canonical constructor
-        //, but defence-in-depth: Map.of's null-value rejection would
-        // throw NPE if any future field added here is nullable.
+        // Use HashMap instead of Map.of(...). The runId is already non-null
+        // per the AgentInvokeRequest canonical constructor, but defence-in-
+        // depth: Map.of's null-value rejection would throw NPE if any future
+        // field added here is nullable.
         Map<String, Object> metrics = new HashMap<>();
         metrics.put("engine", "InMemoryStatelessEngine");
         metrics.put("request_id", request.runId());

--- a/agent-service/src/main/java/com/huawei/ascend/service/engine/spi/AgentInvokeRequest.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/engine/spi/AgentInvokeRequest.java
@@ -19,7 +19,7 @@ import java.util.Objects;
  * reference impl.
  *
  * @param runId           the Run this invocation belongs to.
- * @param taskId          the Task this Run materializes (decoupled from sessionId.
+ * @param taskId          the Task this Run materializes (decoupled from sessionId).
  * @param sessionId       the Session whose context this invocation reads.
  * @param tenantId        mandatory per Rule R-C.c.
  * @param sessionContext  projected SessionContext from ContextProjector SPI.

--- a/agent-service/src/main/java/com/huawei/ascend/service/runtime/resilience/spi/ResilienceContract.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/runtime/resilience/spi/ResilienceContract.java
@@ -9,7 +9,7 @@ package com.huawei.ascend.service.runtime.resilience.spi;
  *   ({@code @CircuitBreaker}, {@code @Retry}, {@code @TimeLimiter}) using the resolved policy names.
  *   Spring {@code @ConfigurationProperties} wiring is deferred to W2.</li>
  *   <li><b>Skill-capacity axis</b> ({@link #resolve(String, String)}, W1.x Phase 9+): tenant + skill
- *   admission.b). Consults
+ *   admission. Consults
  *   {@code docs/governance/skill-capacity.yaml} via {@link SkillCapacityRegistry}.</li>
  * </ul>
  *
@@ -50,6 +50,6 @@ public interface ResilienceContract {
     default SkillResolution resolve(String tenant, String skill) {
         throw new UnsupportedOperationException(
                 "Two-arg resolve(tenant, skill) requires DefaultSkillResilienceContract "
-                        + "(Rule R-K (legacy 41.b) activation.");
+                        + "(Rule R-K skill-capacity activation).");
     }
 }

--- a/agent-service/src/main/java/com/huawei/ascend/service/task/Task.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/task/Task.java
@@ -14,7 +14,7 @@ import java.util.Optional;
  *
  * <p>A2A protocol state vocabulary alignment per
  * {@code docs/contracts/a2a-envelope.v1.yaml} (contract-only adoption;
- * NO SDK runtime dep.
+ * NO SDK runtime dep).
  *
  * @param taskId     unique task identifier.
  * @param tenantId   mandatory per Rule R-C.c.

--- a/docs/governance/recurring-defect-families.yaml
+++ b/docs/governance/recurring-defect-families.yaml
@@ -38,7 +38,7 @@
 # freshness + E158 yaml/md family-id parity).
 
 schema_version: 1
-last_updated: 2026-05-21  # rc30 CI-corrective: sed delimiter fix + tree-block dir cleanup; rc29 corrective — table-row-only extractor + LCP prefix + Rule 44 fixed-string: F-l1-architecture-grounding-gap closed (real gate helpers shipped per ADR-0099). occurrences extended through rc22+rc27.
+last_updated: 2026-05-21  # rc31 orphan-paren cleanup; rc30 CI-corrective: sed delimiter fix + tree-block dir cleanup; rc29 corrective — table-row-only extractor + LCP prefix + Rule 44 fixed-string: F-l1-architecture-grounding-gap closed (real gate helpers shipped per ADR-0099). occurrences extended through rc22+rc27.
 
 families:
   - id: F-numeric-drift


### PR DESCRIPTION
Round-4 review found 3 orphan-paren defects from rc27's D-9 scrub. Plus 2 cosmetic Javadoc fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)