### PR TITLE
Narrow Rule G-9.b: exclude CI workflow files from refresh signals

### DIFF
--- a/docs/governance/recurring-defect-families.yaml
+++ b/docs/governance/recurring-defect-families.yaml
@@ -459,6 +459,13 @@ families:
       to next # Rule|# === boundary; helper regex widened to accept
       .bash/.py; bash -n added as CI step; Rule 114 negative fixture
       parameterised. Dead SURFACE_PREFIX_BASES removed.
+      2026-05-23 scope narrowing: derive_signal_paths now excludes
+      .github/workflows/ from the refresh-signal set (SIGNAL_PATH_EXCLUSION_PREFIXES).
+      ADV-RC18-3 over-derived CI workflow files as G-9.b signals, so routine
+      action-version bumps forced a families content-diff (false friction
+      neither the kernel nor the card ever mandated). Workflows remain a
+      deleted-module-name CONTENT surface (Rule G-2.1/94/98); they are simply
+      no longer architecture-refresh signals.
 
   - id: F-progressive-loading-weak-enforcement
     title: CLAUDE.md Kernel Loaded but Rules Don't Fire at Work Time

--- a/docs/governance/rules/rule-G-9.md
+++ b/docs/governance/rules/rule-G-9.md
@@ -78,6 +78,15 @@ An "architecture refresh signal" is any of:
 - Change in the `^#### Rule X` heading set in `CLAUDE.md`
 - Change in `docs/governance/rules/*.md` (new card, edited card)
 
+In addition, each family's declared `surfaces[]` are derived into the signal
+set (ADV-RC18-3), so a change to a watched surface re-triggers re-evaluation of
+that family. **Exception — CI workflow files (`.github/workflows/`) are excluded
+from the signal set** (`SIGNAL_PATH_EXCLUSION_PREFIXES`). Workflow YAML is
+infrastructure: it is watched for deleted-module-name *content* by Rule
+G-2.1 / 94 / 98, but a routine action-version or runner bump is not an
+architecture-refresh event and must not force a `recurring-defect-families.yaml`
+content-diff.
+
 If ANY refresh signal is present in `git log` since the last commit that
 modified `recurring-defect-families.yaml`, the implementation in
 `gate/lib/validate_recurring_families.py` resolves the signal-touching

--- a/gate/lib/validate_recurring_families.py
+++ b/gate/lib/validate_recurring_families.py
@@ -70,6 +70,17 @@ BASE_SIGNAL_PATHS = [
     "CLAUDE.md",
 ]
 
+# Path prefixes that family surfaces may legitimately name (so the deleted-
+# module-name gates Rule G-2.1 / 94 / 98 scan their CONTENT) but which are NOT
+# architecture-refresh signals for G-9.b. The kernel's refresh signals are new
+# ADR / baseline_metrics change / new release note / #### Rule heading change —
+# never CI runtime config. A CI workflow bump (action version, runner image,
+# step tweak) is infrastructure maintenance, not a defect-family event, so it
+# must not force a recurring-defect-families.yaml content-diff. derive_signal_paths
+# filters these out AFTER glob expansion so the surface still resolves (no spurious
+# "matched no files" WARN) but never enters the freshness signal set.
+SIGNAL_PATH_EXCLUSION_PREFIXES = (".github/workflows/",)
+
 
 def fail(msg: str) -> None:
     print(f"FAIL: {msg}")
@@ -351,7 +362,12 @@ def derive_signal_paths(yaml_data: dict, repo_root: str = ".") -> list[str]:
                     file=sys.stderr,
                 )
             paths.add(base)
-    return sorted(p for p in paths if p)
+    # Drop CI-runtime / infrastructure surfaces (e.g. .github/workflows/*.yml):
+    # watched for content by the deleted-name gates, but not G-9.b refresh signals.
+    return sorted(
+        p for p in paths
+        if p and not p.startswith(SIGNAL_PATH_EXCLUSION_PREFIXES)
+    )
 
 
 def cmd_freshness(yaml_path: str, repo_root: str = ".") -> int:


### PR DESCRIPTION
## Problem
`derive_signal_paths` over-derived `.github/workflows/*.yml` as a G-9.b architecture-refresh signal (it's a `surfaces[]` entry of `F-deleted-module-name-leakage`). So a routine GitHub-Actions version bump (#59) forced a `recurring-defect-families.yaml` content-diff — friction that neither the G-9 **kernel** nor the **card** ever mandated (their signals are ADR / `baseline_metrics` / release-note / `#### Rule` heading only).

## Fix
- `gate/lib/validate_recurring_families.py`: add `SIGNAL_PATH_EXCLUSION_PREFIXES = ('.github/workflows/',)`; `derive_signal_paths` filters these **after** glob expansion (the surface still resolves — no spurious `WARN` — but it never enters the freshness signal set). Workflows remain a deleted-module-name **content** surface scanned by Rule G-2.1 / 94 / 98.
- `rule-G-9.md`: document the surface-derivation behaviour and the workflow exclusion.
- `recurring-defect-families.yaml`: record the narrowing under `F-recursive-prevention-irony` (the family that owns the signal-derivation mechanism / ADV-RC18-3).

## Verification
- `derive_signal_paths` returns **no `.github/*`** paths, while retaining CLAUDE.md / docs/adr/ / Dockerfile / README.md / gate/lib/ signals.
- **Proven**: a throwaway ci.yml-only commit → freshness check `exit=0` (PASS) — a CI bump no longer trips G-9.b.
- Full parallel gate `GATE: PASS` (135/135); families validator wellformed + parity OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)