### PR TITLE
fix(runtime): stop flaky CI hang — make InMemoryInternalEventQueue lossless under concurrent producers

### DIFF
--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/queue/InMemoryInternalEventQueue.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/queue/InMemoryInternalEventQueue.java
@@ -3,10 +3,10 @@ package com.huawei.ascend.runtime.queue;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Sinks;
 
-import java.time.Duration;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,6 +19,7 @@ public final class InMemoryInternalEventQueue<T> implements InternalEventQueue<T
 
     private final String queueId;
     private final Sinks.Many<T> sink;
+    private final ReentrantLock emitLock = new ReentrantLock();
     private final AtomicInteger size = new AtomicInteger();
     private final AtomicBoolean subscribed = new AtomicBoolean();
     private final AtomicBoolean closed = new AtomicBoolean();
@@ -43,15 +44,20 @@ public final class InMemoryInternalEventQueue<T> implements InternalEventQueue<T
             throw new IllegalStateException("queue is closed: " + queueId);
         }
         size.incrementAndGet();
-        Sinks.EmitResult result = sink.tryEmitNext(value);
+        // Sinks.many() detects but does not serialize concurrent producers (it returns
+        // FAIL_NON_SERIALIZED), yet the queue contract requires multiple producer threads.
+        // Holding emitLock serializes the hand-off into the single-consumer buffer so every
+        // offer succeeds losslessly instead of racing on the sink's busy-loop fallback (which
+        // throws and drops the value once contention outlasts its retry budget).
+        Sinks.EmitResult result;
+        emitLock.lock();
+        try {
+            result = sink.tryEmitNext(value);
+        } finally {
+            emitLock.unlock();
+        }
         if (result == Sinks.EmitResult.OK) {
             LOGGER.debug("trace stage=queue-offer queueId={} payloadType={} size={} durationMs={}",
-                    queueId, value.getClass().getSimpleName(), size.get(), elapsedMs(startedNanos));
-            return;
-        }
-        if (result == Sinks.EmitResult.FAIL_NON_SERIALIZED) {
-            sink.emitNext(value, Sinks.EmitFailureHandler.busyLooping(Duration.ofMillis(100)));
-            LOGGER.debug("trace stage=queue-offer queueId={} payloadType={} size={} retry=nonSerialized durationMs={}",
                     queueId, value.getClass().getSimpleName(), size.get(), elapsedMs(startedNanos));
             return;
         }
@@ -59,6 +65,11 @@ public final class InMemoryInternalEventQueue<T> implements InternalEventQueue<T
         if (result == Sinks.EmitResult.FAIL_ZERO_SUBSCRIBER) {
             LOGGER.warn("queue offer dropped queueId={} payloadType={} reason=zeroSubscriber",
                     queueId, value.getClass().getSimpleName());
+            return;
+        }
+        if (result == Sinks.EmitResult.FAIL_TERMINATED || result == Sinks.EmitResult.FAIL_CANCELLED) {
+            LOGGER.warn("queue offer dropped queueId={} payloadType={} reason={}",
+                    queueId, value.getClass().getSimpleName(), result);
             return;
         }
         throw new IllegalStateException("queue offer failed for " + queueId + ": " + result);
@@ -87,7 +98,12 @@ public final class InMemoryInternalEventQueue<T> implements InternalEventQueue<T
     public void close() {
         if (closed.compareAndSet(false, true)) {
             size.set(0);
-            sink.tryEmitComplete();
+            emitLock.lock();
+            try {
+                sink.tryEmitComplete();
+            } finally {
+                emitLock.unlock();
+            }
             LOGGER.info("queue closed queueId={}", queueId);
         }
     }

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/queue/InternalEventQueueTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/queue/InternalEventQueueTest.java
@@ -21,6 +21,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class InternalEventQueueTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(InternalEventQueueTest.class);
+    // Bound every verification so a regression that starves the consumer fails fast here
+    // instead of blocking the whole Surefire fork indefinitely.
+    private static final Duration VERIFY_TIMEOUT = Duration.ofSeconds(30);
 
     @Test
     void streamReceivesOfferedValuesAndCloseCompletesConsumer() {
@@ -30,7 +33,7 @@ class InternalEventQueueTest {
                 .then(() -> queue.offer("first"))
                 .expectNext("first")
                 .then(queue::close)
-                .verifyComplete();
+                .expectComplete().verify(VERIFY_TIMEOUT);
     }
 
     @Test
@@ -41,7 +44,7 @@ class InternalEventQueueTest {
 
         StepVerifier.create(queue.stream().take(1))
                 .expectNext("early")
-                .verifyComplete();
+                .expectComplete().verify(VERIFY_TIMEOUT);
     }
 
     @Test
@@ -54,7 +57,7 @@ class InternalEventQueueTest {
                         .hasMessageContaining("single consumer"))
                 .then(() -> queue.offer("first"))
                 .expectNext("first")
-                .verifyComplete();
+                .expectComplete().verify(VERIFY_TIMEOUT);
     }
 
     @Test
