### PR TITLE
chore(gate): replace fossil prologue rule-index with pointer to body headers

### DIFF
--- a/gate/README.md
+++ b/gate/README.md
@@ -60,9 +60,9 @@ Run the bash entrypoint from Git Bash / WSL / any POSIX shell on Windows.
 | `rls-baseline-grandfathered.txt` | Grandfathered Flyway migrations for Rule R-J.a (RLS retrofit deferred to W2 per CLAUDE-deferred.md 40.b). |
 | `log/` | Audit JSON files retained from earlier gate generations; the current canonical bash gate does not write here. |
 
-## Rule catalog (current — see `check_architecture_sync.sh` header for the canonical comment block)
+## Rule catalog (current — the `# Rule N — slug` body headers in `check_architecture_sync.sh`)
 
-The bash script's header comment is the single source of truth for the rule list. The previous markdown table in this README was retired in v2.0.0-rc2 to eliminate dual-truth drift (the rules-table-as-prose became another F-α "parity-claim without enforcer" instance per the second-pass review). To browse the rule list, open `gate/check_architecture_sync.sh` and read the comment block lines 1–119.
+The canonical rule list is the `# Rule N — slug` body headers in `gate/check_architecture_sync.sh` (what `check_parallel.sh` splits on and `gate/lib/build_release_evidence.py` counts). The previous markdown table here was retired in v2.0.0-rc2, and the numbered duplicate in the script header was removed in 2026-06 (it had drifted — it listed retired rules and omitted live ones) — both to keep a single source. To browse the rules: `grep -nE '^# Rule ' gate/check_architecture_sync.sh`.
 
 ## Self-test coverage
 

--- a/gate/check_architecture_sync.sh
+++ b/gate/check_architecture_sync.sh
@@ -28,76 +28,10 @@
 # Prints GATE: PASS or GATE: FAIL at the end.
 #
 # Rules:
