### PR TITLE
fix(fact-layer): run FactLayerByteIdentityIT via Failsafe + provenance-tolerant check

### DIFF
--- a/tools/architecture-workspace/pom.xml
+++ b/tools/architecture-workspace/pom.xml
@@ -124,6 +124,27 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>3.5.2</version>
       </plugin>
+      <!--
+        Fact-Layer Wave 4 (ADR-0154 / Rule G-15 sub-clause .c.bytes): the
+        byte-identity IT (FactLayerByteIdentityIT) is bound to the
+        integration-test/verify phase via Failsafe. Without this plugin the
+        *IT class matched no Surefire include pattern and never ran, so the
+        byte-identity contract was unenforced. Surefire keeps running the
+        unit *Test classes in the test phase; Failsafe runs *IT in verify.
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.5.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>

--- a/tools/architecture-workspace/src/main/java/com/huawei/ascend/tools/architecture/facts/ExtractFactsCli.java
+++ b/tools/architecture-workspace/src/main/java/com/huawei/ascend/tools/architecture/facts/ExtractFactsCli.java
@@ -78,15 +78,29 @@ public final class ExtractFactsCli {
             if (!Files.exists(target)) {
                 throw new IOException("--check: committed file missing " + target);
             }
-            byte[] expected = Files.readAllBytes(target);
-            byte[] actual = Files.readAllBytes(tmp);
-            if (!java.util.Arrays.equals(expected, actual)) {
-                throw new IOException("--check: drift detected on " + target
-                        + " (expected " + expected.length + " bytes, got " + actual.length + ")");
+            String expected = normalizeProvenance(Files.readString(target));
+            String actual = normalizeProvenance(Files.readString(tmp));
+            if (!expected.equals(actual)) {
+                throw new IOException("--check: content drift detected on " + target
+                        + " (differs after normalizing per-commit provenance SHAs)");
             }
         } finally {
             Files.deleteIfExists(tmp);
         }
+    }
+
+    /**
+     * Normalize the per-commit provenance that legitimately varies between the
+     * commit a fact file was generated in and any later workspace HEAD: the
+     * 40-char {@code repo_commit} SHA (and the banner's "at commit &lt;sha&gt;").
+     * Without this, the byte-identity check (Rule G-15.c.bytes) could never be
+     * satisfied across commits — a file generated in commit P embeds P's SHA,
+     * but a re-extraction at HEAD=C embeds C's SHA. Replacing every 40-hex run
+     * with a placeholder makes the check compare CONTENT only; genuine content
+     * drift (a hand-edited fact value) is still detected.
+     */
+    private static String normalizeProvenance(String json) {
+        return json.replaceAll("[0-9a-f]{40}", "<commit>");
     }
 
     private static String argValue(String[] args, String name, String fallback) {


### PR DESCRIPTION
## What
The fact-layer byte-identity IT (`FactLayerByteIdentityIT`, Rule G-15 sub-clause `.c.bytes`) **never ran**: `tools/architecture-workspace` had only `maven-surefire-plugin` (whose default include patterns match `*Test`, not `*IT`) and no `maven-failsafe-plugin`, so the `*IT` class was bound to no lifecycle phase. Consequences: the byte-identity contract was unenforced, and the `maven_tests_green` baseline counted 2 tests that never executed.

## Fix
- Add `maven-failsafe-plugin` (integration-test + verify goals) so `*IT` runs in `mvn verify`. Surefire still runs unit `*Test` in the `test` phase, so the architecture gate's `mvn clean test` is unaffected.
- `ExtractFactsCli --check`: normalize the per-commit provenance SHA (the `repo_commit` field + the banner's "at commit &lt;sha&gt;") before comparing, so the check enforces fact **content** identity but tolerates the commit SHA that legitimately differs between the commit a fact file was generated in and a later HEAD (otherwise the check could never pass across commits). Genuine content drift is still detected.

## Verification
- Local `mvn -f tools/architecture-workspace/pom.xml test-compile`: BUILD SUCCESS.
- The architecture-sync gate (`check_parallel.sh` + workspace gate) is unaffected — the fix touches only the `verify`-phase IT and the `--check` path, neither of which the gate exercises.
- **This PR's CI is the first time the IT actually executes in a full build** — that is the real validation. If the "Maven build + integration tests" check fails on the IT, it means the committed `code-symbols.json` / `tests.json` are stale relative to recently-merged code and need regenerating; otherwise the byte-identity contract is now enforced going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
