### PR TITLE
feat(taskflow): implement IEQ and TCC control loop

### DIFF
--- a/agent-service/src/main/java/com/huawei/ascend/service/engine/config/EngineAutoConfiguration.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/engine/config/EngineAutoConfiguration.java
@@ -1,8 +1,11 @@
 package com.huawei.ascend.service.engine.config;
 
+import com.huawei.ascend.service.engine.api.DefaultEngineDispatchApi;
+import com.huawei.ascend.service.engine.api.EngineDispatchApi;
 import com.huawei.ascend.service.engine.dispatch.AgentHandlerRegistry;
 import com.huawei.ascend.service.engine.dispatch.DefaultAgentHandlerRegistry;
 import com.huawei.ascend.service.engine.dispatch.EngineDispatcher;
+import com.huawei.ascend.service.engine.queue.EngineCommandEventFactory;
 import com.huawei.ascend.service.engine.queue.EngineCommandSubscriber;
 import com.huawei.ascend.service.engine.queue.InMemoryEngineQueueGateway;
 import com.huawei.ascend.service.engine.spi.AccessLayerClient;
@@ -37,6 +40,19 @@ public class EngineAutoConfiguration {
     @ConditionalOnMissingBean
     public EngineQueueGateway engineQueueGateway() {
         return new InMemoryEngineQueueGateway();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public EngineCommandEventFactory engineCommandEventFactory() {
+        return new EngineCommandEventFactory();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public EngineDispatchApi engineDispatchApi(EngineCommandEventFactory commandEventFactory,
+                                               EngineQueueGateway engineQueueGateway) {
+        return new DefaultEngineDispatchApi(commandEventFactory, engineQueueGateway);
     }
 
     @Bean

--- a/agent-service/src/main/java/com/huawei/ascend/service/taskflow/README.md
+++ b/agent-service/src/main/java/com/huawei/ascend/service/taskflow/README.md
@@ -1,0 +1,222 @@
+# Agent Service Taskflow 实现说明
+
+本文说明当前 Internal Event Queue（IEQ）与 Task-Centric Control（TCC）
+的代码实现、用户流程、边界和验证方式。完整设计背景见：
+
+- `architecture/docs/L1/agent-service/2026-05-30-agent-service-l3-l4-task-queue-control-architecture-proposal.cn.md`
+- `architecture/docs/L1/agent-service/2026-05-30-agent-service-l3-l4-task-queue-control-implementation-spec.cn.md`
+
+## 1. 本版实现了什么
+
+本版从“接口冻结”推进到“本地可运行闭环”：
+
+1. IEQ 提供一个薄队列抽象：`TaskQueue<T>`。
+2. IEQ 当前本地实现为 `InMemoryTaskQueue<T>`，底层使用 JDK
+   `LinkedBlockingQueue`。
+3. `QueueFactory` 仍是静态工厂类，不是 SPI，也不是可被外部替换的
+   provider 接口。
+4. `QueueManager` 是弱管理对象：记录队列注册、按 `queueId` 查询、按
+   `tenantId + sessionId` 查询、注销队列；它不强制所有调用方必须通过
+   manager 创建队列。
+5. TCC 的主实现是 `TaskControlService`，负责创建 Task、选择当前 Task、
+   执行状态流转、处理幂等键和 revision fencing。
+6. `TaskControlClient` 是内部 API，不是 SPI。Access 侧只调用
+   `runTask(RunTaskCommand)`；runtime adapter 只调用 `mark*` 状态入口。
+7. `EngineTaskControlAdapter` 把 engine 侧的任务状态回调转成
+   `TaskControlService.mark*`，避免 runtime/engine 直接读写 IEQ。
+8. Spring 自动配置通过 `TaskflowAutoConfiguration` 创建
+   `QueueManager`、`TaskControlService` 和 `EngineTaskControlAdapter`。
+
+## 2. 代码结构
+
+```text
+agent-service/src/main/java/com/huawei/ascend/service/taskflow/
+  config/
+    TaskflowAutoConfiguration.java
+
+  queue/
+    TaskQueue.java
+    InMemoryTaskQueue.java
+    QueueFactory.java
+    QueueManager.java
+    QueueRegistration.java
+
+  control/
+    Task.java
+    TaskState.java
+    TaskFailureCode.java
+    WaitingReason.java
+    TaskControlService.java
+    EngineTaskControlAdapter.java
+    api/
+      TaskControlClient.java
+
+agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/
+  TaskBeanWhiteboxTest.java
+  InMemoryTaskQueueWhiteboxTest.java
+  TaskControlClientApiWhiteboxTest.java
+  QueueManagerWhiteboxTest.java
+  TaskControlServiceWhiteboxTest.java
+  TaskflowEngineBridgeWhiteboxTest.java
+```
+
+## 3. 关键接口和类
+
+### 3.1 IEQ
+
+`TaskQueue<T>` 只定义队列能力：
+
+- `queueId()`
+- `offer(T value)`
+- `poll()`
+- `peek()`
+- `find(Predicate<? super T> matcher)`
+- `snapshot()`
+- `size()`
+
+队列不关心队列内容物类型，也不理解 Task 状态。当前实现虽然会存放
+`Task` 对象，但这是 TCC 的使用方式，不是 IEQ 的语义。
+
+`QueueManager` 管理队列注册关系：
+
+- `register(TaskQueue<T>, QueueRegistration)`
+- `findByQueueId(String)`
+- `findBySession(String tenantId, String sessionId)`
+- `registration(String queueId)`
+- `registrations()`
+- `unregister(String queueId)`
+
+`QueueRegistration` 记录队列归属、创建方和创建时间。Session 队列的默认
+`queueId` 由 `QueueRegistration.sessionQueueId(tenantId, sessionId)` 生成。
+
+### 3.2 TCC
+
+`TaskControlClient` 是 TCC 对外暴露的内部 API：
+
+- `runTask(RunTaskCommand command)`
+- `markRunning(MarkTaskCommand command)`
+- `markWaiting(MarkTaskCommand command)`
+- `markSucceeded(MarkTaskCommand command)`
+- `markFailed(MarkTaskCommand command)`
+- `markCancelled(MarkTaskCommand command)`
+
+Access 侧只应该使用 `runTask`。`RUN`、`RESUME_INPUT`、`CANCEL` 通过
+`TaskAction` 表达，避免把 TaskHandler 拆成多个入口。
+
+Runtime/engine 侧不直接操作 IEQ，也不直接改 Task 字段；它通过
+`EngineTaskControlAdapter` 进入 `mark*`，由 TCC 裁决状态转换是否合法。
+
+## 4. 用户流程如何串起来
+
+### 4.1 系统启动
+
+1. Spring 创建 `QueueManager`。
+2. Spring 创建 `TaskControlService`，并注入 `QueueManager` 与
+   `EngineDispatchApi` 的延迟提供者。
+3. Spring 创建 `EngineTaskControlAdapter`，作为 engine 侧状态回写到 TCC 的
+   adapter。
+4. Engine 自动配置创建 `EngineDispatchApi`。TCC 通过该 API 把执行请求入到
+   engine/runtime 侧。
+
+### 4.2 首次用户输入
+
+1. Access/Session 层拿到或创建 `sessionId`。
+2. Access 把 `tenantId`、`sessionId`、`agentId`、用户输入组装成
+   `RunTaskCommand(action=RUN)`。
+3. `TaskControlService.runTask` 根据 `tenantId + sessionId` 从
+   `QueueManager` 找 session 队列。
+4. 如果 session 队列不存在，TCC 通过 `QueueFactory.inMemorySessionQueue`
+   创建队列，并注册到 `QueueManager`。
+5. 如果当前 session 没有可挂接 Task，TCC 创建一个 `Task`，初始状态为
+   `CREATED`，并写入 session 队列。
+6. TCC 构造 `EngineExecutionScope` 与 `EngineInput`，调用
+   `EngineDispatchApi.enqueueExecution`。
+
+### 4.3 Runtime 等待用户补充
+
+1. Runtime/engine 侧产生等待用户输入的信号。
+2. `EngineTaskControlAdapter` 把该信号转换成
+   `TaskControlService.markWaiting`。
+3. TCC 校验 `expectedRevision`，通过后把 Task 更新为 `WAITING`，并记录
+   `WaitingReason.USER_INPUT`、detail 和 revision。
+4. 面向用户的输出仍由 runtime/access 的同步返回路径处理；IEQ 不承担输出流。
+
+### 4.4 用户补充输入
+
+1. Access 再次调用 `runTask`，这次使用 `TaskAction.RESUME_INPUT`。
+2. TCC 用 `tenantId + sessionId` 找到 session 队列。
+3. 如果没有显式 `taskId`，TCC 选择最新的 `WAITING` Task。
+4. TCC 调用 `EngineDispatchApi.enqueueResume`，把输入继续交给 runtime。
+5. Runtime 继续通过 `EngineTaskControlAdapter` 回写 `markRunning`、
+   `markSucceeded`、`markFailed` 或 `markCancelled`。
+
+### 4.5 取消任务
+
+1. Access 调用 `runTask`，使用 `TaskAction.CANCEL`，并携带 `taskId`。
+2. TCC 把 Task 状态改为 `CANCELLING`。
+3. TCC 调用 `EngineDispatchApi.enqueueCancel`。
+4. Runtime 确认取消后，经 `EngineTaskControlAdapter` 调用
+   `markCancelled`，TCC 将 Task 置为 `CANCELLED`。
+
+## 5. 当前特性
+
+| 特性 | 对应代码 | 说明 |
+|---|---|---|
+| 本地 IEQ | `TaskQueue`、`InMemoryTaskQueue` | 薄队列，只处理对象顺序和读取。 |
+| 队列弱管理 | `QueueManager`、`QueueRegistration` | 记录队列归属和索引，不提供对外 admin port。 |
+| Session 队列创建 | `QueueFactory.inMemorySessionQueue` | 创建时同步注册到 `QueueManager`。 |
+| Task Bean | `Task` | Java Bean，包含状态、revision、detail、时间戳。 |
+| 单入口任务 API | `TaskControlClient.runTask` | Access 侧统一从这里进入。 |
+| 状态回写 API | `TaskControlClient.mark*` | Runtime adapter 回写状态意图。 |
+| 当前 Task 选择 | `TaskControlService.findCurrentTask` | 按 `updatedAt` 再按 `taskId` 选择最新可挂接 Task。 |
+| 幂等 | `RunTaskCommand.idempotencyKey` | 相同 key 返回已记录结果。 |
+| fencing | `MarkTaskCommand.expectedRevision` | 防止旧 runtime 信号覆盖新状态。 |
+| Engine 桥接 | `EngineTaskControlAdapter` | 对齐 engine 回调接口，转换等待原因和失败码。 |
+| 白盒测试 | `taskflow/test/*WhiteboxTest` | 覆盖 Bean、队列、manager、TCC、engine bridge。 |
+
+## 6. 设计边界
+
+这些边界是当前实现需要保持的职责分离：
+
+1. IEQ 不理解 Task 状态；队列只管理对象顺序、读取和快照。
+2. Runtime/engine 不直接读写 IEQ，状态变化必须经 adapter 进入 TCC。
+3. Access 不需要知道 `queueId`，只透传 `tenantId`、`sessionId`、
+   `agentId` 和用户输入。
+4. `QueueManager` 是弱管理对象，不作为对外 admin port 暴露。
+
+## 7. 后续 TODO
+
+1. 接入 Access / Session 的端到端流程：Session 创建时绑定 session 队列，
+   Access 侧统一调用 `runTask`。
+2. 明确 OOD / `NOT_CURRENT_TASK` 后是否立即由 TCC 创建新 Task 的策略，并补
+   对应白盒测试。
+3. 评估是否需要独立 Task 索引或持久化 TaskStore，避免未来持久化后端依赖
+   全量队列扫描。
+4. 增加 Redis/JDBC/Kafka 等持久化 IEQ 后端，同时保持 `TaskQueue` API
+   不变。
+5. 补充分布式后端的 at-least-once / exactly-once、幂等和 fencing 说明。
+
+## 8. 最小验证
+
+推荐先跑 taskflow 白盒测试：
+
+```bash
+./mvnw -pl agent-service -am \
+  -Dtest=TaskBeanWhiteboxTest,InMemoryTaskQueueWhiteboxTest,TaskControlClientApiWhiteboxTest,QueueManagerWhiteboxTest,TaskControlServiceWhiteboxTest,TaskflowEngineBridgeWhiteboxTest \
+  -Dsurefire.failIfNoSpecifiedTests=false \
+  -Pquality -B -ntp test
+```
+
+提交前再跑 agent-service 质量验证：
+
+```bash
+./mvnw -pl agent-service -am -Pquality -B -ntp verify
+```
+
+当前白盒验证结果：
+
+```text
+Taskflow targeted white-box tests: passed
+Tests run: 19, Failures: 0, Errors: 0
+agent-service -Pquality verify: passed
+```

--- a/agent-service/src/main/java/com/huawei/ascend/service/taskflow/config/TaskflowAutoConfiguration.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/taskflow/config/TaskflowAutoConfiguration.java
@@ -1,0 +1,33 @@
+package com.huawei.ascend.service.taskflow.config;
+
+import com.huawei.ascend.service.engine.api.EngineDispatchApi;
+import com.huawei.ascend.service.taskflow.control.EngineTaskControlAdapter;
+import com.huawei.ascend.service.taskflow.control.TaskControlService;
+import com.huawei.ascend.service.taskflow.queue.QueueManager;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class TaskflowAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public QueueManager taskflowQueueManager() {
+        return new QueueManager();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(com.huawei.ascend.service.taskflow.control.api.TaskControlClient.class)
+    public TaskControlService taskControlService(QueueManager queueManager,
+                                                 ObjectProvider<EngineDispatchApi> engineDispatchApi) {
+        return new TaskControlService(queueManager, engineDispatchApi::getIfAvailable, java.time.Clock.systemUTC());
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(com.huawei.ascend.service.engine.spi.TaskControlClient.class)
+    public EngineTaskControlAdapter engineTaskControlAdapter(TaskControlService taskControlService) {
+        return new EngineTaskControlAdapter(taskControlService);
+    }
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/taskflow/control/EngineTaskControlAdapter.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/taskflow/control/EngineTaskControlAdapter.java
@@ -1,0 +1,87 @@
+package com.huawei.ascend.service.taskflow.control;
+
+import com.huawei.ascend.service.engine.event.EngineCancelledEvent;
+import com.huawei.ascend.service.engine.event.EngineCompletedEvent;
+import com.huawei.ascend.service.engine.event.EngineFailedEvent;
+import com.huawei.ascend.service.engine.event.EngineInterruptedEvent;
+import com.huawei.ascend.service.engine.model.EngineExecutionScope;
+import com.huawei.ascend.service.engine.model.InterruptType;
+import com.huawei.ascend.service.taskflow.control.api.TaskControlClient.MarkTaskCommand;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class EngineTaskControlAdapter implements com.huawei.ascend.service.engine.spi.TaskControlClient {
+
+    private final TaskControlService taskControlService;
+
+    public EngineTaskControlAdapter(TaskControlService taskControlService) {
+        this.taskControlService = Objects.requireNonNull(taskControlService, "taskControlService");
+    }
+
+    @Override
+    public void markRunning(EngineExecutionScope scope) {
+        taskControlService.markRunning(command(scope, null, null, null, Map.of())).toCompletableFuture().join();
+    }
+
+    @Override
+    public void markWaiting(EngineExecutionScope scope, EngineInterruptedEvent event) {
+        taskControlService.markWaiting(command(scope, waitingReason(event), null, event, Map.of())).toCompletableFuture().join();
+    }
+
+    @Override
+    public void markSucceeded(EngineExecutionScope scope, EngineCompletedEvent event) {
+        taskControlService.markSucceeded(command(scope, null, null, event, Map.of())).toCompletableFuture().join();
+    }
+
+    @Override
+    public void markFailed(EngineExecutionScope scope, EngineFailedEvent event) {
+        taskControlService.markFailed(command(scope, null, failureCode(event), event, Map.of())).toCompletableFuture().join();
+    }
+
+    @Override
+    public void markCancelled(EngineExecutionScope scope, EngineCancelledEvent event) {
+        taskControlService.markCancelled(command(scope, null, TaskFailureCode.CANCELLED_BY_RUNTIME, event, Map.of()))
+                .toCompletableFuture().join();
+    }
+
+    @Override
+    public EngineExecutionScope createChildTask(EngineExecutionScope parentScope, String targetAgentId, String input) {
+        return taskControlService.createChildTask(parentScope, targetAgentId, input);
+    }
+
+    private MarkTaskCommand command(EngineExecutionScope scope, WaitingReason waitingReason,
+                                    TaskFailureCode failureCode, Object detail, Map<String, Object> metadata) {
+        Task task = taskControlService.findTask(scope.tenantId(), scope.sessionId(), scope.taskId())
+                .orElseThrow(() -> new IllegalArgumentException("task not found: " + scope.taskId()));
+        return new MarkTaskCommand(scope.tenantId(), scope.sessionId(), scope.taskId(), task.getRevision(),
+                waitingReason, failureCode, detail, metadata);
+    }
+
+    private WaitingReason waitingReason(EngineInterruptedEvent event) {
+        if (event == null || event.getInterruptType() == null) {
+            return WaitingReason.USER_INPUT;
+        }
+        InterruptType type = event.getInterruptType();
+        return switch (type) {
+            case HUMAN_INPUT -> WaitingReason.USER_INPUT;
+            case APPROVAL -> WaitingReason.USER_CONFIRMATION;
+            case WAITING_CHILD_AGENT -> WaitingReason.DEPENDENCY;
+        };
+    }
+
+    private TaskFailureCode failureCode(EngineFailedEvent event) {
+        if (event == null || event.getErrorCode() == null || event.getErrorCode().isBlank()) {
+            return TaskFailureCode.RUNTIME_ERROR;
+        }
+        String normalized = event.getErrorCode().trim().toUpperCase();
+        return switch (normalized) {
+            case "AGENT_ID_INVALID" -> TaskFailureCode.AGENT_ID_INVALID;
+            case "OUT_OF_DOMAIN" -> TaskFailureCode.OUT_OF_DOMAIN;
+            case "NOT_CURRENT_TASK" -> TaskFailureCode.NOT_CURRENT_TASK;
+            case "ENGINE_DISPATCH_REJECTED" -> TaskFailureCode.ENGINE_DISPATCH_REJECTED;
+            case "CANCELLED_BY_RUNTIME" -> TaskFailureCode.CANCELLED_BY_RUNTIME;
+            default -> TaskFailureCode.RUNTIME_ERROR;
+        };
+    }
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/taskflow/control/TaskControlService.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/taskflow/control/TaskControlService.java
@@ -1,0 +1,353 @@
+package com.huawei.ascend.service.taskflow.control;
+
+import com.huawei.ascend.service.engine.api.EngineDispatchApi;
+import com.huawei.ascend.service.engine.api.EnqueueEngineCancelRequest;
+import com.huawei.ascend.service.engine.api.EnqueueEngineExecutionRequest;
+import com.huawei.ascend.service.engine.api.EnqueueEngineResumeRequest;
+import com.huawei.ascend.service.engine.api.EnqueueEngineStatus;
+import com.huawei.ascend.service.engine.model.EngineExecutionScope;
+import com.huawei.ascend.service.engine.model.EngineInput;
+import com.huawei.ascend.service.engine.model.EngineMessage;
+import com.huawei.ascend.service.taskflow.control.api.TaskControlClient;
+import com.huawei.ascend.service.taskflow.queue.QueueFactory;
+import com.huawei.ascend.service.taskflow.queue.QueueManager;
+import com.huawei.ascend.service.taskflow.queue.TaskQueue;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
+
+public class TaskControlService implements TaskControlClient {
+
+    private final QueueManager queueManager;
+    private final Supplier<EngineDispatchApi> engineDispatchApi;
+    private final Clock clock;
+    private final ConcurrentMap<SessionKey, Object> sessionLocks = new ConcurrentHashMap<>();
+    private final ConcurrentMap<IdempotencyKey, TaskResult> idempotencyResults = new ConcurrentHashMap<>();
+    private final Object queueCreationLock = new Object();
+
+    public TaskControlService(QueueManager queueManager, EngineDispatchApi engineDispatchApi) {
+        this(queueManager, () -> engineDispatchApi, Clock.systemUTC());
+    }
+
+    public TaskControlService(QueueManager queueManager, EngineDispatchApi engineDispatchApi, Clock clock) {
+        this(queueManager, () -> engineDispatchApi, clock);
+    }
+
+    public TaskControlService(QueueManager queueManager, Supplier<EngineDispatchApi> engineDispatchApi, Clock clock) {
+        this.queueManager = Objects.requireNonNull(queueManager, "queueManager");
+        this.engineDispatchApi = Objects.requireNonNull(engineDispatchApi, "engineDispatchApi");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    @Override
+    public CompletionStage<TaskResult> runTask(RunTaskCommand command) {
+        Objects.requireNonNull(command, "command");
+        TaskResult result = idempotencyKey(command)
+                .map(key -> idempotencyResults.computeIfAbsent(key, ignored -> doRunTask(command)))
+                .orElseGet(() -> doRunTask(command));
+        return CompletableFuture.completedStage(result);
+    }
+
+    @Override
+    public CompletionStage<TaskResult> markRunning(MarkTaskCommand command) {
+        return CompletableFuture.completedStage(mark(command, TaskState.RUNNING,
+                null, null, command.detail(), "marked running"));
+    }
+
+    @Override
+    public CompletionStage<TaskResult> markWaiting(MarkTaskCommand command) {
+        WaitingReason reason = Objects.requireNonNull(command.waitingReason(), "waitingReason");
+        return CompletableFuture.completedStage(mark(command, TaskState.WAITING,
+                reason, null, command.detail(), "marked waiting"));
+    }
+
+    @Override
+    public CompletionStage<TaskResult> markSucceeded(MarkTaskCommand command) {
+        return CompletableFuture.completedStage(mark(command, TaskState.COMPLETED,
+                null, null, command.detail(), "marked succeeded"));
+    }
+
+    @Override
+    public CompletionStage<TaskResult> markFailed(MarkTaskCommand command) {
+        TaskFailureCode code = command.failureCode() == null ? TaskFailureCode.RUNTIME_ERROR : command.failureCode();
+        return CompletableFuture.completedStage(mark(command, TaskState.FAILED,
+                null, code, command.detail(), "marked failed"));
+    }
+
+    @Override
+    public CompletionStage<TaskResult> markCancelled(MarkTaskCommand command) {
+        TaskFailureCode code = command.failureCode() == null
+                ? TaskFailureCode.CANCELLED_BY_RUNTIME
+                : command.failureCode();
+        return CompletableFuture.completedStage(mark(command, TaskState.CANCELLED,
+                null, code, command.detail(), "marked cancelled"));
+    }
+
+    public Optional<Task> findTask(String tenantId, String sessionId, String taskId) {
+        return taskQueue(tenantId, sessionId).find(task -> taskId.equals(task.getTaskId()));
+    }
+
+    public Optional<Task> findCurrentTask(String tenantId, String sessionId) {
+        return latest(taskQueue(tenantId, sessionId).snapshot().stream()
+                .filter(this::attachable));
+    }
+
+    public List<Task> tasks(String tenantId, String sessionId) {
+        return taskQueue(tenantId, sessionId).snapshot();
+    }
+
+    public EngineExecutionScope createChildTask(EngineExecutionScope parentScope, String targetAgentId, Object input) {
+        Objects.requireNonNull(parentScope, "parentScope");
+        String tenantId = requireNonBlank(parentScope.tenantId(), "tenantId");
+        String sessionId = requireNonBlank(parentScope.sessionId(), "sessionId");
+        String agentId = requireNonBlank(targetAgentId, "targetAgentId");
+        Task task;
+        synchronized (sessionLock(tenantId, sessionId)) {
+            task = Task.created(tenantId, sessionId, agentId, clock.instant());
+            task.setDetail(input);
+            taskQueue(tenantId, sessionId).offer(task);
+        }
+        return scopeFor(task, userId(parentScope.userId()));
+    }
+
+    private TaskResult doRunTask(RunTaskCommand command) {
+        return switch (command.action()) {
+            case RUN -> runOrCreate(command, false);
+            case RESUME_INPUT -> runOrCreate(command, true);
+            case CANCEL -> cancel(command);
+        };
+    }
+
+    private TaskResult runOrCreate(RunTaskCommand command, boolean resumeOnly) {
+        Task task;
+        boolean resume;
+        synchronized (sessionLock(command.tenantId(), command.sessionId())) {
+            Optional<Task> selected = selectTarget(command, resumeOnly);
+            if (selected.isEmpty() && resumeOnly) {
+                task = createTask(command);
+                resume = false;
+            } else {
+                task = selected.orElseGet(() -> createTask(command));
+                resume = command.action() == TaskAction.RESUME_INPUT && task.getState() == TaskState.WAITING;
+            }
+        }
+        return dispatch(task, command, resume);
+    }
+
+    private TaskResult cancel(RunTaskCommand command) {
+        Task task;
+        synchronized (sessionLock(command.tenantId(), command.sessionId())) {
+            task = findTask(command.tenantId(), command.sessionId(), command.taskId())
+                    .orElseThrow(() -> new IllegalArgumentException("task not found: " + command.taskId()));
+            if (task.terminal()) {
+                return result(task, false, "terminal task cannot be cancelled");
+            }
+            if (task.getState() != TaskState.CANCELLING) {
+                task.transitionTo(TaskState.CANCELLING, null, null, command.reason(), clock.instant());
+            }
+        }
+        EnqueueEngineStatus status = engineDispatchApi().enqueueCancel(
+                new EnqueueEngineCancelRequest(scopeFor(task, userId(command))));
+        if (status == EnqueueEngineStatus.FAILED) {
+            return failDispatch(task, TaskFailureCode.ENGINE_DISPATCH_REJECTED, "engine rejected cancel");
+        }
+        return currentResult(task, true, "cancel enqueued");
+    }
+
+    private TaskResult dispatch(Task task, RunTaskCommand command, boolean resume) {
+        EnqueueEngineStatus status;
+        try {
+            EngineExecutionScope scope = scopeFor(task, userId(command));
+            EngineInput input = engineInput(command.input(), resume ? "RESUME_SIGNAL" : "USER_MESSAGE");
+            status = resume
+                    ? engineDispatchApi().enqueueResume(new EnqueueEngineResumeRequest(scope, input))
+                    : engineDispatchApi().enqueueExecution(new EnqueueEngineExecutionRequest(scope, input));
+        } catch (RuntimeException e) {
+            TaskFailureCode code = task.getAgentId() == null || task.getAgentId().isBlank()
+                    ? TaskFailureCode.AGENT_ID_INVALID
+                    : TaskFailureCode.ENGINE_DISPATCH_REJECTED;
+            return failDispatch(task, code, e.getMessage());
+        }
+        if (status == EnqueueEngineStatus.FAILED) {
+            return failDispatch(task, TaskFailureCode.ENGINE_DISPATCH_REJECTED, "engine rejected dispatch");
+        }
+        return currentResult(task, true, resume ? "resume enqueued" : "execution enqueued");
+    }
+
+    private TaskResult failDispatch(Task task, TaskFailureCode code, Object detail) {
+        synchronized (sessionLock(task.getTenantId(), task.getSessionId())) {
+            if (!task.terminal()) {
+                task.transitionTo(TaskState.FAILED, null, code, detail, clock.instant());
+            }
+            return result(task, false, "engine dispatch failed");
+        }
+    }
+
+    private TaskResult mark(MarkTaskCommand command, TaskState nextState, WaitingReason waitingReason,
+                            TaskFailureCode failureCode, Object detail, String message) {
+        synchronized (sessionLock(command.tenantId(), command.sessionId())) {
+            Task task = findTask(command.tenantId(), command.sessionId(), command.taskId())
+                    .orElseThrow(() -> new IllegalArgumentException("task not found: " + command.taskId()));
+            if (task.getRevision() != command.expectedRevision()) {
+                return result(task, false, "stale task revision");
+            }
+            if (!allowed(task.getState(), nextState)) {
+                return result(task, false, "transition rejected");
+            }
+            if (task.getState() != nextState || waitingReason != task.getWaitingReason()
+                    || failureCode != task.getFailureCode() || detail != task.getDetail()) {
+                task.transitionTo(nextState, waitingReason, failureCode, detail, clock.instant());
+            }
+            return result(task, true, message);
+        }
+    }
+
+    private Optional<Task> selectTarget(RunTaskCommand command, boolean resumeOnly) {
+        if (command.taskId() != null && !command.taskId().isBlank()) {
+            return findTask(command.tenantId(), command.sessionId(), command.taskId())
+                    .filter(task -> resumeOnly ? task.getState() == TaskState.WAITING : attachable(task));
+        }
+        if (resumeOnly) {
+            return latest(taskQueue(command.tenantId(), command.sessionId()).snapshot().stream()
+                    .filter(task -> task.getState() == TaskState.WAITING));
+        }
+        return findCurrentTask(command.tenantId(), command.sessionId());
+    }
+
+    private Task createTask(RunTaskCommand command) {
+        Task task = Task.created(command.tenantId(), command.sessionId(), command.agentId(), clock.instant());
+        task.setDetail(command.input());
+        taskQueue(command.tenantId(), command.sessionId()).offer(task);
+        return task;
+    }
+
+    private boolean attachable(Task task) {
+        return !task.terminal() && task.getState() != TaskState.CANCELLING;
+    }
+
+    private Optional<Task> latest(java.util.stream.Stream<Task> tasks) {
+        return tasks.max(Comparator.comparing(Task::getUpdatedAt).thenComparing(Task::getTaskId));
+    }
+
+    private boolean allowed(TaskState current, TaskState next) {
+        if (current == next) {
+            return true;
+        }
+        if (current.isTerminal()) {
+            return false;
+        }
+        return switch (current) {
+            case CREATED -> next == TaskState.RUNNING || next == TaskState.CANCELLING || next == TaskState.FAILED;
+            case RUNNING -> next == TaskState.WAITING || next == TaskState.COMPLETED
+                    || next == TaskState.FAILED || next == TaskState.CANCELLING || next == TaskState.CANCELLED;
+            case WAITING -> next == TaskState.RUNNING || next == TaskState.FAILED
+                    || next == TaskState.CANCELLING || next == TaskState.CANCELLED;
+            case PAUSED -> next == TaskState.RUNNING || next == TaskState.FAILED || next == TaskState.CANCELLING;
+            case CANCELLING -> next == TaskState.CANCELLED || next == TaskState.FAILED;
+            case COMPLETED, FAILED, CANCELLED -> false;
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private TaskQueue<Task> taskQueue(String tenantId, String sessionId) {
+        Optional<TaskQueue<?>> existing = queueManager.findBySession(tenantId, sessionId);
+        if (existing.isPresent()) {
+            return (TaskQueue<Task>) existing.get();
+        }
+        synchronized (queueCreationLock) {
+            return (TaskQueue<Task>) queueManager.findBySession(tenantId, sessionId)
+                    .orElseGet(() -> QueueFactory.inMemorySessionQueue(tenantId, sessionId, queueManager));
+        }
+    }
+
+    private Object sessionLock(String tenantId, String sessionId) {
+        return sessionLocks.computeIfAbsent(new SessionKey(tenantId, sessionId), ignored -> new Object());
+    }
+
+    private EngineExecutionScope scopeFor(Task task, String userId) {
+        return new EngineExecutionScope(task.getTenantId(), userId, task.getSessionId(),
+                task.getTaskId(), task.getAgentId() == null ? "" : task.getAgentId());
+    }
+
+    private EngineDispatchApi engineDispatchApi() {
+        EngineDispatchApi api = engineDispatchApi.get();
+        if (api == null) {
+            throw new IllegalStateException("engine dispatch api is not available");
+        }
+        return api;
+    }
+
+    private String userId(RunTaskCommand command) {
+        Object userId = command.metadata().get("userId");
+        return userId == null ? null : userId.toString();
+    }
+
+    private String userId(String value) {
+        return value == null || value.isBlank() ? null : value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private EngineInput engineInput(Object input, String inputType) {
+        if (input instanceof EngineInput engineInput) {
+            return engineInput;
+        }
+        if (input instanceof Map<?, ?> map) {
+            return new EngineInput(inputType, List.of(), Map.copyOf((Map<String, Object>) map));
+        }
+        return new EngineInput(inputType,
+                List.of(new EngineMessage("user", input == null ? "" : input.toString())),
+                Map.of());
+    }
+
+    private TaskResult currentResult(Task task, boolean accepted, String message) {
+        synchronized (sessionLock(task.getTenantId(), task.getSessionId())) {
+            return result(task, accepted, message);
+        }
+    }
+
+    private TaskResult result(Task task, boolean accepted, String message) {
+        return new TaskResult(task.getTenantId(), task.getSessionId(), task.getTaskId(),
+                task.getState(), task.getRevision(), accepted, message);
+    }
+
+    private Optional<IdempotencyKey> idempotencyKey(RunTaskCommand command) {
+        if (command.idempotencyKey() == null || command.idempotencyKey().isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.of(new IdempotencyKey(command.tenantId(), command.sessionId(),
+                command.taskId(), command.action(), command.idempotencyKey()));
+    }
+
+    private static String requireNonBlank(String value, String name) {
+        Objects.requireNonNull(value, name);
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+
+    private record SessionKey(String tenantId, String sessionId) {
+        private SessionKey {
+            tenantId = requireNonBlank(tenantId, "tenantId");
+            sessionId = requireNonBlank(sessionId, "sessionId");
+        }
+    }
+
+    private record IdempotencyKey(
+            String tenantId,
+            String sessionId,
+            String taskId,
+            TaskAction action,
+            String idempotencyKey) {
+    }
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/taskflow/queue/InMemoryTaskQueue.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/taskflow/queue/InMemoryTaskQueue.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Predicate;
 
 /**
  * Current in-memory TaskQueue implementation backed by JDK primitives.
@@ -39,6 +40,12 @@ public final class InMemoryTaskQueue<T> implements TaskQueue<T> {
     @Override
     public Optional<T> peek() {
         return Optional.ofNullable(delegate.peek());
+    }
+
+    @Override
+    public Optional<T> find(Predicate<? super T> matcher) {
+        Objects.requireNonNull(matcher, "matcher");
+        return delegate.stream().filter(matcher).findFirst();
     }
 
     @Override

--- a/agent-service/src/main/java/com/huawei/ascend/service/taskflow/queue/QueueFactory.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/taskflow/queue/QueueFactory.java
@@ -15,4 +15,20 @@ public final class QueueFactory {
     public static <T> TaskQueue<T> inMemoryQueue(String queueId) {
         return new InMemoryTaskQueue<>(queueId);
     }
+
+    public static <T> TaskQueue<T> inMemoryQueue(
+            String queueId,
+            QueueManager manager,
+            QueueRegistration registration) {
+        TaskQueue<T> queue = inMemoryQueue(queueId);
+        return manager.register(queue, registration);
+    }
+
+    public static <T> TaskQueue<T> inMemorySessionQueue(
+            String tenantId,
+            String sessionId,
+            QueueManager manager) {
+        QueueRegistration registration = QueueRegistration.session(tenantId, sessionId);
+        return inMemoryQueue(registration.queueId(), manager, registration);
+    }
 }

--- a/agent-service/src/main/java/com/huawei/ascend/service/taskflow/queue/QueueManager.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/taskflow/queue/QueueManager.java
@@ -1,0 +1,80 @@
+package com.huawei.ascend.service.taskflow.queue;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class QueueManager {
+
+    private final ConcurrentMap<String, TaskQueue<?>> queuesById = new ConcurrentHashMap<>();
+    private final ConcurrentMap<SessionKey, String> queueIdsBySession = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, QueueRegistration> registrations = new ConcurrentHashMap<>();
+
+    public <T> TaskQueue<T> register(TaskQueue<T> queue, QueueRegistration registration) {
+        Objects.requireNonNull(queue, "queue");
+        Objects.requireNonNull(registration, "registration");
+        if (!queue.queueId().equals(registration.queueId())) {
+            throw new IllegalArgumentException("queueId mismatch");
+        }
+        TaskQueue<?> existing = queuesById.putIfAbsent(queue.queueId(), queue);
+        if (existing != null && existing != queue) {
+            throw new IllegalStateException("queue already registered: " + queue.queueId());
+        }
+        SessionKey sessionKey = new SessionKey(registration.tenantId(), registration.sessionId());
+        String existingQueueId = queueIdsBySession.putIfAbsent(sessionKey, queue.queueId());
+        if (existingQueueId != null && !existingQueueId.equals(queue.queueId())) {
+            throw new IllegalStateException("session already has queue: " + registration.sessionId());
+        }
+        registrations.putIfAbsent(queue.queueId(), registration);
+        return queue;
+    }
+
+    public Optional<TaskQueue<?>> findByQueueId(String queueId) {
+        Objects.requireNonNull(queueId, "queueId");
+        return Optional.ofNullable(queuesById.get(queueId));
+    }
+
+    public Optional<TaskQueue<?>> findBySession(String tenantId, String sessionId) {
+        String queueId = queueIdsBySession.get(new SessionKey(tenantId, sessionId));
+        return queueId == null ? Optional.empty() : findByQueueId(queueId);
+    }
+
+    public Optional<QueueRegistration> registration(String queueId) {
+        Objects.requireNonNull(queueId, "queueId");
+        return Optional.ofNullable(registrations.get(queueId));
+    }
+
+    public List<QueueRegistration> registrations() {
+        return registrations.values().stream()
+                .sorted(Comparator.comparing(QueueRegistration::createdAt)
+                        .thenComparing(QueueRegistration::queueId))
+                .toList();
+    }
+
+    public void unregister(String queueId) {
+        Objects.requireNonNull(queueId, "queueId");
+        QueueRegistration registration = registrations.remove(queueId);
+        queuesById.remove(queueId);
+        if (registration != null) {
+            queueIdsBySession.remove(new SessionKey(registration.tenantId(), registration.sessionId()), queueId);
+        }
+    }
+
+    private record SessionKey(String tenantId, String sessionId) {
+        private SessionKey {
+            tenantId = requireNonBlank(tenantId, "tenantId");
+            sessionId = requireNonBlank(sessionId, "sessionId");
+        }
+    }
+
+    private static String requireNonBlank(String value, String name) {
+        Objects.requireNonNull(value, name);
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/taskflow/queue/QueueRegistration.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/taskflow/queue/QueueRegistration.java
@@ -1,0 +1,37 @@
+package com.huawei.ascend.service.taskflow.queue;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record QueueRegistration(
+        String queueId,
+        String tenantId,
+        String sessionId,
+        String owner,
+        Instant createdAt) {
+
+    public QueueRegistration {
+        queueId = requireNonBlank(queueId, "queueId");
+        tenantId = requireNonBlank(tenantId, "tenantId");
+        sessionId = requireNonBlank(sessionId, "sessionId");
+        owner = requireNonBlank(owner, "owner");
+        createdAt = Objects.requireNonNull(createdAt, "createdAt");
+    }
+
+    public static QueueRegistration session(String tenantId, String sessionId) {
+        return new QueueRegistration(sessionQueueId(tenantId, sessionId),
+                tenantId, sessionId, "session", Instant.now());
+    }
+
+    public static String sessionQueueId(String tenantId, String sessionId) {
+        return requireNonBlank(tenantId, "tenantId") + ":" + requireNonBlank(sessionId, "sessionId");
+    }
+
+    private static String requireNonBlank(String value, String name) {
+        Objects.requireNonNull(value, name);
+        if (value.isBlank()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value;
+    }
+}

--- a/agent-service/src/main/java/com/huawei/ascend/service/taskflow/queue/TaskQueue.java
+++ b/agent-service/src/main/java/com/huawei/ascend/service/taskflow/queue/TaskQueue.java
@@ -2,6 +2,7 @@ package com.huawei.ascend.service.taskflow.queue;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 /**
  * Internal Event Queue (IEQ) boundary.
@@ -19,6 +20,8 @@ public interface TaskQueue<T> {
     Optional<T> poll();
 
     Optional<T> peek();
+
+    Optional<T> find(Predicate<? super T> matcher);
 
     List<T> snapshot();
 

--- a/agent-service/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/agent-service/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,1 +1,2 @@
+com.huawei.ascend.service.taskflow.config.TaskflowAutoConfiguration
 com.huawei.ascend.service.engine.config.EngineAutoConfiguration

--- a/agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/QueueManagerWhiteboxTest.java
+++ b/agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/QueueManagerWhiteboxTest.java
@@ -1,0 +1,49 @@
+package com.huawei.ascend.service.taskflow.test;
+
+import com.huawei.ascend.service.taskflow.queue.QueueFactory;
+import com.huawei.ascend.service.taskflow.queue.QueueManager;
+import com.huawei.ascend.service.taskflow.queue.QueueRegistration;
+import com.huawei.ascend.service.taskflow.queue.TaskQueue;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class QueueManagerWhiteboxTest {
+
+    @Test
+    void factoryCanRegisterSessionQueueWithManager() {
+        QueueManager manager = new QueueManager();
+
+        TaskQueue<Object> queue = QueueFactory.inMemorySessionQueue("tenant", "session", manager);
+
+        assertThat(manager.findBySession("tenant", "session")).containsSame(queue);
+        assertThat(manager.registration(queue.queueId()))
+                .map(QueueRegistration::sessionId)
+                .contains("session");
+        assertThat(manager.registrations()).hasSize(1);
+    }
+
+    @Test
+    void unregisterRemovesQueueAndSessionLookup() {
+        QueueManager manager = new QueueManager();
+        TaskQueue<Object> queue = QueueFactory.inMemorySessionQueue("tenant", "session", manager);
+
+        manager.unregister(queue.queueId());
+
+        assertThat(manager.findByQueueId(queue.queueId())).isEmpty();
+        assertThat(manager.findBySession("tenant", "session")).isEmpty();
+        assertThat(manager.registrations()).isEmpty();
+    }
+
+    @Test
+    void duplicateQueueIdIsRejected() {
+        QueueManager manager = new QueueManager();
+        QueueRegistration registration = QueueRegistration.session("tenant", "session");
+        QueueFactory.inMemoryQueue(registration.queueId(), manager, registration);
+
+        assertThatThrownBy(() -> QueueFactory.inMemoryQueue(registration.queueId(), manager, registration))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("queue already registered");
+    }
+}

--- a/agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/TaskControlServiceWhiteboxTest.java
+++ b/agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/TaskControlServiceWhiteboxTest.java
@@ -1,0 +1,170 @@
+package com.huawei.ascend.service.taskflow.test;
+
+import com.huawei.ascend.service.engine.api.EngineDispatchApi;
+import com.huawei.ascend.service.engine.api.EnqueueEngineCancelRequest;
+import com.huawei.ascend.service.engine.api.EnqueueEngineExecutionRequest;
+import com.huawei.ascend.service.engine.api.EnqueueEngineResumeRequest;
+import com.huawei.ascend.service.engine.api.EnqueueEngineStatus;
+import com.huawei.ascend.service.taskflow.control.Task;
+import com.huawei.ascend.service.taskflow.control.TaskControlService;
+import com.huawei.ascend.service.taskflow.control.TaskFailureCode;
+import com.huawei.ascend.service.taskflow.control.TaskState;
+import com.huawei.ascend.service.taskflow.control.WaitingReason;
+import com.huawei.ascend.service.taskflow.control.api.TaskControlClient;
+import com.huawei.ascend.service.taskflow.queue.QueueManager;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaskControlServiceWhiteboxTest {
+
+    private final RecordingEngineDispatchApi engine = new RecordingEngineDispatchApi();
+    private final QueueManager queueManager = new QueueManager();
+    private final TaskControlService service = new TaskControlService(
+            queueManager,
+            engine,
+            Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC));
+
+    @Test
+    void runTaskCreatesSessionQueueAndDispatchesExecution() {
+        TaskControlClient.TaskResult result = run(TaskControlClient.TaskAction.RUN, null, "agent", "hello", "idem-1");
+
+        assertThat(result.accepted()).isTrue();
+        assertThat(result.state()).isEqualTo(TaskState.CREATED);
+        assertThat(queueManager.findBySession("tenant", "session")).isPresent();
+        assertThat(engine.executions).hasSize(1);
+        assertThat(engine.executions.get(0).scope().sessionId()).isEqualTo("session");
+        assertThat(engine.executions.get(0).scope().agentId()).isEqualTo("agent");
+        assertThat(service.tasks("tenant", "session")).hasSize(1);
+    }
+
+    @Test
+    void markMethodsEnforceRevisionAndTransitionOrder() {
+        TaskControlClient.TaskResult created = run(TaskControlClient.TaskAction.RUN, null, "agent", "hello", null);
+
+        TaskControlClient.TaskResult running = service.markRunning(mark(created.taskId(), 1L, null, null, null))
+                .toCompletableFuture().join();
+        TaskControlClient.TaskResult stale = service.markWaiting(mark(created.taskId(), 1L,
+                        WaitingReason.USER_INPUT, null, "need-city"))
+                .toCompletableFuture().join();
+        TaskControlClient.TaskResult waiting = service.markWaiting(mark(created.taskId(), 2L,
+                        WaitingReason.USER_INPUT, null, "need-city"))
+                .toCompletableFuture().join();
+        TaskControlClient.TaskResult rerunning = service.markRunning(mark(created.taskId(), 3L, null, null, null))
+                .toCompletableFuture().join();
+        TaskControlClient.TaskResult done = service.markSucceeded(mark(created.taskId(), 4L, null, null, "done"))
+                .toCompletableFuture().join();
+
+        assertThat(running.state()).isEqualTo(TaskState.RUNNING);
+        assertThat(stale.accepted()).isFalse();
+        assertThat(stale.revision()).isEqualTo(2L);
+        assertThat(waiting.state()).isEqualTo(TaskState.WAITING);
+        assertThat(rerunning.state()).isEqualTo(TaskState.RUNNING);
+        assertThat(done.state()).isEqualTo(TaskState.COMPLETED);
+        assertThat(done.revision()).isEqualTo(5L);
+    }
+
+    @Test
+    void resumeInputTargetsWaitingTaskAndCancelMakesNextRunCreateNewTask() {
+        TaskControlClient.TaskResult created = run(TaskControlClient.TaskAction.RUN, null, "agent", "hello", null);
+        service.markRunning(mark(created.taskId(), 1L, null, null, null)).toCompletableFuture().join();
+        service.markWaiting(mark(created.taskId(), 2L, WaitingReason.USER_INPUT, null, "need-city"))
+                .toCompletableFuture().join();
+
+        TaskControlClient.TaskResult resumed = run(TaskControlClient.TaskAction.RESUME_INPUT, null, "agent", "beijing", null);
+        TaskControlClient.TaskResult cancelling = run(TaskControlClient.TaskAction.CANCEL,
+                resumed.taskId(), "agent", null, null);
+        TaskControlClient.TaskResult next = run(TaskControlClient.TaskAction.RUN, null, "agent", "new intent", null);
+
+        assertThat(engine.resumes).hasSize(1);
+        assertThat(resumed.taskId()).isEqualTo(created.taskId());
+        assertThat(cancelling.state()).isEqualTo(TaskState.CANCELLING);
+        assertThat(engine.cancels).hasSize(1);
+        assertThat(next.taskId()).isNotEqualTo(created.taskId());
+        assertThat(service.tasks("tenant", "session")).hasSize(2);
+    }
+
+    @Test
+    void idempotencyKeyReturnsSameTaskResultWithoutSecondDispatch() {
+        TaskControlClient.TaskResult first = run(TaskControlClient.TaskAction.RUN, null, "agent", "hello", "same-key");
+        TaskControlClient.TaskResult second = run(TaskControlClient.TaskAction.RUN, null, "agent", "hello", "same-key");
+
+        assertThat(second).isEqualTo(first);
+        assertThat(engine.executions).hasSize(1);
+        assertThat(service.tasks("tenant", "session")).hasSize(1);
+    }
+
+    @Test
+    void rejectedEngineDispatchMarksTaskFailed() {
+        engine.status = EnqueueEngineStatus.FAILED;
+
+        TaskControlClient.TaskResult result = run(TaskControlClient.TaskAction.RUN, null, "agent", "hello", null);
+        Task task = service.findTask("tenant", "session", result.taskId()).orElseThrow();
+
+        assertThat(result.accepted()).isFalse();
+        assertThat(result.state()).isEqualTo(TaskState.FAILED);
+        assertThat(task.getFailureCode()).isEqualTo(TaskFailureCode.ENGINE_DISPATCH_REJECTED);
+    }
+
+    private TaskControlClient.TaskResult run(TaskControlClient.TaskAction action, String taskId,
+                                             String agentId, Object input, String idempotencyKey) {
+        return service.runTask(new TaskControlClient.RunTaskCommand(
+                "tenant",
+                "session",
+                taskId,
+                agentId,
+                action,
+                input,
+                "reason",
+                idempotencyKey,
+                Map.of("userId", "user")))
+                .toCompletableFuture().join();
+    }
+
+    private TaskControlClient.MarkTaskCommand mark(String taskId, long expectedRevision,
+                                                   WaitingReason waitingReason,
+                                                   TaskFailureCode failureCode,
+                                                   Object detail) {
+        return new TaskControlClient.MarkTaskCommand(
+                "tenant",
+                "session",
+                taskId,
+                expectedRevision,
+                waitingReason,
+                failureCode,
+                detail,
+                Map.of());
+    }
+
+    private static final class RecordingEngineDispatchApi implements EngineDispatchApi {
+        private final List<EnqueueEngineExecutionRequest> executions = new ArrayList<>();
+        private final List<EnqueueEngineResumeRequest> resumes = new ArrayList<>();
+        private final List<EnqueueEngineCancelRequest> cancels = new ArrayList<>();
+        private EnqueueEngineStatus status = EnqueueEngineStatus.SUCCESS;
+
+        @Override
+        public EnqueueEngineStatus enqueueExecution(EnqueueEngineExecutionRequest request) {
+            executions.add(request);
+            return status;
+        }
+
+        @Override
+        public EnqueueEngineStatus enqueueResume(EnqueueEngineResumeRequest request) {
+            resumes.add(request);
+            return status;
+        }
+
+        @Override
+        public EnqueueEngineStatus enqueueCancel(EnqueueEngineCancelRequest request) {
+            cancels.add(request);
+            return status;
+        }
+    }
+}

--- a/agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/TaskflowEngineBridgeWhiteboxTest.java
+++ b/agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/TaskflowEngineBridgeWhiteboxTest.java
@@ -1,0 +1,78 @@
+package com.huawei.ascend.service.taskflow.test;
+
+import com.huawei.ascend.service.engine.api.DefaultEngineDispatchApi;
+import com.huawei.ascend.service.engine.api.EngineDispatchApi;
+import com.huawei.ascend.service.engine.dispatch.AgentHandlerRegistry;
+import com.huawei.ascend.service.engine.dispatch.DefaultAgentHandlerRegistry;
+import com.huawei.ascend.service.engine.dispatch.EngineDispatcher;
+import com.huawei.ascend.service.engine.queue.EngineCommandEventFactory;
+import com.huawei.ascend.service.engine.queue.EngineCommandSubscriber;
+import com.huawei.ascend.service.engine.queue.InMemoryEngineQueueGateway;
+import com.huawei.ascend.service.engine.support.FakeInterruptingAgentHandler;
+import com.huawei.ascend.service.engine.support.RecordingAccessLayerClient;
+import com.huawei.ascend.service.taskflow.control.EngineTaskControlAdapter;
+import com.huawei.ascend.service.taskflow.control.TaskControlService;
+import com.huawei.ascend.service.taskflow.control.TaskState;
+import com.huawei.ascend.service.taskflow.control.WaitingReason;
+import com.huawei.ascend.service.taskflow.control.api.TaskControlClient;
+import com.huawei.ascend.service.taskflow.queue.QueueManager;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaskflowEngineBridgeWhiteboxTest {
+
+    @Test
+    void executeWaitingResumeCompletionLoopUpdatesTccStateWithoutEngineOwningQueue() {
+        QueueManager manager = new QueueManager();
+        InMemoryEngineQueueGateway engineQueue = new InMemoryEngineQueueGateway();
+        EngineDispatchApi dispatchApi = new DefaultEngineDispatchApi(new EngineCommandEventFactory(), engineQueue);
+        TaskControlService tcc = new TaskControlService(
+                manager,
+                dispatchApi,
+                Clock.fixed(Instant.parse("2026-06-01T00:00:00Z"), ZoneOffset.UTC));
+        EngineTaskControlAdapter adapter = new EngineTaskControlAdapter(tcc);
+        RecordingAccessLayerClient access = new RecordingAccessLayerClient();
+        AgentHandlerRegistry registry = new DefaultAgentHandlerRegistry();
+        registry.register("echo-agent", new FakeInterruptingAgentHandler("echo-agent"));
+        new EngineCommandSubscriber(engineQueue, new EngineDispatcher(registry, adapter, access)).start();
+
+        TaskControlClient.TaskResult waiting = tcc.runTask(command(
+                        TaskControlClient.TaskAction.RUN, null, "hello"))
+                .toCompletableFuture().join();
+
+        assertThat(waiting.state()).isEqualTo(TaskState.WAITING);
+        assertThat(tcc.findTask("tenant", "session", waiting.taskId()).orElseThrow().getWaitingReason())
+                .isEqualTo(WaitingReason.USER_INPUT);
+
+        TaskControlClient.TaskResult completed = tcc.runTask(command(
+                        TaskControlClient.TaskAction.RESUME_INPUT, null, "yes"))
+                .toCompletableFuture().join();
+
+        assertThat(completed.taskId()).isEqualTo(waiting.taskId());
+        assertThat(completed.state()).isEqualTo(TaskState.COMPLETED);
+        assertThat(access.signals)
+                .containsExactly("REQUEST_INPUT:" + waiting.taskId(),
+                        "APPEND:" + waiting.taskId(),
+                        "COMPLETE:" + waiting.taskId());
+        assertThat(manager.findBySession("tenant", "session")).isPresent();
+    }
+
+    private TaskControlClient.RunTaskCommand command(TaskControlClient.TaskAction action, String taskId, String input) {
+        return new TaskControlClient.RunTaskCommand(
+                "tenant",
+                "session",
+                taskId,
+                "echo-agent",
+                action,
+                input,
+                null,
+                null,
+                Map.of("userId", "user"));
+    }
+}

--- a/architecture/docs/L1/agent-service/2026-05-30-agent-service-l3-l4-task-queue-control-architecture-proposal.cn.md
+++ b/architecture/docs/L1/agent-service/2026-05-30-agent-service-l3-l4-task-queue-control-architecture-proposal.cn.md
@@ -9,7 +9,9 @@ authoring_mode: architecture_proposal
 
 # Agent Service L3/L4 Taskflow Queue/Control 架构提议
 
-本文收敛 2026-05-30 至 2026-06-01 的架构讨论，并同步 PR #102 当前实现。核心目标是先冻结 L3/L4 的最小接口面，避免提前把 Runtime、QueueManager、TaskStore 等后续实现铺得过重。
+本文收敛 2026-05-30 至 2026-06-01 的架构讨论，并同步当前 taskflow 实现。代码旁审阅入口见 `agent-service/src/main/java/com/huawei/ascend/service/taskflow/README.md`。
+
+当前目标已经从“冻结最小接口面”推进到“本地可运行闭环”：IEQ 提供薄队列与弱管理，TCC 维护 Task 状态并通过 engine dispatch API 交付执行意图，runtime/engine 状态回写经 adapter 进入 TCC 裁决。
 
 ## 0. 结论
 
@@ -20,9 +22,9 @@ authoring_mode: architecture_proposal
 5. `RUN`、`RESUME_INPUT`、`CANCEL` 通过 `TaskAction` 枚举表达，不拆成多个 `TaskHandler` 方法。
 6. `QueueFactory` 在 W1 是静态工厂类，不是 interface。
 7. W1 Queue 使用 JDK `LinkedBlockingQueue` 实现内存 FIFO。
-8. `QueueManager` 采用弱管理方向，但不进入 W1 必须代码。
+8. `QueueManager` 采用弱管理方向，当前已进入实现：记录队列注册、归属、查询和注销，不提供对外 admin port。
 9. Runtime 不持有 Queue，不定义 `RuntimeQueueGateway`，不直接发布或消费 Queue。
-10. Runtime 状态意图通过 adapter 调用 L4 `TaskControlClient.mark*`。
+10. Runtime 状态意图通过 `EngineTaskControlAdapter` 调用 L4 `TaskControlClient.mark*`。
 11. Runtime 面向用户的主输出当前按同步返回路径进入 Access。
 12. Task 信号在 L1-L4 内闭环：L1 归一输入，L2 只提供会话绑定，L3 只承载对象，L4 解释信号并维护 Task 状态。
 13. `queued` 是处理过程，不是 Task 主状态。
@@ -32,8 +34,28 @@ authoring_mode: architecture_proposal
 一句话版本：
 
 ```text
-L1 用 runTask 提交意图，L3 提供薄 Queue，L4 维护 Task 状态，Runtime 只通过 adapter 回写 mark* 状态意图。
+L1 用 runTask 提交意图，IEQ 提供薄 Queue 和弱管理，TCC 维护 Task 状态，runtime/engine 只通过 adapter 回写 mark* 状态意图。
 ```
+
+## 0.1 本版实现增量
+
+1. 新增代码旁说明：`agent-service/src/main/java/com/huawei/ascend/service/taskflow/README.md`。
+2. IEQ 侧实现 `TaskQueue<T>`、`InMemoryTaskQueue<T>`、`QueueFactory`、`QueueManager`、`QueueRegistration`。
+3. TCC 侧实现 `TaskControlService`：创建 Task、查找当前 Task、处理 `RUN` / `RESUME_INPUT` / `CANCEL`、执行状态流转、处理幂等键和 revision fencing。
+4. Runtime/engine 桥接实现 `EngineTaskControlAdapter`：把 engine 回调映射到 TCC `markRunning`、`markWaiting`、`markSucceeded`、`markFailed`、`markCancelled`。
+5. 自动配置实现 `TaskflowAutoConfiguration`，并在 engine 自动配置中补齐 `EngineDispatchApi`。
+6. 白盒测试覆盖 Bean、队列、QueueManager、TCC 服务和 engine bridge。
+
+## 0.2 与用户流程的关系
+
+1. 系统启动时，Spring 创建 `QueueManager`、`TaskControlService`、`EngineTaskControlAdapter` 和 `EngineDispatchApi`。
+2. 首次用户输入时，Access/Session 取得 `sessionId` 后调用 `TaskControlClient.runTask(action=RUN)`。
+3. TCC 根据 `tenantId + sessionId` 从 `QueueManager` 查找 session 队列；没有则通过 `QueueFactory.inMemorySessionQueue` 创建并注册。
+4. TCC 在 session 队列内创建或选择 Task，然后通过 `EngineDispatchApi.enqueueExecution` 交给 runtime/engine。
+5. Runtime/engine 需要等待用户时，经 `EngineTaskControlAdapter` 回写 `markWaiting`，TCC 把 Task 置为 `WAITING`。
+6. 用户补充输入时，Access 再调用 `runTask(action=RESUME_INPUT)`，TCC 默认选择最新 `WAITING` Task 并调用 `enqueueResume`。
+7. 用户取消时，Access 调用 `runTask(action=CANCEL)`，TCC 先置为 `CANCELLING`，再调用 `enqueueCancel`，最终由 adapter 回写 `markCancelled`。
+8. Runtime/engine 面向用户的输出仍走同步返回到 Access 的链路；IEQ 不承担输出流。
 
 ## 1. 与旧设计的冲突解决
 
@@ -41,7 +63,7 @@ L1 用 runTask 提交意图，L3 提供薄 Queue，L4 维护 Task 状态，Runti
 |---|---|
 | Session 是否包含 Task | 不包含。Session 是会话窗口，不是任务聚合。 |
 | Queue 是否持有 Task 状态 | 不持有。Queue 只管理对象顺序和读取，不解释对象。 |
-| 是否需要三轨 Queue | 暂不需要。当前只冻结一个薄 Queue API；通道语义由调用方和后续 manager/policy 处理。 |
+| 是否需要三轨 Queue | 暂不需要。当前只保留薄 Queue API；通道语义由 TCC 和后续策略处理。 |
 | Runtime 是否消费 Queue | 不消费。Runtime 不拿 Queue，也不发布 Queue 对象。 |
 | 是否需要 `RuntimeQueueGateway` | 不需要。Runtime 细节先回到 L4，由 L4 决定是否写 Queue。 |
 | `TaskHandler` 是否需要多个方法 | W1 不需要。统一 `runTask + TaskAction`。 |
@@ -66,8 +88,8 @@ sequenceDiagram
     Access->>Session: getOrCreateSession(sessionId?)
     Session-->>Access: sessionId
     Access->>TCC: runTask(RunTaskCommand)
-    TCC->>Queue: optional offer(Object)
-    TCC->>Runtime: future dispatch boundary
+    TCC->>Queue: find or create session Task
+    TCC->>Runtime: enqueueExecution / enqueueResume / enqueueCancel
     Runtime-->>Access: sync user output
     Runtime-->>TCC: markRunning / markWaiting / markSucceeded / markFailed / markCancelled
     TCC->>Queue: optional offer(Task detail/event as Object)
@@ -76,7 +98,7 @@ sequenceDiagram
 说明：
 
 - Access 不需要知道 `queueId`。
-- Controller/Control 后续通过 `sessionId` 和内部绑定找到 Queue。
+- TCC 通过 `sessionId` 和 `QueueManager` 找到 session 队列。
 - Runtime 同步返回用户输出，同时通过 adapter 回写状态意图。
 - Queue 只看到 `Object`，不知道对象是否代表 Task、上下文或诊断信息。
 
@@ -134,12 +156,16 @@ agent-service/src/main/java/com/huawei/ascend/service/taskflow/
     TaskQueue.java
     InMemoryTaskQueue.java
     QueueFactory.java
+    QueueManager.java
+    QueueRegistration.java
 
   control/
     Task.java
     TaskState.java
     TaskFailureCode.java
     WaitingReason.java
+    TaskControlService.java
+    EngineTaskControlAdapter.java
     api/
       TaskControlClient.java
 
@@ -147,6 +173,9 @@ agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/
   TaskBeanWhiteboxTest.java
   InMemoryTaskQueueWhiteboxTest.java
   TaskControlClientApiWhiteboxTest.java
+  QueueManagerWhiteboxTest.java
+  TaskControlServiceWhiteboxTest.java
+  TaskflowEngineBridgeWhiteboxTest.java
 ```
 
 开发约束：
@@ -155,7 +184,7 @@ agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/
 2. `control/api/TaskControlClient` 是内部 API，不是 SPI。
 3. 当前不新增 `spi/` 包。
 4. Runtime adapter 不放进 `queue/`。
-5. 后续若接入 PR #100 的 Runtime/Engine 设计，由 Runtime 侧 adapter 转接，L3 Queue 不感知。
+5. 当前通过 `EngineTaskControlAdapter` 对接 Runtime/Engine 状态回写，IEQ 不感知。
 
 ### 2.4 进程视图
 
@@ -202,17 +231,24 @@ flowchart TB
         Tests["White-box tests"]
     end
 
+    subgraph CurrentControl["当前 TCC"]
+        Manager["QueueManager 弱管理"]
+        Service["TaskControlService / revision fencing"]
+        Adapter["EngineTaskControlAdapter"]
+    end
+
     subgraph Future["后续 Wave"]
-        Manager["Weak QueueManager"]
-        Store["TaskStore / CAS"]
+        Store["Task index / durable store"]
         DistQueue["Redis/JDBC/Kafka Queue"]
-        Adapter["Runtime adapter"]
     end
 
     JVM --> Q
     Q --> JDK
     Tests --> Q
-    Future -.does not change W1 API.-> JVM
+    JVM --> Manager
+    JVM --> Service
+    JVM --> Adapter
+    Future -.保持 TaskQueue API 不变.-> JVM
 ```
 
 ## 3. 接口定义
@@ -225,6 +261,7 @@ public interface TaskQueue<T> {
     boolean offer(T value);
     Optional<T> poll();
     Optional<T> peek();
+    Optional<T> find(Predicate<? super T> matcher);
     List<T> snapshot();
     int size();
 }
@@ -240,10 +277,34 @@ public final class QueueFactory {
     public static <T> TaskQueue<T> inMemoryQueue(String queueId) {
         return new InMemoryTaskQueue<>(queueId);
     }
+
+    public static <T> TaskQueue<T> inMemoryQueue(
+            String queueId, QueueManager manager, QueueRegistration registration) {
+        return manager.register(new InMemoryTaskQueue<>(queueId), registration);
+    }
+
+    public static TaskQueue<Task> inMemorySessionQueue(
+            String tenantId, String sessionId, QueueManager manager) {
+        QueueRegistration registration = QueueRegistration.session(tenantId, sessionId);
+        return inMemoryQueue(registration.queueId(), manager, registration);
+    }
 }
 ```
 
-### 3.3 TaskControlClient
+### 3.3 QueueManager
+
+```java
+public class QueueManager {
+    public <T> TaskQueue<T> register(TaskQueue<T> queue, QueueRegistration registration);
+    public Optional<TaskQueue<?>> findByQueueId(String queueId);
+    public Optional<TaskQueue<?>> findBySession(String tenantId, String sessionId);
+    public Optional<QueueRegistration> registration(String queueId);
+    public List<QueueRegistration> registrations();
+    public void unregister(String queueId);
+}
+```
+
+### 3.4 TaskControlClient
 
 ```java
 public interface TaskControlClient {
@@ -316,8 +377,8 @@ CANCELLED
 | Queue backend | 新增实现类，例如 Redis/JDBC/Kafka Queue。 | 修改 `TaskControlClient` 或让 Queue 理解 Task。 |
 | Task 动作 | 优先扩展 `TaskAction`。 | 给 `TaskHandler` 继续加多个入口方法。 |
 | Runtime 接入 | Runtime 侧 adapter 调用 `TaskControlClient.mark*`。 | Runtime 直接持有 Queue 或写 Task 字段。 |
-| Queue 管理 | 后续新增弱管理 `QueueManager`。 | 把 admin port 挂到 `TaskQueue` 主接口。 |
-| Task 存储 | 后续新增 `TaskStore`。 | 在 Queue 里扫描对象来判断当前 Task。 |
+| Queue 管理 | 当前实现弱管理 `QueueManager`。 | 把 admin port 挂到 `TaskQueue` 主接口。 |
+| Task 查询 | 当前由 TCC 基于 session 队列查找；后续可增加索引。 | 让 IEQ 理解 Task 状态。 |
 
 ### 5.2 依赖倒置
 
@@ -340,7 +401,7 @@ Runtime adapter -> L4 TaskControlClient.mark*
 
 ## 6. QueueManager 裁决
 
-当前结论：采用弱管理方向，但不进入 W1 必须代码。
+当前结论：采用弱管理方向，并已实现 `QueueManager`。
 
 弱管理含义：
 
@@ -350,12 +411,12 @@ Runtime adapter -> L4 TaskControlClient.mark*
 4. Manager 不要求普通调用方拿 admin port。
 5. Manager 不理解 Task 状态。
 
-后续实现建议：
+当前实现：
 
 ```text
-QueueFactory.create -> notify QueueManager.onCreated
-QueueFactory.destroy -> notify QueueManager.onDeleted
-QueueManager -> list/query/audit/listener registry
+QueueFactory.inMemorySessionQueue -> QueueManager.register
+QueueManager.findBySession -> locate session queue
+QueueManager.unregister -> remove queue registration
 ```
 
 ## 7. Runtime 边界
@@ -392,14 +453,14 @@ sequenceDiagram
     Session-->>Access: sessionId
     Access->>TCC: runTask(action=RUN, sessionId, agentId, input)
     TCC->>TCC: create Task(CREATED)
-    TCC->>Runtime: future dispatch
-    TCC->>TCC: markRunning
+    TCC->>Runtime: enqueueExecution
+    Runtime-->>TCC: markRunning
     Runtime-->>Access: sync output
     Runtime-->>TCC: markWaiting(USER_INPUT)
     Access->>TCC: runTask(action=RESUME_INPUT, sessionId, input)
-    TCC->>Runtime: future dispatch with existing task
+    TCC->>Runtime: enqueueResume with existing task
     Runtime-->>TCC: markFailed(OUT_OF_DOMAIN)
-    TCC->>TCC: close old task and create next task in future wave
+    TCC->>TCC: mark failed; next-task policy remains future wave
 ```
 
 流程备注：
@@ -407,7 +468,7 @@ sequenceDiagram
 - 第一次没有 Session 时，由 SessionFactory 创建 Session。
 - Session 对 Access 只返回 `sessionId`。
 - Access 不传 `queueId`。
-- 有效 Task 的判断后续由 L4 TaskStore/索引完成，不靠扫描 Queue 内容。
+- 有效 Task 的判断当前由 TCC 在 session 队列内完成；后续可增加索引或持久化 TaskStore。
 - OOD 后是否立即创建新 Task 是后续 W3 策略，需要单独实现和测试。
 
 ## 9. 风险与待确认
@@ -415,7 +476,7 @@ sequenceDiagram
 | 风险 | 当前处理 |
 |---|---|
 | Runtime 同步返回 Access，同时回写 TCC，可能出现顺序/失败一致性问题。 | 记录为 W3/W4 风险；需要幂等键、revision 和失败补偿策略。 |
-| Access 不知道 `queueId`，Controller 后续如何定位 Queue。 | 通过 Session 内部绑定和弱管理 QueueManager 解决；W1 不实现。 |
+| Access 不知道 `queueId`，TCC 如何定位 Queue。 | 通过 `QueueManager.findBySession(tenantId, sessionId)` 解决。 |
 | OOD 后谁创建新 Task。 | L4 创建，Runtime 只报告 `OUT_OF_DOMAIN` / `NOT_CURRENT_TASK`。 |
 | QueueManager 强管理会带来权限面。 | 采用弱管理，不暴露 admin port。 |
 | 当前 API 仍有 `mark*` 多方法。 | 这些是 Runtime adapter 回写状态意图，不是 L1 handler 入口；L1 仍只有 `runTask`。 |
@@ -423,7 +484,7 @@ sequenceDiagram
 
 ## 10. Wave 计划
 
-### W1：当前 PR #102
+### W1：当前实现
 
 交付：
 
@@ -435,6 +496,10 @@ sequenceDiagram
 - `TaskFailureCode`
 - `WaitingReason`
 - `TaskControlClient`
+- `QueueManager`
+- `QueueRegistration`
+- `TaskControlService`
+- `EngineTaskControlAdapter`
 - 白盒测试
 
 验证：
@@ -445,32 +510,36 @@ sequenceDiagram
 - Task transition 递增 revision。
 - `RunTaskCommand` 防御性拷贝 metadata。
 - `CANCEL` 必须携带 `taskId`。
+- `QueueManager` 可按 `queueId` 与 session 查询。
+- `TaskControlService` 能创建、恢复、取消和标记 Task。
+- `EngineTaskControlAdapter` 能把 engine 回调映射成 TCC 状态流转。
 
-### W2：弱管理 QueueManager
-
-交付：
-
-- Queue 生命周期事实登记。
-- Queue 查询和审计视图。
-- listener registry。
-- 不改变 `TaskQueue` 主接口。
-
-### W3：TaskStore 与控制实现
+### W2：Access / Session 集成
 
 交付：
 
-- 当前 Task 查询。
-- `findActiveTask(sessionId)`。
-- revision/CAS。
-- OOD 后创建新 Task 的策略。
+- Access 注册绑定 TCC 的 TaskHandler。
+- Session 创建时明确绑定 session 队列。
+- Access 只透传 `sessionId` 和 `agentId`，不感知 `queueId`。
+- 端到端跑通首次输入、等待补充和取消任务。
 
-### W4：Runtime adapter
+### W3：状态策略增强
 
 交付：
 
-- 对齐 PR #100 Runtime/Engine SPI。
-- Runtime adapter 回写 `TaskControlClient.mark*`。
-- Runtime 不直接访问 Queue。
+- OOD 后由 TCC 创建新 Task 的策略。
+- 并发输入排序策略测试。
+- dispatch 失败补偿策略。
+- 独立 Task 索引或持久化 TaskStore 评估。
+
+### W4：持久化 IEQ 后端
+
+交付：
+
+- Redis/JDBC/Kafka 等队列实现。
+- 保持 `TaskQueue` 语义不变。
+- 保持 Queue 不理解 Task 状态。
+- 补充 at-least-once / exactly-once 边界说明。
 
 ## 11. 当前 PR 检查项
 

--- a/architecture/docs/L1/agent-service/2026-05-30-agent-service-l3-l4-task-queue-control-implementation-spec.cn.md
+++ b/architecture/docs/L1/agent-service/2026-05-30-agent-service-l3-l4-task-queue-control-implementation-spec.cn.md
@@ -9,11 +9,17 @@ authoring_mode: implementation_spec
 
 # Agent Service L3/L4 Taskflow Queue/Control 实现规格
 
-本文只说明当前 PR #102 的 W1 实现形态：包结构、接口、数据结构、测试和后续 Wave。本文不重复解释为什么这样设计；原因见同目录架构提议文档。
+本文说明当前 taskflow 的实现形态：包结构、接口、数据结构、测试和后续 Wave。本文不重复解释为什么这样设计；原因见同目录架构提议文档。
+
+代码旁审阅入口见：
+
+```text
+agent-service/src/main/java/com/huawei/ascend/service/taskflow/README.md
+```
 
 ## 0. W1 实现范围
 
-W1 只保留必须代码：
+W1 已经从“接口冻结”推进到“本地可运行闭环”：
 
 1. L3 提供一个基于 JDK `LinkedBlockingQueue` 的本地内存队列。
 2. `QueueFactory` 是 `final` 工具类，提供静态工厂函数，不是 interface。
@@ -21,8 +27,10 @@ W1 只保留必须代码：
 4. L4 提供一个紧凑的 `TaskControlClient` API。
 5. L1 侧只有一个任务入口：`runTask(RunTaskCommand)`。
 6. `RUN`、`RESUME_INPUT`、`CANCEL` 通过 `TaskAction` 表达，不拆成多个 handler 方法。
-7. 当前不实现 `QueueManager`、`TaskStore`、`TaskController`、runtime dispatcher；这些进入后续 Wave。
+7. 当前实现 `QueueManager` 弱管理：记录队列注册、按 `queueId` 查询、按 `tenantId + sessionId` 查询和注销。
 8. 当前不定义 `RuntimeQueueGateway`。Runtime 不直接发布或消费 Queue。
+9. 当前实现 `TaskControlService`，负责 Task 创建、当前 Task 选择、状态流转、幂等和 revision fencing。
+10. 当前实现 `EngineTaskControlAdapter`，把 engine 侧状态回调转成 TCC `mark*` 调用。
 
 ## 1. 包结构
 
@@ -32,12 +40,16 @@ agent-service/src/main/java/com/huawei/ascend/service/taskflow/
     TaskQueue.java
     InMemoryTaskQueue.java
     QueueFactory.java
+    QueueManager.java
+    QueueRegistration.java
 
   control/
     Task.java
     TaskState.java
     TaskFailureCode.java
     WaitingReason.java
+    TaskControlService.java
+    EngineTaskControlAdapter.java
     api/
       TaskControlClient.java
 
@@ -45,6 +57,9 @@ agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/
   TaskBeanWhiteboxTest.java
   InMemoryTaskQueueWhiteboxTest.java
   TaskControlClientApiWhiteboxTest.java
+  QueueManagerWhiteboxTest.java
+  TaskControlServiceWhiteboxTest.java
+  TaskflowEngineBridgeWhiteboxTest.java
 ```
 
 命名规则：
@@ -62,12 +77,14 @@ package com.huawei.ascend.service.taskflow.queue;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 public interface TaskQueue<T> {
     String queueId();
     boolean offer(T value);
     Optional<T> poll();
     Optional<T> peek();
+    Optional<T> find(Predicate<? super T> matcher);
     List<T> snapshot();
     int size();
 }
@@ -77,7 +94,7 @@ public interface TaskQueue<T> {
 
 1. Queue 不关心队列内容物类型。
 2. Queue 不解析 Task，不持有 Task 状态。
-3. Queue 当前只提供 FIFO、查看快照和读取能力。
+3. Queue 当前只提供 FIFO、查看快照、按谓词查找和读取能力。
 4. `snapshot()` 返回只读拷贝，不能 drain 队列。
 5. Queue 不暴露 admin port。
 
@@ -106,6 +123,17 @@ public final class QueueFactory {
     public static <T> TaskQueue<T> inMemoryQueue(String queueId) {
         return new InMemoryTaskQueue<>(queueId);
     }
+
+    public static <T> TaskQueue<T> inMemoryQueue(
+            String queueId, QueueManager manager, QueueRegistration registration) {
+        return manager.register(new InMemoryTaskQueue<>(queueId), registration);
+    }
+
+    public static TaskQueue<Task> inMemorySessionQueue(
+            String tenantId, String sessionId, QueueManager manager) {
+        QueueRegistration registration = QueueRegistration.session(tenantId, sessionId);
+        return inMemoryQueue(registration.queueId(), manager, registration);
+    }
 }
 ```
 
@@ -113,8 +141,30 @@ public final class QueueFactory {
 
 1. `QueueFactory` 不是 interface。
 2. W1 只提供静态工厂函数。
-3. 后续若引入弱管理 `QueueManager`，可在创建/销毁时通知 manager；W1 不强制实现。
+3. 带 `QueueManager` 的重载在创建 session 队列时同步注册弱管理关系。
 4. 创建 Queue 不要求调用方知道具体实现类。
+
+### 2.4 QueueManager
+
+`QueueManager` 是弱管理对象，不是 admin port。
+
+```java
+public class QueueManager {
+    public <T> TaskQueue<T> register(TaskQueue<T> queue, QueueRegistration registration);
+    public Optional<TaskQueue<?>> findByQueueId(String queueId);
+    public Optional<TaskQueue<?>> findBySession(String tenantId, String sessionId);
+    public Optional<QueueRegistration> registration(String queueId);
+    public List<QueueRegistration> registrations();
+    public void unregister(String queueId);
+}
+```
+
+实现规则：
+
+1. `QueueManager` 只记录队列注册、归属和注销事实。
+2. `QueueManager` 不理解 Task 状态。
+3. 普通调用方不需要拿到对外 admin port。
+4. session 队列通过 `tenantId + sessionId` 定位，Access 不传 `queueId`。
 
 ## 3. L4 Task 数据结构
 
@@ -288,9 +338,9 @@ public record TaskResult(
 }
 ```
 
-## 5. Runtime 边界
+## 5. Runtime / engine 边界
 
-当前 W1 不新增 Runtime 派发接口。
+当前不定义 `RuntimeQueueGateway`，但已经通过 PR #100/#105 的 engine dispatch API 完成最小桥接。
 
 规则：
 
@@ -300,6 +350,8 @@ public record TaskResult(
 4. Runtime 面向 Access 的输出按同步返回链路处理。
 5. Runtime 的状态意图由 adapter 转成 `TaskControlClient.mark*` 调用。
 6. Runtime 细节对象如果需要入队，必须先交回 L4，由 L4 决定是否写 Queue。
+7. TCC 通过 `EngineDispatchApi.enqueueExecution`、`enqueueResume`、`enqueueCancel` 把执行意图交给 engine/runtime 侧。
+8. `EngineTaskControlAdapter` 把 engine 侧 Task 控制回调映射到 `TaskControlService.mark*`。
 
 ## 6. 当前流程视图
 
@@ -314,10 +366,10 @@ sequenceDiagram
 
     Client->>Access: user input(sessionId, agentId, query)
     Access->>TCC: runTask(action=RUN/RESUME_INPUT/CANCEL)
-    TCC->>Queue: optional offer(Object)
-    TCC->>Runtime: future wave dispatch
+    TCC->>Queue: find or create session Task
+    TCC->>Runtime: enqueueExecution / enqueueResume / enqueueCancel
     Runtime-->>Access: sync user output
-    Runtime-->>TCC: markRunning/markWaiting/markSucceeded/markFailed/markCancelled
+    Runtime-->>TCC: EngineTaskControlAdapter -> mark*
 ```
 
 ## 7. 状态转换视图
@@ -354,46 +406,50 @@ agent-service/src/test/java/com/huawei/ascend/service/taskflow/test/
 1. `TaskBeanWhiteboxTest`
 2. `InMemoryTaskQueueWhiteboxTest`
 3. `TaskControlClientApiWhiteboxTest`
+4. `QueueManagerWhiteboxTest`
+5. `TaskControlServiceWhiteboxTest`
+6. `TaskflowEngineBridgeWhiteboxTest`
 
 最小验证命令：
 
 ```powershell
-.\mvnw.cmd -pl agent-service -am "-Dtest=TaskBeanWhiteboxTest,InMemoryTaskQueueWhiteboxTest,TaskControlClientApiWhiteboxTest" "-Dsurefire.failIfNoSpecifiedTests=false" -Pquality -B -ntp test
+.\mvnw.cmd -pl agent-service -am "-Dtest=TaskBeanWhiteboxTest,InMemoryTaskQueueWhiteboxTest,TaskControlClientApiWhiteboxTest,QueueManagerWhiteboxTest,TaskControlServiceWhiteboxTest,TaskflowEngineBridgeWhiteboxTest" "-Dsurefire.failIfNoSpecifiedTests=false" -Pquality -B -ntp test
 ```
 
 ## 9. 后续 Wave
 
-### W2：弱管理 QueueManager
+### W2：Access / Session 集成
 
 目标：
 
-- 记录 Queue 创建者、归属 session、生命周期事实。
-- 管理监听注册、审计日志和维护视图。
-- 不作为强制创建入口。
-- 不在 Queue 主接口上暴露 admin port。
+- Access 注册绑定 TCC 的 TaskHandler。
+- Session 创建时明确绑定 session 队列。
+- Access 仍只传 `sessionId`，不感知 `queueId`。
+- 端到端串起首次用户输入、等待用户补充和取消任务。
 
-### W3：TaskStore 与状态机实现
-
-目标：
-
-- 实现当前 Task 查询。
-- 实现 `findActiveTask(sessionId)`。
-- 实现 revision/CAS。
-- 实现 Runtime OOD 后由 L4 创建新 Task 的策略。
-
-### W4：Runtime adapter 接入
+### W3：状态策略增强
 
 目标：
 
-- 对齐 PR #100 的 Runtime/Engine SPI。
-- Runtime adapter 将执行结果转换成 `TaskControlClient.mark*`。
-- Runtime 不直接访问 Queue。
+- 明确 Runtime OOD 后由 TCC 创建新 Task 的策略。
+- 补充并发用户输入的排序策略测试。
+- 补充 dispatch 失败后的补偿策略。
+- 评估是否需要独立 Task 索引或持久化 TaskStore。
+
+### W4：持久化 IEQ 后端
+
+目标：
+
+- 增加 Redis/JDBC/Kafka 等后端实现。
+- 保持 `TaskQueue` 语义不变。
+- 保持 Queue 不理解 Task 状态。
+- 为持久化后端补充 exactly-once / at-least-once 边界说明。
 
 ## 10. 已解决的冲突
 
 1. `TaskHandler` 不再暴露 `resumeInput`、`cancelTask`，统一为 `runTask + TaskAction`。
 2. `QueueFactory` 不再是 interface，W1 是静态工具类。
-3. 当前不实现 `QueueManager` 强管理。
+3. 当前实现 `QueueManager` 弱管理，不实现强管理或对外 admin port。
 4. 当前不定义 `RuntimeQueueGateway`。
 5. taskflow 当前按内部 API 处理，不注册为新的 SPI 面。
 6. 白盒测试已经放入 `agent-service/src/test/java/com/huawei/ascend/service/taskflow/test`。


### PR DESCRIPTION
## Summary

This PR implements the first runnable local loop for the agent-service taskflow layer:

- adds the Internal Event Queue (IEQ) local queue surface, weak `QueueManager`, and session queue registration model
- adds the Task-Centric Control (TCC) service for task creation, current-task selection, state transitions, idempotency, and revision fencing
- bridges engine/runtime task callbacks into TCC through `EngineTaskControlAdapter`, while keeping runtime/engine from directly reading or writing IEQ
- wires taskflow auto-configuration and the engine dispatch API required by the control loop
- adds white-box tests for queue management, TCC behavior, and engine bridge mapping
- updates the L1 taskflow architecture/spec docs and adds a code-adjacent taskflow README for reviewers

## Scope Control

Only taskflow implementation, required engine auto-configuration, targeted tests, and taskflow/L1 documentation are included. Existing unrelated untracked files under docs/logs, gate/log, and agent-service/bin were intentionally left out of the commit.

## Validation

- `git diff --cached --check`
- `.\mvnw.cmd -pl agent-service -am -Pquality -B -ntp verify`

Both checks passed locally.