-#   1.  status_enum_invalid                          -- docs/governance/architecture-status.yaml status values
-#   2.  delivery_log_parity                          -- gate/log/*.json sha field matches filename basename
-#   3.  eol_policy                                   -- *.sh files in gate/ must be LF (not CRLF)
-#   4.  ci_no_or_true_mask                           -- no gate/run_* || true in .github/workflows/*.yml
-#   5.  required_files_present                       -- contract-catalog.md and openapi-v1.yaml must exist
-#   6.  metric_naming_namespace                      -- springai_ascend_ prefix in Java metric names
-#   7.  shipped_impl_paths_exist                     -- every shipped: true implementation: path exists on disk
-#   8.  no_hardcoded_versions_in_arch                -- module ARCHITECTURE.md files must not pin OSS versions inline
-#   9.  openapi_path_consistency                     -- /v3/api-docs must appear in WebSecurityConfig + platform ARCH
-#  10.  module_dep_direction                         -- agent-runtime must not depend on agent-platform (ADR-0055: platform->runtime is now ALLOWED)
-#  11.  shipped_envelope_fingerprint_present         -- InMemoryCheckpointer enforces §4 #13 16-KiB cap
-#  12.  inmemory_orchestrator_posture_guard_present  -- AppPostureGate.requireDev in all 3 in-memory components (ADR-0035)
-#  16.  http_contract_w1_tenant_and_cancel_consistency -- W1 HTTP contract: no replace-X-Tenant-Id wording, no CREATED initial status, no DELETE cancel route, no W0 cancel/idempotency future-state drift
-#  17.  contract_catalog_spi_table_matches_source     -- SPI sub-table must list 7 known SPIs; OssApiProbe must not appear before Probes sub-table
-#  19.  shipped_row_tests_evidence                    -- every shipped: true row must have non-empty tests: pointing to real files (ADR-0042, strengthened)
-#  21.  bom_glue_paths_exist                          -- BoM must not contain known ghost implementation paths unless they exist (ADR-0043)
-#  23.  active_doc_internal_links_resolve             -- markdown links ](path) in active docs must resolve to existing files (ADR-0043)
-#  24.  shipped_row_evidence_paths_exist              -- l2_documents: and latest_delivery_file: on shipped rows must exist on disk (ADR-0045)
-#  --- L1 Rule-28 sub-checks (ADR-0059) ---
-#  28a. tenant_column_present                          -- every CREATE TABLE in db/migration declares tenant_id (enforcer E15)
-#  28b. high_cardinality_tag_guard                     -- no Tag.of("run_id"|"idempotency_key"|"jwt_sub"|"body", …) in agent-*/main (enforcer E19)
-#  28c. no_secret_patterns                             -- gitleaks-style sweep of tracked files; allowlist via 'secret-allowlist:' (enforcer E20)
-#  28d. out_of_scope_name_guard                        -- W2+ deferred names absent from agent-*/main (enforcer E26)
-#  28e. module_count_invariant                         -- root pom.xml declares exactly 9 <module> entries (enforcer E27; bumped from 4 to 9 by 2026-05-17 six-module materialization PR; canonical count lives in docs/governance/architecture-status.yaml#repository_counts.total_reactor_modules and is data-driven cross-checked by Rule 64)
-#  28f. enforcers_yaml_wellformed                      -- docs/governance/enforcers.yaml every row has all 5 fields + legal kind (enforcer E29)
-#  28j. enforcer_artifact_paths_exist                   -- every artifact: path in enforcers.yaml resolves on disk (enforcer E33, Phase K audit fix F6)
-#  28k. javadoc_enforcer_citation_semantic_check        -- *Test.java/*IT.java Javadoc `enforcers.yaml#E<n>` citations match the E-row's artifact: field (post-review fix plan F / P1-2)
-#  30.  telemetry_vertical_constraint_coverage         -- ARCHITECTURE.md §4 #53–#59 each cited by an enforcer row (L1.x Telemetry Vertical, enforcer E47)
-#  --- Layer-0 governing principles (ADR-0064..0067) ---
-#  32.  competitive_baselines_present_and_wellformed    -- docs/governance/competitive-baselines.yaml has 4 pillars (Rule 30, enforcer E50)
-#  33.  release_note_references_four_pillars            -- latest release note mentions all 4 pillars by name (Rule 30, enforcer E51)
-#  36.  domain_module_has_spi_package                   -- every kind:domain module declares spi_packages and each one resolves on disk (Rule 32, enforcer E54)
-#  --- W1 Layered 4+1 + Architecture Graph (ADR-0068) ---
-#  37.  architecture_artefact_front_matter             -- every ARCH/L2/ADR.yaml carries level: + view: front-matter (Rule 33, enforcer E55)
-#  38.  architecture_graph_well_formed                 -- generated architecture-graph.yaml builds + validates (Rule 34, enforcer E56)
-#  39.  review_proposal_front_matter                   -- docs/logs/reviews/*.md front-matter is OPTIONAL (interaction records); validated only when a doc opts into 4+1 proposal classification (Rule 33, enforcer E57)
-#  41.  enforcer_anchor_resolves                       -- every artifact: anchor resolves to real method/heading (Phase M, enforcer E60)
-#  42.  architecture_graph_idempotent                  -- twice-run graph build is byte-identical (Phase M, enforcer E61)
-#  44.  frozen_doc_edit_path_compliance                -- freeze_id-tagged file edits require docs/logs/reviews/*.md proposal (Phase M, enforcer E63)
-#  --- W1.x L0 ironclad-rule enforcers (ADR-0069) ---
-#  46.  cursor_flow_documented                         -- openapi-v1.yaml declares TaskCursor schema + x-cursor-flow annotation (Rule 36 / P-F, enforcer E65)
-#  49.  deployment_plane_in_module_metadata            -- every module-metadata.yaml declares deployment_plane (Rule 39 / P-I, enforcer E68)
-#  50.  rls_for_new_tenant_tables                      -- Flyway migrations with tenant_id enable RLS or are grandfathered (Rule 40 / P-J, enforcer E69)
-#  51.  skill_capacity_yaml_present_and_wellformed     -- skill-capacity.yaml schema check (Rule 41 / P-K, enforcer E70)
-#  52.  sandbox_policies_yaml_present_and_wellformed   -- sandbox-policies.yaml default_policy 6 keys (Rule 42 / P-L, enforcer E71)
-#  --- W1.x Phase 8 — Cursor Flow runtime activation (ADR-0070) ---
-#  53.  cursor_flow_integration_test_present           -- RunCursorFlowIT asserts POST /v1/runs returns 202 within 200ms even with a 30s-blocking dispatcher (Rule 36.b / P-F, enforcer E72)
-#  --- W1.x Phase 9 — ResilienceContract runtime activation (ADR-0070) ---
-#  54.  skill_capacity_runtime_resolver_present        -- DefaultSkillResilienceContract implements resolve(tenant, skill) consulting SkillCapacityRegistry; rejection carries SuspendReason.RateLimited (Rule 41.b / P-K, enforcer E73)
-#  --- W2.x Phase 1 — Engine Envelope + Strict Matching (ADR-0072) ---
-#  --- W2.x Phase 2 — Engine Hooks + Runtime Middleware SPI (ADR-0073) ---
-#  --- W2.x Phase 3 — S2C Capability Callback (ADR-0074) ---
-#  58.  s2c_callback_yaml_present_and_wellformed       -- docs/contracts/s2c-callback.v1.yaml declares request+response shape with 6 mandatory request fields and outcome enum (Rule 46 / P-M, enforcer E81)
-#  --- W2.x Phase 6 — Schema-First Domain Contracts (ADR-0077, Rule 48) ---
-#  --- v2.0.0-rc2 second-pass review closure (F-α / F-β / F-γ category audit) ---
-#  62.  contract_yaml_declares_status                   -- every docs/contracts/*.v1.yaml + 3 governance YAMLs declare top-level status: with allowed enum value (F-β structural prevention)
-#  --- 2026-05-17 cross-corpus consistency audit prevention rules (G1/G2/G3 closure, enforcers E94-E96) ---
-#  --- 2026-05-17 CLAUDE.md token-optimization wave PR1 (enforcers E97-E101) ---
-#  --- 2026-05-17 gate-script efficiency wave PR-E1 (enforcer E103) ---
-#  --- 2026-05-18 Linux-first dev environment policy (enforcer E104) ---
-#  74.  linux_first_dev_doc_present                      -- docs/governance/dev-environment.md exists + recommends WSL2/WSL1/Linux for verification (Rule 74 / PR-E7, enforcer E104)
-#  --- 2026-05-18 SPI metadata integrity wave (Rules 75-78; enforcers E105-E111) ---
-#  --- 2026-05-18 rc4 cross-constraint review response prevention wave (Rules 80-83; enforcers E113-E116) ---
-#  --- 2026-05-18 rc5 post-response review response prevention wave (Rules 84-85; enforcers E117-E118) ---
-#  84.  active_module_architecture_path_truth           -- every architecture/docs/L1/agent-*.md architecture/docs/L1/agent-service/ARCHITECTURE.md (status != skeleton|deferred) inline path claim "<module>/src/main/java/..." must resolve on disk OR carry a historical/moved/extracted-per-ADR/superseded/deferred marker within +/-3 lines (rc5 P0-1 prevention, enforcer E117)
-#  85.  catalog_spi_row_matches_module_spi_metadata     -- every non-(internal) row in contract-catalog.md SPI table must have its package in <module>/module-metadata.yaml#spi_packages AND docs/dfx/<module>.yaml#spi_packages; the (N total) header MUST equal the non-internal row count (rc5 P1-2 prevention, enforcer E118)
-#  --- 2026-05-19 rc10 post-corrective review response prevention wave (Rules 99-100 + Rule 94/98 widening; enforcers E139-E142) ---
-#  99.  kernel_terminal_verb_vs_shipped_decision_check  -- For every #### Rule N kernel block in CLAUDE.md with a matching ## Rule N.<letter> sub-clause in CLAUDE-deferred.md, the kernel MUST NOT use end-state verb tokens (`are SUSPENDED`, `is SUSPENDED`, `transitions to FAILED`, `consumes the * capacity`, `is rejected, not failed`, `admits the caller`) that overclaim shipped behaviour. Closes rc10 P1-1 (J-α family; Rule 41 kernel said "callers are SUSPENDED" while shipped code returns SkillResolution.reject — the actual transition is deferred to Rule 41.c).
-#  100. kernel_implementation_disjunction_truth        -- For every rule in gate/rule-100-disjunction-allowlist.txt, BOTH the #### Rule N kernel block in CLAUDE.md AND the matching docs/governance/rules/rule-NN.md card MUST contain explicit disjunction wording (EITHER / OR / either surface / either ... or). Closes rc10 P1-3 (J-γ family; Rule 96 kernel said "MUST contain" while impl accepted EITHER kernel OR card — kernel-AND-impl-OR drift in the rule whose job is preventing such drift).
-#  121. whitebox_quality_reports                     -- Maven SpotBugs/PMD/Checkstyle reports exist; high-confidence SpotBugs + hard-style Checkstyle findings block, PMD is review-trigger summary (Rule G-12, enforcer E169)
+#   The canonical rule list is the `# Rule N — slug` body headers below the prologue
+#   (what gate/check_parallel.sh splits on, and gate/lib/build_release_evidence.py counts).
+#   A numbered duplicate previously lived here but drifted — it listed retired rules and
+#   omitted live ones — so it was removed to keep a single source of truth.
 
 set -uo pipefail
 export LC_ALL=C


### PR DESCRIPTION
The gate's numbered `#  N. slug` header index had become a pure-comment **fossil**: ~30 entries for retired rules, all live rules >58 missing, entry 11 with a stale slug. **Nothing parses it** — `check_parallel.sh` splits on the `# Rule N — slug` *body* headers and `build_release_evidence.py` counts them. So it was dual-truth that could only drift.

Replaced the 70-line fossil with a 4-line pointer to the body headers (the single source); `gate/README.md` updated to match (it had falsely called the header index "the single source of truth").

No rule logic touched. Verified WSL: gate PASS (32 rules) · self-tests 102/102 · `sync_baseline --check` exit 0 · `bash -n` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