@@ -81,7 +84,7 @@ class InternalEventQueueTest {
         StepVerifier.create(queue.stream().take(producerCount * eventsPerProducer))
                 .then(start::countDown)
                 .expectNextCount(producerCount * eventsPerProducer)
-                .verifyComplete();
+                .expectComplete().verify(VERIFY_TIMEOUT);
 
         executor.shutdownNow();
     }
@@ -115,7 +118,7 @@ class InternalEventQueueTest {
                     assertThat(new HashSet<>(values)).hasSize(expectedEvents);
                     assertThat(values).contains(0, expectedEvents - 1);
                 })
-                .verifyComplete();
+                .expectComplete().verify(VERIFY_TIMEOUT);
 
         executor.shutdownNow();
     }
@@ -167,7 +170,7 @@ class InternalEventQueueTest {
                             latencyMicros.getMax());
                     assertThat(totalDurationMs).isLessThan(5_000L);
                 })
-                .verifyComplete();
+                .expectComplete().verify(VERIFY_TIMEOUT);
 
         executor.shutdownNow();
     }
@@ -181,7 +184,7 @@ class InternalEventQueueTest {
         assertThat(queue.size()).isEqualTo(1);
         StepVerifier.create(queue.stream().take(1))
                 .expectNext("first")
-                .verifyComplete();
+                .expectComplete().verify(VERIFY_TIMEOUT);
         assertThat(queue.size()).isZero();
     }
 
@@ -205,7 +208,7 @@ class InternalEventQueueTest {
                 .then(() -> queue.offer("late"))
                 .expectNext("late")
                 .thenCancel()
-                .verify();
+                .verify(VERIFY_TIMEOUT);
     }
 
     private record TimedEvent(int id, long createdNanos) {


### PR DESCRIPTION
## Problem
The flaky CI hang (observed: agent-runtime Maven verify running 28+ min before `timeout-minutes: 30` killed it) is **`InternalEventQueueTest`**. Same test passes on most runs; under CI's 2-core contention it hangs.

## Root cause (reproduced)
`InternalEventQueue` contracts *"support multiple producer threads"*, but `InMemoryInternalEventQueue.offer()` emitted through `Sinks.many().unicast()` + `tryEmitNext` with a `busyLooping(100ms)` fallback that **throws and drops the value** once concurrent-emit contention outlasts its retry budget. A dropped event leaves the stress test's `.take(N)` one short, and its **no-timeout `StepVerifier`** then blocks the whole Surefire fork forever.

Reproduced deterministically on the **first** 2-core-pinned run (`taskset -c 0,1`).

## Fix
1. **`InMemoryInternalEventQueue`** — serialize emission with a `ReentrantLock` around `tryEmitNext`/`tryEmitComplete`; serialized emits into the single-consumer buffer never hit `FAIL_NON_SERIALIZED`, so no event is dropped. Honors the multi-producer contract.
2. **`InternalEventQueueTest`** — bound every `StepVerifier` with `verify(Duration)` (30s) so a future regression fails fast instead of hanging the fork.

## Verification
- Pre-fix: hung on the 1st 2-core run.
- Post-fix: **25/25 green** 2-core runs (`Tests run: 9, Failures: 0, Errors: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)