### PR TITLE
Bump GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Maven build + integration tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # rc18 Wave 1 / ADR-0095: full history required for Gate Rule 111
           # (architecture_refresh_defect_family_re_eval_required) freshness
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -69,7 +69,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: |
@@ -102,13 +102,13 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # rc18 Wave 1 / ADR-0095: full history required for Gate Rule 111
           # freshness check (see ci.yml comment above).
           fetch-depth: 0
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'

--- a/docs/governance/recurring-defect-families.yaml
+++ b/docs/governance/recurring-defect-families.yaml
@@ -122,7 +122,9 @@ families:
       "deleted-module scope" gate. Future refactors will still leak into
       new surfaces; Rule 110 META + Rule G-9 freshness gate are the
       structural backstops that catch the next family member before
-      reviewers do.
+      reviewers do. 2026-05-23 re-evaluation on the CI workflow bump to
+      Node 24 (actions/checkout@v6 + setup-java@v5 + upload-artifact@v7):
+      version-string change only, no deleted-module-name surface impact.
 
   - id: F-authority-surface-path-drift
     title: Authority-Surface Path Drift After Code Refactor


### PR DESCRIPTION
Clears the Node.js-20 deprecation warnings (Node 20 is forced off GitHub runners June 2026).

- `actions/checkout@v4` → `@v6`
- `actions/setup-java@v4` → `@v5`
- `actions/upload-artifact@v4` → `@v7`

All three latest majors run on **Node 24** (verified via `action.yml` `runs.using: node24`). Usage (`fetch-depth: 0`, `java-version`/`distribution`/`cache: maven`, `name`/`path`) is unchanged and backward-compatible.

Includes the Rule G-9 re-evaluation note on the `ci.yml` change (a `F-deleted-module-name-leakage` surface): version-string bump only, no deleted-module-name impact.

Verified: full parallel gate `GATE: PASS` (135/135), families validator wellformed + parity OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)