### PR TITLE
fix(gate): de-flake Rule 42 idempotency check (parallel race) + clean dangling render refs

### DIFF
--- a/.claude/skills/formal-release-transaction.md
+++ b/.claude/skills/formal-release-transaction.md
@@ -2,12 +2,12 @@
 name: formal-release-transaction
 description: |
   Use this skill when preparing, reviewing, or publishing a formal L0 release
-  note. Delegates to `/refresh-architecture-doc` for the upstream authority
-  surface refresh + template re-render stages; then validates the formal
-  release transaction shape (evidence bundle present, formal_release
-  frontmatter coherent, current-vs-forward claims expressed, recurring-family
-  closures recorded). Replaces the previous single-stage post-author
-  validator with an integrated flow.
+  note. Validates the formal release transaction shape: evidence bundle present,
+  `formal_release` frontmatter coherent, current-vs-forward claims expressed, and
+  recurring-family closures recorded. (The former single-source render pipeline —
+  /refresh-architecture-doc + .md.j2 template re-render — was removed in the
+  2026-06-03 governance cleanup; release notes are hand-authored from the
+  release-readiness template, validated structurally + by the gate.)
 scope: project
 ---
 
@@ -15,23 +15,14 @@ scope: project
 
 ## Purpose
 
-A formal release note is the last derivative artefact in the
-architecture-document chain. Before its content can be trusted, every
-upstream authority surface it references MUST be refreshed and every
-downstream rendered template MUST be byte-identical to those surfaces
-(Rule G-13). This skill drives the integrated flow.
+A formal release note is the last derivative artefact in the architecture-document
+chain. Its numeric claims MUST come from the generated evidence bundle (never
+hand-typed), and its frontmatter + claim structure MUST be coherent before the
+note is trusted. This skill drives that validation flow.
 
 ## Required workflow
 
-### Stage A — Run `/refresh-architecture-doc` first
-
-The 9-stage refresh-order discipline (pre-flight gate, ADRs, graph,
-status.yaml, CLAUDE.md kernel + cards, families ledger, phase contracts,
-template render idempotency, README + numeric claims, full gate)
-applies to every release. Do not skip to stage B with refresh-skill
-stages failing.
-
-### Stage B — Freeze the candidate commit
+### Stage A — Freeze the candidate commit
 
 Record the SHA in the release note frontmatter:
 
@@ -44,7 +35,7 @@ status: formal-release-candidate
 ---
 ```
 
-### Stage C — Generate the evidence bundle
+### Stage B — Generate the evidence bundle
 
 ```bash
 python3 gate/lib/build_release_evidence.py \
