### PR TITLE
fix(runtime): publish absolute A2A agent card URLs

### DIFF
--- a/agent-runtime/README.md
+++ b/agent-runtime/README.md
@@ -72,6 +72,12 @@ Current built-in properties are:
 
 - `agent-runtime.access.a2a.default-tenant-id`
 - `agent-runtime.access.a2a.default-agent-id`
+- `agent-runtime.access.a2a.public-base-url`
+
+`public-base-url` is the externally reachable runtime base URL used when
+publishing absolute A2A endpoint URLs in `/.well-known/agent-card.json`. If it is
+blank, the discovery controller derives a local base URL from the current HTTP
+request.
 
 The local example sets:
 
@@ -81,6 +87,7 @@ agent-runtime:
     a2a:
       default-tenant-id: sample-tenant
       default-agent-id: openjiuwen-react-agent
+      # public-base-url: https://agents.example.com/runtime-one
 ```
 
 ## Exposed A2A endpoints

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/access/config/AccessLayerConfiguration.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/access/config/AccessLayerConfiguration.java
@@ -62,8 +62,10 @@ public class AccessLayerConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    A2aWellKnownAgentCardController a2aWellKnownAgentCardController(AgentCard agentCard) {
-        return new A2aWellKnownAgentCardController(agentCard);
+    A2aWellKnownAgentCardController a2aWellKnownAgentCardController(
+            AgentCard agentCard,
+            A2aAccessProperties properties) {
+        return new A2aWellKnownAgentCardController(agentCard, properties);
     }
 
     @Bean

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/access/protocol/a2a/A2aAccessProperties.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/access/protocol/a2a/A2aAccessProperties.java
@@ -7,6 +7,7 @@ public class A2aAccessProperties {
 
     private String defaultTenantId;
     private String defaultAgentId;
+    private String publicBaseUrl;
 
     public String getDefaultTenantId() {
         return defaultTenantId;
@@ -22,5 +23,13 @@ public class A2aAccessProperties {
 
     public void setDefaultAgentId(String defaultAgentId) {
         this.defaultAgentId = defaultAgentId;
+    }
+
+    public String getPublicBaseUrl() {
+        return publicBaseUrl;
+    }
+
+    public void setPublicBaseUrl(String publicBaseUrl) {
+        this.publicBaseUrl = publicBaseUrl;
     }
 }

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/access/protocol/a2a/A2aWellKnownAgentCardController.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/access/protocol/a2a/A2aWellKnownAgentCardController.java
@@ -1,7 +1,11 @@
 package com.huawei.ascend.runtime.access.protocol.a2a;
 
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.util.List;
 import java.util.Objects;
 import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentInterface;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -10,17 +14,89 @@ import org.springframework.web.bind.annotation.RestController;
 public final class A2aWellKnownAgentCardController {
 
     private final AgentCard agentCard;
+    private final A2aAccessProperties properties;
 
-    public A2aWellKnownAgentCardController(AgentCard agentCard) {
+    public A2aWellKnownAgentCardController(AgentCard agentCard, A2aAccessProperties properties) {
         this.agentCard = Objects.requireNonNull(agentCard, "agentCard");
+        this.properties = Objects.requireNonNull(properties, "properties");
     }
 
     @GetMapping("/.well-known/agent-card.json")
-    public ResponseEntity<AgentCard> getAgentCard() {
-        return ResponseEntity.ok(agentCard);
+    public ResponseEntity<AgentCard> getAgentCard(HttpServletRequest request) {
+        return ResponseEntity.ok(resolveUrls(baseUrl(request)));
+    }
+
+    private AgentCard resolveUrls(String baseUrl) {
+        return AgentCard.builder(agentCard)
+                .url(resolveUrl(baseUrl, agentCard.url()))
+                .supportedInterfaces(resolveInterfaces(baseUrl))
+                .build();
+    }
+
+    private List<AgentInterface> resolveInterfaces(String baseUrl) {
+        if (agentCard.supportedInterfaces() == null) {
+            return null;
+        }
+        return agentCard.supportedInterfaces().stream()
+                .map(agentInterface -> new AgentInterface(
+                        agentInterface.protocolBinding(),
+                        resolveUrl(baseUrl, agentInterface.url()),
+                        agentInterface.tenant(),
+                        agentInterface.protocolVersion()))
+                .toList();
+    }
+
+    private static String resolveUrl(String baseUrl, String url) {
+        if (url == null || url.isBlank()) {
+            return url;
+        }
+        URI uri = URI.create(url);
+        if (uri.isAbsolute()) {
+            return url;
+        }
+        return appendPath(baseUrl, url);
+    }
+
+    private static String appendPath(String baseUrl, String path) {
+        return stripTrailingSlash(baseUrl) + "/" + stripLeadingSlash(path);
+    }
+
+    private static String stripLeadingSlash(String value) {
+        String result = value;
+        while (result.startsWith("/")) {
+            result = result.substring(1);
+        }
+        return result;
+    }
+
+    private String baseUrl(HttpServletRequest request) {
+        String configured = properties.getPublicBaseUrl();
+        if (configured != null && !configured.isBlank()) {
+            return stripTrailingSlash(configured.strip());
+        }
+        return requestOrigin(request);
+    }
+
+    private static String stripTrailingSlash(String value) {
+        if (value.endsWith("/")) {
+            return value.substring(0, value.length() - 1);
+        }
+        return value;
+    }
+
+    private static String requestOrigin(HttpServletRequest request) {
+        StringBuilder origin = new StringBuilder(request.getScheme())
+                .append("://")
+                .append(request.getServerName());
+        int port = request.getServerPort();
+        if (!isDefaultPort(request.getScheme(), port)) {
+            origin.append(':').append(port);
+        }
+        return origin.toString();
+    }
+
+    private static boolean isDefaultPort(String scheme, int port) {
+        return ("http".equalsIgnoreCase(scheme) && port == 80)
+                || ("https".equalsIgnoreCase(scheme) && port == 443);
     }
 }
-
-
-
-

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/access/protocol/a2a/A2aAccessPropertiesBindingTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/access/protocol/a2a/A2aAccessPropertiesBindingTest.java
@@ -17,12 +17,14 @@ class A2aAccessPropertiesBindingTest {
         contextRunner
                 .withPropertyValues(
                         "agent-runtime.access.a2a.default-tenant-id=tenant-from-runtime-prefix",
-                        "agent-runtime.access.a2a.default-agent-id=agent-from-runtime-prefix")
+                        "agent-runtime.access.a2a.default-agent-id=agent-from-runtime-prefix",
+                        "agent-runtime.access.a2a.public-base-url=https://agents.example.com/runtime-one")
                 .run(context -> {
                     A2aAccessProperties properties = context.getBean(A2aAccessProperties.class);
 
                     assertThat(properties.getDefaultTenantId()).isEqualTo("tenant-from-runtime-prefix");
                     assertThat(properties.getDefaultAgentId()).isEqualTo("agent-from-runtime-prefix");
+                    assertThat(properties.getPublicBaseUrl()).isEqualTo("https://agents.example.com/runtime-one");
                 });
     }
 

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/access/protocol/a2a/A2aWellKnownAgentCardControllerTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/access/protocol/a2a/A2aWellKnownAgentCardControllerTest.java
@@ -1,0 +1,71 @@
+package com.huawei.ascend.runtime.access.protocol.a2a;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.a2aproject.sdk.spec.AgentCapabilities;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentInterface;
+import org.a2aproject.sdk.spec.TransportProtocol;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class A2aWellKnownAgentCardControllerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void publishesAbsoluteA2aUrlsFromRequestOriginWhenPublicBaseUrlIsNotConfigured() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders
+                .standaloneSetup(new A2aWellKnownAgentCardController(relativeAgentCard(), new A2aAccessProperties()))
+                .build();
+
+        MvcResult result = mockMvc.perform(get("http://runtime.example:18080/.well-known/agent-card.json"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode card = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(card.path("url").asText()).isEqualTo("http://runtime.example:18080/a2a");
+        assertThat(card.path("supportedInterfaces").get(0).path("url").asText())
+                .isEqualTo("http://runtime.example:18080/a2a");
+    }
+
+    @Test
+    void configuredPublicBaseUrlOverridesRequestOriginForPublishedA2aUrls() throws Exception {
+        A2aAccessProperties properties = new A2aAccessProperties();
+        properties.setPublicBaseUrl("https://agents.example.com/runtime-one");
+        MockMvc mockMvc = MockMvcBuilders
+                .standaloneSetup(new A2aWellKnownAgentCardController(relativeAgentCard(), properties))
+                .build();
+
+        MvcResult result = mockMvc.perform(get("http://internal:8080/.well-known/agent-card.json"))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode card = objectMapper.readTree(result.getResponse().getContentAsString());
+        assertThat(card.path("url").asText()).isEqualTo("https://agents.example.com/runtime-one/a2a");
+        assertThat(card.path("supportedInterfaces").get(0).path("url").asText())
+                .isEqualTo("https://agents.example.com/runtime-one/a2a");
+    }
+
+    private static AgentCard relativeAgentCard() {
+        return AgentCard.builder()
+                .name("sample")
+                .description("sample")
+                .url("/a2a")
+                .version("1")
+                .capabilities(AgentCapabilities.builder().streaming(true).build())
+                .defaultInputModes(List.of("text"))
+                .defaultOutputModes(List.of("text"))
+                .skills(List.of())
+                .supportedInterfaces(List.of(new AgentInterface(TransportProtocol.JSONRPC.asString(), "/a2a")))
+                .preferredTransport(TransportProtocol.JSONRPC.asString())
+                .build();
+    }
+}

--- a/examples/agent-runtime-a2a-llm-e2e/README.cn.md
+++ b/examples/agent-runtime-a2a-llm-e2e/README.cn.md
@@ -1,0 +1,321 @@
+# Agent Runtime A2A LLM E2E 示例
+
+## 目的
+
+本示例演示如何启动一个 `agent-runtime` 应用：它暴露 A2A 端点，在端点后托管一个 openJiuwen ReAct agent，并只从 A2A 客户端视角验证整条链路。
+
+示例位于 `examples/agent-runtime-a2a-llm-e2e`，包含：
+
+- Spring Boot 服务端：`com.huawei.ascend.examples.a2a.OpenJiuwenA2aAgentRuntimeApplication`
+- 控制台客户端：`com.huawei.ascend.examples.a2a.A2aConsoleClientApplication`
+- 一个端到端测试：通过本地 OpenAI-compatible LLM gateway 验证 A2A 流程
+
+## 验证内容
+
+本示例验证以下边界：
+
+1. `agent-runtime` 通过 A2A 托管并暴露 agent。
+2. 客户端发现 `/.well-known/agent-card.json`。
+3. 客户端向 `/a2a` 发送 streaming JSON-RPC 请求。
+4. 客户端读取 A2A 流式事件，直到运行完成。
+5. 输入 `ping` 时，最终可见回答是 `pong`。
+
+当前自动化 E2E 测试断言 `ping -> pong` 行为。
+
+## Gateway Facade 示例
+
+本模块还包含一个最小 Gateway facade 示例，位于
+`com.huawei.ascend.examples.a2a.gateway`。它展示平台层如何维护多个单 agent runtime 实例注册表，并暴露少量 HTTP facade 能力：
+
+- runtime 自注册、续租、注销
+- 租户范围内的 agent 列表和 AgentCard 查询
+- 按 `tenantId` 和 `agentId` 做路由解析
+- 面向客户参考的最小 A2A JSON-RPC 转发端点
+- runtime-to-runtime A2A 调用的租户级 `RouteGrant` 签发和校验
+- 异步 A2A 交互遥测记录和查询 API
+
+该 facade 示例故意保持本地、内存态。它是面向客户的可插拔 gateway 集成示例，不是生产 `agent-service` 实现。
+
+### Runtime-to-Runtime 发现与遥测
+
+对于东西向 runtime 调用，示例让 examples 层承担发现、路由策略和可观测性职责，但不强制所有 runtime-to-runtime payload 都经过 examples 数据面：
+
+1. source runtime 向 facade 请求短期 `RouteGrant`
+2. facade 解析健康的 target runtime 并签发 grant
+3. source runtime 直接调用 target runtime A2A 端点
+4. target runtime 在接受调用前校验 grant
+5. source 和 target runtime 异步上报交互遥测
+
+示例暴露的最小 HTTP 端点：
+
+- `POST /v1/route-grants/resolve`
+- `POST /v1/route-grants/validate`
+- `POST /v1/a2a-interactions`
+- `GET /v1/a2a-interactions?tenantId=...&correlationId=...`
+
+这让 runtime 缓存保持较小：runtime 缓存的是带 TTL 和 policy version 的 scoped grant，而不是完整的 `tenantId x sourceAgentId x targetAgentId x replica` 授权表。
+
+### Gateway DFX 参考形态
+
+Gateway facade 示例不是五个九生产 gateway，但它展示了客户侧平台 facade 应具备的最小 DFX 形态：
+
+- runtime 注册记录携带 TTL / lease 信息
+- 过期 lease 标记为 `UNREACHABLE`，且不再可路由
+- cold、draining、unreachable、at-capacity runtime fail closed，并返回明确错误码
+- 多个 runtime 副本通过同一 route view 解析，只有 `READY` 副本能接收新流量
+- A2A 转发端点返回路由解析、响应开始、总转发耗时和选中 runtime instance 的 trace header
+- route grant 短期有效、租户级、方法级、带签名
+- A2A interaction telemetry 携带 correlation、route latency、first-byte latency、total latency、status 和 selected runtime identity
+
+生产部署仍需补齐持久或可重建的 registry 状态、runtime 身份认证、租户-agent 授权、限流、熔断、多 AZ 部署、同城容灾、跨区域恢复、SLA/SLO 看板和 error-budget 治理。
+
+## 快速开始：配置模板 + 脚本
+
+进入 `examples/agent-runtime-a2a-llm-e2e` 目录后，复制一个模板，填好配置，然后通过 helper 脚本运行：
+
+```bash
+cp .env.openai-compatible.example .env   # 或复制 .env.ollama.example 后再编辑
+bash scripts/test-e2e.sh .env            # 安装 agent-runtime 并运行 E2E suite
+# Windows: ./scripts/test-e2e.ps1 -EnvFile .env
+```
+
+手工验证服务端时，推荐使用 server helper 脚本，因为它会在启动 Spring Boot 前加载 env 文件：
+
+```bash
+bash scripts/run-server.sh .env
+# Windows: ./scripts/run-server.ps1 -EnvFile .env
+```
+
+模板说明：你填写的 `.env` 已 gitignore；`*.example` 模板会被提交到仓库。
+
+- `.env.example` — 列出所有变量，并带内联说明。
+- `.env.ollama.example` — 本地 Ollama，通过 OpenAI-compatible `/v1` 接口访问，默认模型 `gemma4:latest`。
+- `.env.openai-compatible.example` — 云端 OpenAI-compatible API 模板，不包含真实 key。
+
+> `.env` 不会被 Maven 或 Spring Boot 自动加载。helper 脚本会先 source env 文件，再启动 Maven。如果直接运行 `./mvnw ... spring-boot:run`，Java 进程只能看到当前 shell 已经 export 的变量。
+
+> 真实 LLM E2E 测试 `OpenJiuwenReactAgentA2aE2eTest` 只有在 `SAA_SAMPLE_LLM_API_KEY` 非空时才运行。未设置时，JUnit `assumeTrue()` 会在 agent-card 断言后跳过真实 LLM 分支；suite 中其他部分仍会运行。
+
+## 哪些环境变量会真正生效？
+
+Maven 和 Spring Boot 只会看到启动时传入 Java 进程的环境变量。实际生效规则如下：
+
+1. **helper 脚本加载的 env 文件值** — `scripts/run-server.sh` 和 `scripts/test-e2e.sh` 会加载传入的 env 文件；未传参数时默认加载本示例目录下的 `.env`。如果 env 文件定义了某个变量，它会覆盖运行脚本的 shell 中已 export 的同名变量。
+2. **显式 shell 环境变量** — 当你直接运行 Maven，或 helper 脚本加载的 env 文件没有定义某个变量时，Maven 会看到启动 shell 中已 export 的变量，例如 `export SAA_SAMPLE_LLM_API_KEY=...`。
+3. **Spring Boot 默认值** — 如果 Java 进程看不到环境变量，就使用 `src/main/resources/application.yaml` 中的默认值。
+
+仓库内默认值是面向本地 OpenAI-compatible gateway 的占位配置：
+
+```yaml
+sample:
+  openjiuwen:
+    model-provider: ${SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER:openai}
+    api-key: ${SAA_SAMPLE_LLM_API_KEY:sk-local-placeholder}
+    api-base: ${SAA_SAMPLE_OPENJIUWEN_API_BASE:http://localhost:4000/v1}
+    model-name: ${SAA_SAMPLE_LLM_MODEL:gpt-5.4-mini}
+    ssl-verify: ${SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY:false}
+```
+
+`sk-local-placeholder` 是**不可用占位 key**，不是实际 key。Ollama 这类本地 gateway 通常忽略 `Authorization` header，所以任意字符串都可用；如果你使用云端 API 或会校验 key 的本地 gateway，请设置 `SAA_SAMPLE_LLM_API_KEY`，并通过 `scripts/run-server.sh .env` 启动，或在运行 Maven 前手工 export。
+
+从仓库根目录手工加载 `.env` 的方式：
+
+```bash
+set -a
+. ./examples/agent-runtime-a2a-llm-e2e/.env
+set +a
+./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml spring-boot:run
+```
+
+如果你已经启动了 server，修改 `.env` 不会影响正在运行的 Java 进程。需要停止旧 server 后重新启动。
+
+## 本地 LLM 默认值和 curl 检查
+
+示例默认指向本地 OpenAI-compatible gateway。启动 sample 前，可以先直接检查 gateway：
+
+```bash
+curl http://localhost:4000/v1/models \
+  -H 'Authorization: Bearer sk-local-placeholder'
+```
+
+如果你的 gateway 会校验 key，请使用 `.env` 中同一个 key：
+
+```bash
+curl http://localhost:4000/v1/models \
+  -H "Authorization: Bearer ${SAA_SAMPLE_LLM_API_KEY}"
+```
+
+如果 gateway 使用其他 key、host 或 model，请覆盖下方环境变量。
+
+## 可覆盖的环境变量
+
+本示例使用的 runtime 配置前缀是 `agent-runtime.access.a2a`：
+
+```yaml
+agent-runtime:
+  access:
+    a2a:
+      default-tenant-id: sample-tenant
+      default-agent-id: openjiuwen-react-agent
+      # public-base-url: https://agents.example.com/runtime-one
+```
+
+`public-base-url` 对本地运行是可选的。为空时，agent-card 端点会根据当前 HTTP 请求推导 base URL。生产环境建议显式设置为 runtime 的外部可访问 base URL，这样标准 A2A client 能拿到不依赖本地 host/port 推断的绝对 endpoint URL。
+
+LLM 相关变量：
+
+- `SAA_SAMPLE_LLM_API_KEY`
+- `SAA_SAMPLE_OPENJIUWEN_API_BASE`
+- `SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER`
+- `SAA_SAMPLE_LLM_MODEL`
+- `SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY`
+
+控制台客户端支持位置参数或环境变量：
+
+- 第 1 个参数或 `SAA_SAMPLE_A2A_BASE_URL`：A2A server base URL，默认 `http://localhost:8080`
+- 第 2 个参数或 `SAA_SAMPLE_AGENT_ID`：agent id，默认 `openjiuwen-react-agent`
+- 第 3 个参数或 `SAA_SAMPLE_USER_ID`：user id，默认 `manual-user`
+
+示例覆盖：
+
+```bash
+export SAA_SAMPLE_LLM_API_KEY="<your-key>"
+export SAA_SAMPLE_OPENJIUWEN_API_BASE="http://localhost:4000/v1"
+export SAA_SAMPLE_LLM_MODEL="gpt-5.4-mini"
+export SAA_SAMPLE_A2A_BASE_URL="http://localhost:18080"
+```
+
+## 安装 runtime 依赖
+
+该 example 位于 root Maven reactor 外部，因此需要先把 runtime 依赖安装到本地 Maven 仓库：
+
+```bash
+./mvnw -pl agent-runtime -am -DskipTests install
+```
+
+这样 `examples/agent-runtime-a2a-llm-e2e` 就能解析当前的 `agent-runtime` snapshot。
+
+`bash scripts/run-server.sh .env` 会在启动服务前自动执行安装步骤。
+
+## 自动化测试
+
+推荐通过 helper 脚本运行示例测试模块：
+
+```bash
+bash scripts/test-e2e.sh .env
+```
+
+测试会启动示例应用，通过 A2A 客户端流程调用它，并期望 `ping` 的可见响应是 `pong`。
+
+如果你已经手工 export 所需变量，也可以直接运行 Maven：
+
+```bash
+./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml test
+```
+
+## 手工验证
+
+1. 确认本地 OpenAI-compatible endpoint 可访问。
+2. 使用 env-loading helper 脚本启动服务端：
+
+```bash
+bash scripts/run-server.sh .env
+```
+
+该脚本会加载 `.env`、安装 `agent-runtime`，然后启动 Spring Boot server。若旧 server 已在运行，请先停止旧进程；修改 `.env` 不会更新已运行 Java 进程的配置。
+
+3. 在另一个终端启动控制台客户端：
+
+```bash
+./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml \
+  exec:java \
+  -Dexec.mainClass=com.huawei.ascend.examples.a2a.A2aConsoleClientApplication
+```
+
+4. 在提示符中输入：
+
+```text
+ping
+```
+
+5. 确认打印响应是 `pong`。
+
+如果要指定其他 server，请把 base URL 作为第一个参数传入：
+
+```bash
+./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml \
+  exec:java \
+  -Dexec.mainClass=com.huawei.ascend.examples.a2a.A2aConsoleClientApplication \
+  -Dexec.args="http://localhost:18080"
+```
+
+server 启动后，也可以直接用 curl 验证 A2A surface。
+
+检查 agent card：
+
+```bash
+curl http://localhost:8080/.well-known/agent-card.json
+```
+
+向 `/a2a` 发送 streaming JSON-RPC 请求：
+
+```bash
+curl http://localhost:8080/a2a \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: text/event-stream' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "manual-1",
+    "method": "message/stream",
+    "params": {
+      "message": {
+        "role": "user",
+        "messageId": "manual-message-1",
+        "contextId": "manual-session-1",
+        "metadata": {
+          "userId": "manual-user",
+          "agentId": "openjiuwen-react-agent",
+          "sessionId": "manual-session-1"
+        },
+        "parts": [
+          {
+            "kind": "text",
+            "text": "ping"
+          }
+        ]
+      }
+    }
+  }'
+```
+
+SSE stream 应包含 accepted event，然后出现 completed response，用户可见文本为 `pong`。
+
+## 期望的 ping/pong 路径
+
+正常 happy path：
+
+- 输入：`ping`
+- 从 `/.well-known/agent-card.json` 发现 agent card
+- 向 `/a2a` 发送 JSON-RPC streaming 请求
+- 最终可见回答：`pong`
+
+## 排错
+
+- `Could not resolve com.huawei.ascend:agent-runtime:<version>`
+  - 先运行 `./mvnw -pl agent-runtime -am -DskipTests install`。
+
+- server 启动成功，但模型调用失败。
+  - 检查 `SAA_SAMPLE_LLM_API_KEY`、`SAA_SAMPLE_OPENJIUWEN_API_BASE` 和 `SAA_SAMPLE_LLM_MODEL`。
+  - 确认本地 gateway 能响应：`curl http://localhost:4000/v1/models -H 'Authorization: Bearer ...'`。
+  - 如果 gateway 用真实 key 能成功，但 sample 表现像仍在用 placeholder key，请停止 server，并用 `bash scripts/run-server.sh .env` 重启。
+  - 如果 `/v1/models` 成功但 sample 仍失败，请用同一个 key 和 model 直接测试 gateway 的 `/v1/chat/completions` 端点。
+
+- 控制台客户端连不上。
+  - 确认 server 运行在 `http://localhost:8080`，或通过 `SAA_SAMPLE_A2A_BASE_URL` / 第一个 CLI 参数传入正确 base URL。
+
+- A2A 调用没有最终回答。
+  - 检查 stream 是否到达 completed event。
+  - 重新运行自动化测试，验证期望的 `ping -> pong` 路径。
+
+- 本地 gateway TLS 或证书问题。
+  - 检查 `SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY`；本示例本地默认值为 `false`。

--- a/examples/agent-runtime-a2a-llm-e2e/README.md
+++ b/examples/agent-runtime-a2a-llm-e2e/README.md
@@ -87,13 +87,20 @@ cross-region recovery, SLA/SLO dashboards, and error-budget governance.
 
 ## Quick start (config templates + scripts)
 
-Copy a template, fill it, and run — the env file is the only thing that differs
-between a local Ollama and a cloud OpenAI-compatible API; the command is identical:
+From `examples/agent-runtime-a2a-llm-e2e`, copy a template, fill it, and run through the helper script:
 
 ```bash
-cp .env.ollama.example .env        # or .env.openai-compatible.example, then edit
-bash scripts/test-e2e.sh .env      # installs agent-runtime + runs the E2E suite
+cp .env.openai-compatible.example .env   # or .env.ollama.example, then edit
+bash scripts/test-e2e.sh .env            # installs agent-runtime + runs the E2E suite
 # Windows: ./scripts/test-e2e.ps1 -EnvFile .env
+```
+
+For manual server verification, prefer the server helper script because it loads
+the env file before starting Spring Boot:
+
+```bash
+bash scripts/run-server.sh .env
+# Windows: ./scripts/run-server.ps1 -EnvFile .env
 ```
 
 Templates (the `.env` you fill is gitignored; the `*.example` templates are tracked):
@@ -102,13 +109,31 @@ Templates (the `.env` you fill is gitignored; the `*.example` templates are trac
 - `.env.ollama.example` — local Ollama via its OpenAI-compatible `/v1` surface (`gemma4:latest`).
 - `.env.openai-compatible.example` — a cloud OpenAI-compatible API (no real key committed).
 
+> `.env` is not loaded automatically by Maven or Spring Boot. The helper scripts
+> load it with shell sourcing before launching Maven. If you run `./mvnw ...
+> spring-boot:run` directly, only variables already exported in your shell are
+> visible to the Java process.
+
 > The real-LLM e2e (`OpenJiuwenReactAgentA2aE2eTest`) only runs when
 > `SAA_SAMPLE_LLM_API_KEY` is non-blank. Without it, JUnit `assumeTrue()` **skips**
 > that branch after the agent-card assertions (the rest of the suite still runs).
 
-## Local LLM Defaults and Curl
+## Which Environment Values Are Effective?
 
-The example is configured for a local OpenAI-compatible gateway by default. The checked-in defaults are env-aware placeholders in `examples/agent-runtime-a2a-llm-e2e/src/main/resources/application.yaml`:
+Maven and Spring Boot see the process environment at launch time. The effective
+values are:
+
+1. **Helper-script env file values** — `scripts/run-server.sh` and
+   `scripts/test-e2e.sh` load the env file argument, defaulting to `.env` in this
+   example directory. If the env file defines a variable, that value overrides a
+   same-name variable that was already exported in the shell running the script.
+2. **Explicit shell environment** — when you run Maven directly, or when a helper
+   script loads an env file that does not define a variable, Maven sees variables
+   already exported in the launching shell, for example `export SAA_SAMPLE_LLM_API_KEY=...`.
+3. **Spring Boot defaults** — if no environment variable is visible to the Java
+   process, the values in `src/main/resources/application.yaml` are used.
+
+The checked-in defaults are placeholders for a local OpenAI-compatible gateway:
 
 ```yaml
 sample:
@@ -120,13 +145,36 @@ sample:
     ssl-verify: ${SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY:false}
 ```
 
-`sk-local-placeholder` is a **non-functional placeholder**, not a usable key: local gateways (Ollama) ignore the `Authorization` header, so any string works. For a real cloud OpenAI-compatible API, set `SAA_SAMPLE_LLM_API_KEY` to your own key.
+`sk-local-placeholder` is a **non-functional placeholder**, not a usable key:
+local gateways such as Ollama ignore the `Authorization` header, so any string
+works there. For a real cloud API or a local gateway that validates keys, set
+`SAA_SAMPLE_LLM_API_KEY` and start the server through `scripts/run-server.sh .env`
+or export the variable before running Maven.
 
-You can sanity-check the local gateway directly before starting the sample:
+Manual export alternative from the repository root:
+
+```bash
+set -a
+. ./examples/agent-runtime-a2a-llm-e2e/.env
+set +a
+./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml spring-boot:run
+```
+
+## Local LLM Defaults and Curl
+
+The example is configured for a local OpenAI-compatible gateway by default. You
+can sanity-check the local gateway directly before starting the sample:
 
 ```bash
 curl http://localhost:4000/v1/models \
   -H 'Authorization: Bearer sk-local-placeholder'
+```
+
+If your gateway validates keys, use the same key that you put in `.env`:
+
+```bash
+curl http://localhost:4000/v1/models \
+  -H "Authorization: Bearer ${SAA_SAMPLE_LLM_API_KEY}"
 ```
 
 If your gateway uses a different key, host, or model, override the environment variables described below.
@@ -141,7 +189,13 @@ agent-runtime:
     a2a:
       default-tenant-id: sample-tenant
       default-agent-id: openjiuwen-react-agent
+      # public-base-url: https://agents.example.com/runtime-one
 ```
+
+`public-base-url` is optional for local runs. When it is blank, the agent-card
+endpoint derives the base URL from the current HTTP request. In production, set
+it to the externally reachable runtime base URL so standard A2A clients receive
+absolute endpoint URLs that do not depend on local host/port inference.
 
 The example also recognizes these environment variables for the local LLM setup:
 
@@ -176,32 +230,38 @@ This example is outside the root Maven reactor, so install the runtime dependenc
 
 That makes the current `agent-runtime` snapshot available to `examples/agent-runtime-a2a-llm-e2e`.
 
+The server helper script performs this install step automatically before starting the server.
+
 ## Automated Test
 
-Run the example test module directly:
+Run the example test module directly through the helper script:
+
+```bash
+bash scripts/test-e2e.sh .env
+```
+
+The test starts the example application, calls it through the A2A client flow, and expects the visible response for `ping` to be `pong`.
+
+If you have already exported the required variables and want to run Maven directly:
 
 ```bash
 ./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml test
 ```
 
-The test starts the example application, calls it through the A2A client flow, and expects the visible response for `ping` to be `pong`.
-
 ## Manual Verification
 
 1. Make sure your local OpenAI-compatible endpoint is reachable.
-2. Install the runtime dependency:
+2. Start the example server with the env-loading helper script:
 
 ```bash
-./mvnw -pl agent-runtime -am -DskipTests install
+bash scripts/run-server.sh .env
 ```
 
-3. Start the example server:
+The script loads `.env`, installs `agent-runtime`, and starts the Spring Boot server.
+If the server is already running, stop it first; changing `.env` does not update an
+already-running Java process.
 
-```bash
-./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml spring-boot:run
-```
-
-4. In another terminal, start the console client:
+3. In another terminal, start the console client:
 
 ```bash
 ./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml \
@@ -209,13 +269,13 @@ The test starts the example application, calls it through the A2A client flow, a
   -Dexec.mainClass=com.huawei.ascend.examples.a2a.A2aConsoleClientApplication
 ```
 
-5. At the prompt, enter:
+4. At the prompt, enter:
 
 ```text
 ping
 ```
 
-6. Confirm the printed response is `pong`.
+5. Confirm the printed response is `pong`.
 
 To target a different server, pass the base URL as the first argument:
 
@@ -284,6 +344,8 @@ Expected happy path:
 - The server starts but the model call fails.
   - Verify `SAA_SAMPLE_LLM_API_KEY`, `SAA_SAMPLE_OPENJIUWEN_API_BASE`, and `SAA_SAMPLE_LLM_MODEL`.
   - Confirm the local gateway responds to `curl http://localhost:4000/v1/models -H 'Authorization: Bearer ...'`.
+  - If the gateway succeeds with your real key but the sample fails with a placeholder-key symptom, stop the server and restart it with `bash scripts/run-server.sh .env`.
+  - If `/v1/models` succeeds but the sample still fails, test the gateway's `/v1/chat/completions` endpoint with the same key and model.
 
 - The console client cannot connect.
   - Confirm the server is running on `http://localhost:8080` or pass the correct base URL through `SAA_SAMPLE_A2A_BASE_URL` or the first CLI argument.

--- a/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/SampleA2aClient.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/SampleA2aClient.java
@@ -14,7 +14,6 @@ import org.a2aproject.sdk.client.http.A2ACardResolver;
 import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransport;
 import org.a2aproject.sdk.client.transport.spi.interceptors.ClientCallContext;
 import org.a2aproject.sdk.spec.AgentCard;
-import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.spec.Part;
 import org.a2aproject.sdk.spec.Message;
 import org.a2aproject.sdk.spec.MessageSendParams;
@@ -22,7 +21,6 @@ import org.a2aproject.sdk.spec.StreamingEventKind;
 import org.a2aproject.sdk.spec.TaskArtifactUpdateEvent;
 import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.a2aproject.sdk.spec.TextPart;
-import org.a2aproject.sdk.spec.TransportProtocol;
 
 public final class SampleA2aClient {
 
@@ -45,7 +43,7 @@ public final class SampleA2aClient {
         CountDownLatch completed = new CountDownLatch(1);
         AtomicReference<Throwable> failure = new AtomicReference<>();
         AtomicBoolean sawTerminal = new AtomicBoolean(false);
-        JSONRPCTransport transport = new JSONRPCTransport(jsonRpcEndpoint(card));
+        JSONRPCTransport transport = new JSONRPCTransport(card);
         try {
             transport.sendMessageStreaming(
                     messageSendParams(userId, agentId, sessionId, text),
@@ -78,19 +76,6 @@ public final class SampleA2aClient {
             throw new IllegalStateException("A2A stream failed", failure.get());
         }
         return List.copyOf(events);
-    }
-
-    String jsonRpcEndpoint(AgentCard card) {
-        String protocol = TransportProtocol.JSONRPC.asString();
-        String endpoint = card.supportedInterfaces().stream()
-                .filter(agentInterface -> protocol.equals(agentInterface.protocolBinding()))
-                .map(AgentInterface::url)
-                .findFirst()
-                .orElse(card.url());
-        if (endpoint == null || endpoint.isBlank()) {
-            throw new IllegalStateException("Agent card does not advertise a JSONRPC endpoint");
-        }
-        return baseUri.resolve(endpoint).toString();
     }
 
     public static String textFrom(List<StreamingEventKind> events) {

--- a/examples/agent-runtime-a2a-llm-e2e/src/test/java/com/huawei/ascend/examples/a2a/OpenJiuwenReactAgentA2aE2eTest.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/test/java/com/huawei/ascend/examples/a2a/OpenJiuwenReactAgentA2aE2eTest.java
@@ -1,7 +1,6 @@
 package com.huawei.ascend.examples.a2a;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.net.URI;
@@ -40,8 +39,8 @@ class OpenJiuwenReactAgentA2aE2eTest {
         assertThat(agentCard.description()).contains("openJiuwen ReAct agent");
         assertThat(agentCard.capabilities().streaming()).isTrue();
         assertThat(agentCard.supportedInterfaces())
-                .extracting(AgentInterface::protocolBinding, AgentInterface::url)
-                .contains(tuple(TransportProtocol.JSONRPC.asString(), "/a2a"));
+                .extracting(AgentInterface::protocolBinding)
+                .contains(TransportProtocol.JSONRPC.asString());
 
         assumeTrue(hasText(System.getenv("SAA_SAMPLE_LLM_API_KEY")),
                 "SAA_SAMPLE_LLM_API_KEY not set; skipping real openJiuwen ReAct agent E2E sample");

--- a/examples/agent-runtime-a2a-llm-e2e/src/test/java/com/huawei/ascend/examples/a2a/RuntimeAppBootTest.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/test/java/com/huawei/ascend/examples/a2a/RuntimeAppBootTest.java
@@ -14,7 +14,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.a2aproject.sdk.spec.AgentCard;
-import org.a2aproject.sdk.spec.AgentInterface;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -38,7 +37,6 @@ class RuntimeAppBootTest {
                     URI.create("http://localhost:" + runtime.port()), TIMEOUT);
 
             AgentCard card = client.agentCard();
-            assertThat(card.supportedInterfaces()).extracting(AgentInterface::url).contains("/a2a");
             assertThat(card.capabilities().streaming()).isTrue();
         }
     }

--- a/examples/agent-runtime-a2a-llm-e2e/src/test/java/com/huawei/ascend/examples/a2a/SampleA2aClientTest.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/test/java/com/huawei/ascend/examples/a2a/SampleA2aClientTest.java
@@ -2,12 +2,7 @@ package com.huawei.ascend.examples.a2a;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.URI;
-import java.time.Duration;
 import java.util.List;
-import org.a2aproject.sdk.spec.AgentCapabilities;
-import org.a2aproject.sdk.spec.AgentCard;
-import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.spec.Artifact;
 import org.a2aproject.sdk.spec.Message;
 import org.a2aproject.sdk.spec.TaskArtifactUpdateEvent;
@@ -15,27 +10,9 @@ import org.a2aproject.sdk.spec.TaskState;
 import org.a2aproject.sdk.spec.TaskStatus;
 import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.a2aproject.sdk.spec.TextPart;
-import org.a2aproject.sdk.spec.TransportProtocol;
 import org.junit.jupiter.api.Test;
 
 class SampleA2aClientTest {
-
-    @Test
-    void resolvesRelativeJsonRpcInterfaceAgainstDiscoveredServiceBaseUri() {
-        SampleA2aClient client = new SampleA2aClient(URI.create("http://localhost:8080"), Duration.ofSeconds(1));
-        AgentCard card = AgentCard.builder()
-                .name("sample")
-                .description("sample")
-                .version("1")
-                .capabilities(AgentCapabilities.builder().streaming(true).build())
-                .defaultInputModes(List.of("text"))
-                .defaultOutputModes(List.of("text"))
-                .skills(List.of())
-                .supportedInterfaces(List.of(new AgentInterface(TransportProtocol.JSONRPC.asString(), "/a2a")))
-                .build();
-
-        assertThat(client.jsonRpcEndpoint(card)).isEqualTo("http://localhost:8080/a2a");
-    }
 
     @Test
     void extractsTextFromAllA2aStreamingEventShapes() {


### PR DESCRIPTION
## Summary
- publish absolute A2A AgentCard endpoint URLs using public-base-url or request origin fallback
- add public-base-url binding and focused controller coverage
- simplify the sample A2A client to delegate endpoint handling to the SDK and document env/public URL behavior

## Tests
- ./mvnw -pl agent-runtime test
- ./mvnw -pl agent-runtime -DskipTests install
- ./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml test

Note: the real LLM branch skips when SAA_SAMPLE_LLM_API_KEY is unset.