### PR TITLE
ci: drop -T 1C from verify to prevent cross-module IT context-boot deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,13 @@ jobs:
           cache: maven
 
       - name: Maven verify (compile + unit + integration tests)
-        run: ./mvnw -T 1C -B -ntp --strict-checksums -Pquality verify
+        # NOTE: no -T 1C here. Spring Boot 4.0.5 is not thread-safe at
+        # SpringApplication.run() init; -T 1C boots module ITs concurrently in
+        # parallel reactor JVMs and intermittently deadlocks (observed: 5h+ hangs
+        # on main and PR CI). Running the reactor single-threaded means only one
+        # context boots at a time globally, removing the race. Failsafe also has a
+        # 15-min forkedProcessTimeoutInSeconds safety net (see parent pom).
+        run: ./mvnw -B -ntp --strict-checksums -Pquality verify
 
       - name: Install Python deps for architecture-graph generation
         # Required by Rule 34 (architecture_graph_well_formed) — the gate


### PR DESCRIPTION
Follow-up to #125. Prevents the intermittent multi-hour CI deadlock: Spring Boot 4.0.5 is not thread-safe at SpringApplication.run init, and -T 1C boots module integration-test contexts concurrently in parallel reactor JVMs. Running the reactor single-threaded for verify means only one context boots at a time globally, removing the race. Complements the Failsafe forkedProcessTimeoutInSeconds safety net already merged in #125. This PRs own CI run validates the fix (verify now runs sequentially). Generated with Claude Code.