@@ -53,91 +44,57 @@ python3 gate/lib/build_release_evidence.py \
     --output gate/release-ci-evidence/<release-id>.evidence.yaml
 ```
 
-The bundle is the canonical numeric input for the release note. Hand-typed
-counts are forbidden under Rule G-13.b — every count comes from the bundle
-or from the render-context loader.
+The bundle is the canonical numeric input for the release note — every count comes
+from it, never hand-typed. `build_release_evidence.py` also runs the formal-release
+transaction-shape validation (`gate/lib/check_formal_release_transaction.py`):
+scaffold files exist; the release-readiness schema declares its core models;
+the evidence-bundle `baseline_comparison` shows all `matches: true`; and the
+frontmatter `formal_release: true` <-> `evidence_bundle:` reference is consistent.
 
-### Stage D — Validate the transaction
+### Stage C — Hand-author the release note
 
-```bash
-bash gate/check_formal_release_transaction.sh \
-    --evidence gate/release-ci-evidence/<release-id>.evidence.yaml
-```
+Author the note from `docs/governance/release-readiness/formal-release-note-template.en.md`,
+filling the generated tables (Evidence, Baseline, Family Closures) from the
+evidence bundle's values. Do not hand-type counts that diverge from the bundle.
 
-Checks: scaffold files exist; release-readiness schema declares all five
-core models PLUS the W1-added RenderContext / TemplatedArtifact / RenderSchema
-models; evidence-bundle baseline_comparison shows all `matches: true`;
-frontmatter `formal_release: true` ↔ `evidence_bundle:` reference is consistent.
+### Stage D — Current-vs-forward claims (hand-author, validated structurally)
 
-### Stage E — Render the release note from template (W3+)
+For every staged behavior, write a `CurrentForwardClaim` record (per the
+release-readiness.schema.yaml model): subject; current shipped behavior; current
+verified by (tests, gates, code paths); forward behavior; promotion trigger; the
+phrase that must not be claimed before promotion.
 
-Once the release-note template lands in W3, hand-typed prose for the
-generated tables (Evidence, Baseline, Family Closures, Authority Refresh)
-is forbidden. Instead:
+### Stage E — Recurring-family closures
 
-```bash
-python3 gate/lib/load_render_context.py release_note \
-    --seed gate/release-ci-evidence/<release-id>-narrative-seed.yaml \
-    --run-self-tests --include-maven-reports \
-    --output gate/release-ci-evidence/<release-id>-render-context.yaml
-python3 -m gate.lib.render_template \
-    docs/governance/templates/release-note.md.j2 \
-    --data gate/release-ci-evidence/<release-id>-render-context.yaml \
-    --output docs/logs/releases/<date>-l0-<release-id>.md
-```
+For every touched recurring family, write a `DefectFamilyClosure`: family id;
+cited findings; sibling surfaces checked; closure result
+(`closed | accepted_residual | not_ready`); residual risk (empty if closed).
 
-Pre-W3, hand-author the release note using the
-`docs/governance/release-readiness/formal-release-note-template.en.md`
-template; the W3 cutover migrates to `.md.j2`.
-
-### Stage F — Current-vs-forward claims (hand-author, validated structurally)
-
-For every staged behavior, write a `CurrentForwardClaim` record (per
-the release-readiness.schema.yaml model):
-- subject,
-- current shipped behavior,
-- current verified by (tests, gates, code paths),
-- forward behavior,
-- promotion trigger,
-- phrase that must not be claimed before promotion.
-
-### Stage G — Recurring-family closures
-
-For every touched recurring family, write a `DefectFamilyClosure`:
-- family id,
-- cited findings,
-- sibling surfaces checked,
-- closure result (`closed | accepted_residual | not_ready`),
-- residual risk (empty if closed).
-
-### Stage H — Final gate
+### Stage F — Final gate
 
 ```bash
 bash gate/check_parallel.sh
 ./mvnw clean verify
 ```
 
-All 140+ rules + Maven verify MUST PASS.
+The active gate rules + Maven verify MUST PASS.
 
 ## Release decision rule
 
-No evidence bundle means no `formal_release: true` claim. A corrective RC
-note may still be published, but it must not claim final L0 closure and
-must mark itself `status: corrective` in frontmatter.
+No evidence bundle means no `formal_release: true` claim. A corrective RC note may
+still be published, but it must not claim final L0 closure and must mark itself
+`status: corrective` in frontmatter.
 
 ## Files to load when needed
 
 - `docs/governance/release-readiness/release-readiness.schema.yaml`
-- `docs/governance/release-readiness/formal-release-note-template.en.md` (pre-W3)
-- `docs/governance/templates/release-note.md.j2` (post-W3)
+- `docs/governance/release-readiness/formal-release-note-template.en.md`
 - `docs/governance/recurring-defect-families.yaml`
 - `docs/governance/architecture-status.yaml`
 - latest file from `docs/logs/releases/`
 
 ## Composes with
 
-- `/refresh-architecture-doc` — mandatory upstream stage.
-- `/commit-mode` — system-commit phase contract exit criteria gate the
-  final release-note commit.
-- `/refresh-defect-archive` — companion for the recurring-defect ledger
-  refresh.
+- `/commit-mode` — system-commit phase contract exit criteria gate the final
+  release-note commit.
+- `/refresh-defect-archive` — companion for the recurring-defect ledger refresh.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,8 +72,7 @@ runner executes the same rules. A green run prints `GATE: PASS`.
 
 | Artefact | Generated from | Regenerate with |
 |---|---|---|
-| `gate/rules/*.sh` | `gate/check_architecture_sync.sh` (the monolith) | `bash gate/lib/extract_rules.sh` |
-| `architecture/generated/*.dsl` | `*/module-metadata.yaml`, `docs/governance/{enforcers,principle-coverage}.yaml`, `CLAUDE.md`, `docs/adr/*.yaml`, `docs/governance/templates/surface-classification.yaml` | `java ... com.huawei.ascend.tools.architecture.fragment.AllFragmentsCli --repo .` |
+| `architecture/generated/*.dsl` | `*/module-metadata.yaml`, `docs/governance/{enforcers,principle-coverage}.yaml`, `CLAUDE.md`, `docs/adr/*.yaml` | `java ... com.huawei.ascend.tools.architecture.fragment.AllFragmentsCli --repo .` |
 | `docs/governance/architecture-workspace-graph.yaml` | `architecture/workspace.dsl` workspace closure | `bash gate/check_architecture_workspace.sh` |
 | `docs/governance/architecture-graph.yaml` | principle/enforcer/status/ADR inputs (legacy; retires at W7 per ADR-0147) | `python3 gate/build_architecture_graph.py` |
 

--- a/gate/build_architecture_graph.py
+++ b/gate/build_architecture_graph.py
@@ -546,7 +546,9 @@ def main() -> int:
     p.add_argument("--check", action="store_true", help="build and validate; emit non-zero on validation failure")
     p.add_argument("--no-write", action="store_true", help="do not write the output file (use with --check)")
     p.add_argument("--mermaid", action="store_true", help="also emit Mermaid renderer to docs/governance/architecture-graph.mmd")
+    p.add_argument("--output", default=None, help="write the graph YAML to this path instead of the canonical architecture-graph.yaml (Rule 42 builds to isolated temp files to avoid the parallel-gate shared-file race)")
     args = p.parse_args()
+    out_yaml = Path(args.output) if args.output else OUTPUT_YAML
 
     graph = build_graph(REPO)
     yaml_text = yaml.safe_dump(graph, sort_keys=False, allow_unicode=True, width=1000)
@@ -585,10 +587,10 @@ def main() -> int:
         # write_bytes truncates then writes; os.replace is the POSIX atomic
         # rename so readers either see the prior full file or the new full
         # file, never partial bytes.
-        _tmp_path = OUTPUT_YAML.with_suffix(OUTPUT_YAML.suffix + f".tmp.{os.getpid()}")
+        _tmp_path = out_yaml.with_suffix(out_yaml.suffix + f".tmp.{os.getpid()}")
         _tmp_path.write_bytes((header + yaml_text).encode("utf-8"))
-        os.replace(_tmp_path, OUTPUT_YAML)
-        print(f"Wrote {OUTPUT_YAML.relative_to(REPO)}: {graph['node_count']} nodes, {graph['edge_count']} edges")
+        os.replace(_tmp_path, out_yaml)
+        print(f"Wrote {out_yaml}: {graph['node_count']} nodes, {graph['edge_count']} edges")
     else:
         print(f"Built graph (not written): {graph['node_count']} nodes, {graph['edge_count']} edges")
 

--- a/gate/check_architecture_sync.sh
+++ b/gate/check_architecture_sync.sh
@@ -1074,22 +1074,25 @@ _r42_fail=0
 if ! command -v python3 >/dev/null 2>&1 && ! command -v python >/dev/null 2>&1; then
   fail_rule "architecture_graph_idempotent" "neither python3 nor python on PATH — required for gate/build_architecture_graph.py"
   _r42_fail=1
-elif [[ ! -f docs/governance/architecture-graph.yaml ]]; then
-  fail_rule "architecture_graph_idempotent" "docs/governance/architecture-graph.yaml not present — run bash gate/build_architecture_graph.sh first"
-  _r42_fail=1
 else
   _r42_a="$(mktemp 2>/dev/null || echo /tmp/r42_a.$$.yaml)"
   _r42_b="$(mktemp 2>/dev/null || echo /tmp/r42_b.$$.yaml)"
-  cp docs/governance/architecture-graph.yaml "$_r42_a" 2>/dev/null || true
-  if ! bash gate/build_architecture_graph.sh > /dev/null 2>&1; then
+  # Build twice to ISOLATED temp outputs (via --output) and diff them. This is a
+  # true two-fresh-builds idempotency check, independent of the pre-existing
+  # committed docs/governance/architecture-graph.yaml. The previous form captured
+  # the committed file before rebuilding, which under check_parallel.sh raced with
+  # Rules 38/41/106 (concurrent writers/readers of that path): a stale-vs-fresh
+  # capture produced an intermittent false "non-deterministic" diff. Building to
+  # private temps touches no shared file, so the check is deterministic in parallel.
+  if ! bash gate/build_architecture_graph.sh --output "$_r42_a" > /dev/null 2>&1; then
     fail_rule "architecture_graph_idempotent" "graph build failed during idempotency probe"
     _r42_fail=1
-  else
-    cp docs/governance/architecture-graph.yaml "$_r42_b" 2>/dev/null || true
-    if ! diff -q "$_r42_a" "$_r42_b" >/dev/null 2>&1; then
-      fail_rule "architecture_graph_idempotent" "re-running gate/build_architecture_graph.sh produced a DIFFERENT graph — the build is non-deterministic"
-      _r42_fail=1
-    fi
+  elif ! bash gate/build_architecture_graph.sh --output "$_r42_b" > /dev/null 2>&1; then
+    fail_rule "architecture_graph_idempotent" "graph build failed during idempotency probe (second build)"
+    _r42_fail=1
+  elif ! diff -q "$_r42_a" "$_r42_b" >/dev/null 2>&1; then
+    fail_rule "architecture_graph_idempotent" "two fresh gate/build_architecture_graph.sh builds produced DIFFERENT graphs — the build is non-deterministic"
+    _r42_fail=1
   fi
   rm -f "$_r42_a" "$_r42_b" 2>/dev/null || true
 fi


### PR DESCRIPTION
## What

Two follow-ups from the gate-residue cleanup (PRs #121–123).

### 1. Rule 42 `architecture_graph_idempotent` flaky parallel race — FIXED
The check captured the **pre-existing** committed `architecture-graph.yaml`, rebuilt it, then diffed. Under `check_parallel.sh` that path is written by Rule 38 and read by Rules 41/106 concurrently, so the capture could be a stale (prior-run, gitignored) version → an intermittent **false "non-deterministic" diff** (it was always deterministic in serial). Fix: build **twice to isolated temp outputs** and diff them — a true two-fresh-builds idempotency check that touches no shared file. Added `--output PATH` to `gate/build_architecture_graph.py`.

### 2. Dangling references to the removed render layer — CLEANED
- `.claude/skills/formal-release-transaction.md` rewritten: dropped the `/refresh-architecture-doc` delegation + the `.md.j2` render stages + the deleted `check_formal_release_transaction.sh`; release notes are hand-authored from the release-readiness template, validated by `build_release_evidence.py` + the gate.
- `CONTRIBUTING.md` "Generated artefacts" table: removed the `gate/rules/*.sh` row and the `surface-classification.yaml` source (both deleted in #121).

## Verification
- Parallel gate (`gate/check_parallel.sh`): **GATE: PASS** on 2/2 repeated runs — Rule 42 is now stable (was intermittently red).
- CI (Maven build + integration tests): no Java touched → unaffected; CI also runs the parallel gate as a step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
