### PR TITLE
feat(examples): route by runtime capacity

### DIFF
--- a/examples/agent-runtime-a2a-llm-e2e/README.md
+++ b/examples/agent-runtime-a2a-llm-e2e/README.md
@@ -78,8 +78,14 @@ shows the minimum DFX shape expected from a customer-facing platform facade:
 - expired leases are marked `UNREACHABLE` and are no longer routable
 - cold, draining, unreachable, and at-capacity runtimes fail closed with clear
   error codes
+- runtime lease renewals can carry a `RuntimeCapacitySnapshot`; `READY`
+  runtimes whose task or LLM capacity is full are treated as `AT_CAPACITY` for
+  route selection
 - multiple runtime replicas are resolved through the same route view, and only
-  `READY` replicas can receive new traffic
+  healthy low-pressure `READY` replicas receive new traffic first
+- current routing is replica selection only: the sample does not create, stop,
+  scale out, or scale in runtime instances, and it does not implement a K8S HPA
+  or autoscaler control loop
 - the A2A forwarding endpoint returns trace headers for route resolution,
   response start, and selected runtime instance; total forwarding time is
   recorded in telemetry after the stream finishes
@@ -90,8 +96,9 @@ shows the minimum DFX shape expected from a customer-facing platform facade:
 
 Production deployments must still add persistent or reconstructable registry
 state, runtime identity authentication, tenant-agent authorization, rate
-limiting, circuit breaking, multi-AZ deployment, same-city disaster recovery,
-cross-region recovery, SLA/SLO dashboards, and error-budget governance.
+limiting, circuit breaking, dynamic scaling through K8S or an equivalent
+orchestrator, multi-AZ deployment, same-city disaster recovery, cross-region
+recovery, SLA/SLO dashboards, and error-budget governance.
 
 ## Quick start (config templates + scripts)
 

--- a/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/core/InMemoryRuntimeRegistry.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/core/InMemoryRuntimeRegistry.java
@@ -8,6 +8,7 @@ import com.huawei.ascend.examples.a2a.gateway.model.GatewayErrorCode;
 import com.huawei.ascend.examples.a2a.gateway.model.GatewayHealthSnapshot;
 import com.huawei.ascend.examples.a2a.gateway.model.RoutingContext;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeAgentRegistration;
+import com.huawei.ascend.examples.a2a.gateway.model.RuntimeCapacitySnapshot;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeDeregisterResult;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeInstanceId;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeLeaseRenewal;
@@ -85,7 +86,7 @@ public final class InMemoryRuntimeRegistry implements RuntimeRegistrationApi, Ag
         int ready = 0;
         int unreachable = 0;
         for (RuntimeRecord record : records.values()) {
-            RuntimeState state = effectiveState(record);
+            RuntimeState state = effectiveRouteState(record);
             if (state == RuntimeState.READY) {
                 ready++;
             }
@@ -122,7 +123,7 @@ public final class InMemoryRuntimeRegistry implements RuntimeRegistrationApi, Ag
                         record.agentCard().name(),
                         record.version(),
                         record.a2aEndpoint(),
-                        effectiveState(record)))
+                        effectiveRouteState(record)))
                 .toList();
     }
 
@@ -135,9 +136,10 @@ public final class InMemoryRuntimeRegistry implements RuntimeRegistrationApi, Ag
                         record.agentId(),
                         record.runtimeInstanceId(),
                         record.a2aEndpoint(),
-                        record.state(),
+                        effectiveRouteState(record),
                         record.lastHeartbeatAt(),
-                        record.slaSnapshot()))
+                        record.slaSnapshot(),
+                        record.capacitySnapshot()))
                 .orElseThrow(() -> new AgentRouteNotFoundException(
                         "No READY runtime for tenantId=" + tenantId + ", agentId=" + agentId));
     }
@@ -158,12 +160,20 @@ public final class InMemoryRuntimeRegistry implements RuntimeRegistrationApi, Ag
                     "No registered runtime for tenantId=" + tenantId + ", agentId=" + agentId);
         }
         List<RuntimeRecord> ready = candidates.stream()
-                .filter(record -> record.state() == RuntimeState.READY)
+                .filter(record -> effectiveRouteState(record) == RuntimeState.READY)
+                .sorted(Comparator.<RuntimeRecord>comparingDouble(record -> record.capacitySnapshot().routeScore())
+                        .thenComparingLong(record -> record.capacitySnapshot().p95FirstTokenMs())
+                        .thenComparing(RuntimeRecord::lastHeartbeatAt, Comparator.reverseOrder())
+                        .thenComparing(record -> record.runtimeInstanceId().value()))
                 .toList();
         if (!ready.isEmpty()) {
             return ready;
         }
-        RuntimeState dominantState = candidates.get(0).state();
+        RuntimeState dominantState = candidates.stream()
+                .map(this::effectiveRouteState)
+                .filter(RuntimeState.AT_CAPACITY::equals)
+                .findFirst()
+                .orElse(effectiveRouteState(candidates.get(0)));
         throw new AgentRouteNotFoundException(errorCodeForState(dominantState),
                 "No READY runtime for tenantId=" + tenantId + ", agentId=" + agentId
                         + ", dominantState=" + dominantState);
@@ -179,6 +189,14 @@ public final class InMemoryRuntimeRegistry implements RuntimeRegistrationApi, Ag
             return RuntimeState.DEREGISTERED;
         }
         return record.expiresAt().isAfter(clock.instant()) ? record.state() : RuntimeState.UNREACHABLE;
+    }
+
+    private RuntimeState effectiveRouteState(RuntimeRecord record) {
+        RuntimeState state = effectiveState(record);
+        if (state == RuntimeState.READY && record.capacitySnapshot().atCapacity()) {
+            return RuntimeState.AT_CAPACITY;
+        }
+        return state;
     }
 
     private void refreshExpiredLeases() {
@@ -222,6 +240,7 @@ public final class InMemoryRuntimeRegistry implements RuntimeRegistrationApi, Ag
             Instant lastHeartbeatAt,
             Instant expiresAt,
             SlaSnapshot slaSnapshot,
+            RuntimeCapacitySnapshot capacitySnapshot,
             Map<String, Object> metadata) {
 
         private static RuntimeRecord from(RuntimeAgentRegistration registration, Instant now) {
@@ -238,6 +257,7 @@ public final class InMemoryRuntimeRegistry implements RuntimeRegistrationApi, Ag
                     now,
                     now.plus(registration.ttl()),
                     SlaSnapshot.empty(),
+                    registration.capacitySnapshot(),
                     registration.metadata());
         }
 
@@ -255,6 +275,7 @@ public final class InMemoryRuntimeRegistry implements RuntimeRegistrationApi, Ag
                     now,
                     now.plus(renewal.ttl()),
                     renewal.slaSnapshot(),
+                    renewal.capacitySnapshot(),
                     renewal.metadata());
         }
 
@@ -272,6 +293,7 @@ public final class InMemoryRuntimeRegistry implements RuntimeRegistrationApi, Ag
                     lastHeartbeatAt,
                     now,
                     slaSnapshot,
+                    capacitySnapshot,
                     metadata);
         }
     }

--- a/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/http/RuntimeRegistryController.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/http/RuntimeRegistryController.java
@@ -7,6 +7,7 @@ import com.huawei.ascend.examples.a2a.gateway.model.AgentRouteNotFoundException;
 import com.huawei.ascend.examples.a2a.gateway.model.GatewayErrorCode;
 import com.huawei.ascend.examples.a2a.gateway.model.RoutingContext;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeAgentRegistration;
+import com.huawei.ascend.examples.a2a.gateway.model.RuntimeCapacitySnapshot;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeDeregisterResult;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeInstanceId;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeLeaseRenewal;
@@ -55,6 +56,7 @@ public final class RuntimeRegistryController {
                 request.healthEndpoint(),
                 request.version(),
                 Duration.ofSeconds(request.ttlSeconds()),
+                request.capacitySnapshot(),
                 request.metadata()));
     }
 
@@ -65,6 +67,7 @@ public final class RuntimeRegistryController {
                 request.state(),
                 Duration.ofSeconds(request.ttlSeconds()),
                 request.slaSnapshot(),
+                request.capacitySnapshot(),
                 request.metadata()));
     }
 
@@ -114,14 +117,38 @@ public final class RuntimeRegistryController {
             URI healthEndpoint,
             String version,
             long ttlSeconds,
+            RuntimeCapacitySnapshot capacitySnapshot,
             Map<String, Object> metadata) {
+
+        public RuntimeRegistrationRequest(
+                String runtimeInstanceId,
+                String tenantId,
+                String agentId,
+                AgentCard agentCard,
+                URI a2aEndpoint,
+                URI healthEndpoint,
+                String version,
+                long ttlSeconds,
+                Map<String, Object> metadata) {
+            this(runtimeInstanceId, tenantId, agentId, agentCard, a2aEndpoint, healthEndpoint, version, ttlSeconds,
+                    RuntimeCapacitySnapshot.empty(), metadata);
+        }
     }
 
     public record RuntimeLeaseRenewalRequest(
             RuntimeState state,
             long ttlSeconds,
             SlaSnapshot slaSnapshot,
+            RuntimeCapacitySnapshot capacitySnapshot,
             Map<String, Object> metadata) {
+
+        public RuntimeLeaseRenewalRequest(
+                RuntimeState state,
+                long ttlSeconds,
+                SlaSnapshot slaSnapshot,
+                Map<String, Object> metadata) {
+            this(state, ttlSeconds, slaSnapshot, RuntimeCapacitySnapshot.empty(), metadata);
+        }
     }
 
     public record ErrorResponse(String code, String message) {

--- a/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/model/RuntimeAgentRegistration.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/model/RuntimeAgentRegistration.java
@@ -15,6 +15,7 @@ public record RuntimeAgentRegistration(
         URI healthEndpoint,
         String version,
         Duration ttl,
+        RuntimeCapacitySnapshot capacitySnapshot,
         Map<String, Object> metadata) {
 
     public RuntimeAgentRegistration {
@@ -26,7 +27,22 @@ public record RuntimeAgentRegistration(
         healthEndpoint = Objects.requireNonNull(healthEndpoint, "healthEndpoint");
         version = required(version, "version");
         ttl = positive(ttl, "ttl");
+        capacitySnapshot = capacitySnapshot == null ? RuntimeCapacitySnapshot.empty() : capacitySnapshot;
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    public RuntimeAgentRegistration(
+            RuntimeInstanceId runtimeInstanceId,
+            String tenantId,
+            String agentId,
+            AgentCard agentCard,
+            URI a2aEndpoint,
+            URI healthEndpoint,
+            String version,
+            Duration ttl,
+            Map<String, Object> metadata) {
+        this(runtimeInstanceId, tenantId, agentId, agentCard, a2aEndpoint, healthEndpoint, version, ttl,
+                RuntimeCapacitySnapshot.empty(), metadata);
     }
 
     private static String required(String value, String field) {

--- a/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/model/RuntimeCapacitySnapshot.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/model/RuntimeCapacitySnapshot.java
@@ -1,0 +1,71 @@
+package com.huawei.ascend.examples.a2a.gateway.model;
+
+import java.time.Instant;
+
+public record RuntimeCapacitySnapshot(
+        int runningTasks,
+        int queuedTasks,
+        int maxConcurrentTasks,
+        int llmInFlight,
+        int llmQueueDepth,
+        int llmMaxConcurrency,
+        long p50FirstTokenMs,
+        long p95FirstTokenMs,
+        long p99FirstTokenMs,
+        int recent429Count,
+        int recentTimeoutCount,
+        double estimatedLoad,
+        Instant observedAt) {
+
+    public RuntimeCapacitySnapshot {
+        requireNonNegative(runningTasks, "runningTasks");
+        requireNonNegative(queuedTasks, "queuedTasks");
+        requireNonNegative(maxConcurrentTasks, "maxConcurrentTasks");
+        requireNonNegative(llmInFlight, "llmInFlight");
+        requireNonNegative(llmQueueDepth, "llmQueueDepth");
+        requireNonNegative(llmMaxConcurrency, "llmMaxConcurrency");
+        requireNonNegative(p50FirstTokenMs, "p50FirstTokenMs");
+        requireNonNegative(p95FirstTokenMs, "p95FirstTokenMs");
+        requireNonNegative(p99FirstTokenMs, "p99FirstTokenMs");
+        requireNonNegative(recent429Count, "recent429Count");
+        requireNonNegative(recentTimeoutCount, "recentTimeoutCount");
+        if (Double.isNaN(estimatedLoad) || Double.isInfinite(estimatedLoad) || estimatedLoad < 0.0) {
+            throw new IllegalArgumentException("estimatedLoad must be a finite non-negative value");
+        }
+        observedAt = observedAt == null ? Instant.EPOCH : observedAt;
+    }
+
+    public static RuntimeCapacitySnapshot empty() {
+        return new RuntimeCapacitySnapshot(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.0, Instant.EPOCH);
+    }
+
+    public boolean atCapacity() {
+        return taskCapacityReached() || llmCapacityReached() || estimatedLoad >= 1.0;
+    }
+
+    public double routeScore() {
+        double taskLoad = maxConcurrentTasks <= 0 ? 0.0 : (double) (runningTasks + queuedTasks) / maxConcurrentTasks;
+        double llmLoad = llmMaxConcurrency <= 0 ? 0.0 : (double) (llmInFlight + llmQueueDepth) / llmMaxConcurrency;
+        return Math.max(Math.max(taskLoad, llmLoad), estimatedLoad);
+    }
+
+    private boolean taskCapacityReached() {
+        return maxConcurrentTasks > 0 && runningTasks + queuedTasks >= maxConcurrentTasks;
+    }
+
+    private boolean llmCapacityReached() {
+        return llmMaxConcurrency > 0 && llmInFlight + llmQueueDepth >= llmMaxConcurrency;
+    }
+
+    private static void requireNonNegative(long value, String field) {
+        if (value < 0) {
+            throw new IllegalArgumentException(field + " must be non-negative");
+        }
+    }
+
+    private static void requireNonNegative(int value, String field) {
+        if (value < 0) {
+            throw new IllegalArgumentException(field + " must be non-negative");
+        }
+    }
+}

--- a/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/model/RuntimeLeaseRenewal.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/model/RuntimeLeaseRenewal.java
@@ -9,6 +9,7 @@ public record RuntimeLeaseRenewal(
         RuntimeState state,
         Duration ttl,
         SlaSnapshot slaSnapshot,
+        RuntimeCapacitySnapshot capacitySnapshot,
         Map<String, Object> metadata) {
 
     public RuntimeLeaseRenewal {
@@ -18,6 +19,16 @@ public record RuntimeLeaseRenewal(
             throw new IllegalArgumentException("ttl must be positive");
         }
         slaSnapshot = slaSnapshot == null ? SlaSnapshot.empty() : slaSnapshot;
+        capacitySnapshot = capacitySnapshot == null ? RuntimeCapacitySnapshot.empty() : capacitySnapshot;
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    public RuntimeLeaseRenewal(
+            RuntimeInstanceId runtimeInstanceId,
+            RuntimeState state,
+            Duration ttl,
+            SlaSnapshot slaSnapshot,
+            Map<String, Object> metadata) {
+        this(runtimeInstanceId, state, ttl, slaSnapshot, RuntimeCapacitySnapshot.empty(), metadata);
     }
 }

--- a/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/model/RuntimeRoute.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/gateway/model/RuntimeRoute.java
@@ -9,5 +9,6 @@ public record RuntimeRoute(
         URI a2aEndpoint,
         RuntimeState state,
         Instant lastHeartbeatAt,
-        SlaSnapshot slaSnapshot) {
+        SlaSnapshot slaSnapshot,
+        RuntimeCapacitySnapshot capacitySnapshot) {
 }

--- a/examples/agent-runtime-a2a-llm-e2e/src/test/java/com/huawei/ascend/examples/a2a/gateway/InMemoryRuntimeRegistryTest.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/test/java/com/huawei/ascend/examples/a2a/gateway/InMemoryRuntimeRegistryTest.java
@@ -5,6 +5,7 @@ import com.huawei.ascend.examples.a2a.gateway.model.AgentRouteNotFoundException;
 import com.huawei.ascend.examples.a2a.gateway.model.GatewayErrorCode;
 import com.huawei.ascend.examples.a2a.gateway.model.RoutingContext;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeAgentRegistration;
+import com.huawei.ascend.examples.a2a.gateway.model.RuntimeCapacitySnapshot;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeInstanceId;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeLeaseRenewal;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeState;
@@ -106,6 +107,52 @@ class InMemoryRuntimeRegistryTest {
     }
 
     @Test
+    void readyRuntimeWithFullLlmCapacityIsNotRoutable() {
+        InMemoryRuntimeRegistry registry = registryAt(NOW);
+        registry.register(registration("runtime-1", "agent-weather", Duration.ofSeconds(30)));
+        registry.renew(new RuntimeLeaseRenewal(
+                RuntimeInstanceId.of("runtime-1"),
+                RuntimeState.READY,
+                Duration.ofSeconds(30),
+                SlaSnapshot.empty(),
+                capacity(1, 0, 1, 1.0, 100),
+                Map.of("reason", "llm-saturated")));
+
+        assertThatThrownBy(() -> registry.resolveRoute("agent-weather", "tenant-a", RoutingContext.empty()))
+                .isInstanceOfSatisfying(AgentRouteNotFoundException.class,
+                        ex -> assertThat(ex.code()).isEqualTo(GatewayErrorCode.RUNTIME_AT_CAPACITY));
+        assertThat(registry.listAgents("tenant-a").getFirst().state()).isEqualTo(RuntimeState.AT_CAPACITY);
+        assertThat(registry.healthSnapshot(0).readyRuntimeCount()).isZero();
+    }
+
+    @Test
+    void routePrefersLowerPressureReadyRuntime() {
+        MutableClock clock = new MutableClock(NOW);
+        InMemoryRuntimeRegistry registry = new InMemoryRuntimeRegistry(clock);
+        registry.register(registration("runtime-hot", "agent-weather", Duration.ofSeconds(30)));
+        registry.register(registration("runtime-cool", "agent-weather", Duration.ofSeconds(30)));
+
+        registry.renew(new RuntimeLeaseRenewal(
+                RuntimeInstanceId.of("runtime-cool"),
+                RuntimeState.READY,
+                Duration.ofSeconds(30),
+                SlaSnapshot.empty(),
+                capacity(1, 0, 10, 0.1, 60),
+                Map.of()));
+        clock.set(NOW.plusSeconds(1));
+        registry.renew(new RuntimeLeaseRenewal(
+                RuntimeInstanceId.of("runtime-hot"),
+                RuntimeState.READY,
+                Duration.ofSeconds(30),
+                SlaSnapshot.empty(),
+                capacity(8, 1, 10, 0.9, 120),
+                Map.of()));
+
+        assertThat(registry.resolveRoute("agent-weather", "tenant-a", RoutingContext.empty()).runtimeInstanceId())
+                .isEqualTo(RuntimeInstanceId.of("runtime-cool"));
+    }
+
+    @Test
     void deregisterRemovesRuntimeFromRouteView() {
         InMemoryRuntimeRegistry registry = registryAt(NOW);
         registry.register(registration("runtime-1", "agent-weather", Duration.ofSeconds(30)));
@@ -153,6 +200,28 @@ class InMemoryRuntimeRegistryTest {
                         TransportProtocol.JSONRPC.asString(), "/a2a")))
                 .preferredTransport(TransportProtocol.JSONRPC.asString())
                 .build();
+    }
+
+    private static RuntimeCapacitySnapshot capacity(
+            int llmInFlight,
+            int llmQueueDepth,
+            int llmMaxConcurrency,
+            double estimatedLoad,
+            long p95FirstTokenMs) {
+        return new RuntimeCapacitySnapshot(
+                0,
+                0,
+                0,
+                llmInFlight,
+                llmQueueDepth,
+                llmMaxConcurrency,
+                50,
+                p95FirstTokenMs,
+                p95FirstTokenMs * 2,
+                0,
+                0,
+                estimatedLoad,
+                NOW);
     }
 
     private static final class MutableClock extends Clock {

--- a/examples/agent-runtime-a2a-llm-e2e/src/test/java/com/huawei/ascend/examples/a2a/gateway/RuntimeRegistryHttpE2eTest.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/test/java/com/huawei/ascend/examples/a2a/gateway/RuntimeRegistryHttpE2eTest.java
@@ -7,6 +7,7 @@ import com.huawei.ascend.examples.a2a.gateway.http.RuntimeRegistryController.Run
 import com.huawei.ascend.examples.a2a.gateway.model.AgentInteractionEvent;
 import com.huawei.ascend.examples.a2a.gateway.model.InboundA2aContext;
 import com.huawei.ascend.examples.a2a.gateway.model.RoutingContext;
+import com.huawei.ascend.examples.a2a.gateway.model.RuntimeCapacitySnapshot;
 import com.huawei.ascend.examples.a2a.gateway.model.RuntimeState;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
@@ -97,6 +98,74 @@ class RuntimeRegistryHttpE2eTest {
 
         assertThat(response.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE.value());
         assertThat(response.body().path("code").asText()).isEqualTo("RUNTIME_AT_CAPACITY");
+    }
+
+    @Test
+    void httpFacadeStopsRoutingRuntimeWhoseLlmCapacitySnapshotIsFull() {
+        String tenant = "tenant-http-llm-capacity";
+        register(tenant, "runtime-weather-llm", "weather-agent-llm", "http://runtime-weather-llm.local/a2a");
+
+        put(
+                "/v1/runtime-registrations/runtime-weather-llm/lease",
+                new RuntimeLeaseRenewalRequest(
+                        RuntimeState.READY,
+                        30,
+                        null,
+                        new RuntimeCapacitySnapshot(
+                                0,
+                                0,
+                                0,
+                                4,
+                                0,
+                                4,
+                                80,
+                                180,
+                                450,
+                                0,
+                                0,
+                                1.0,
+                                Instant.parse("2026-06-08T00:00:00Z")),
+                        Map.of("reason", "llm-saturated")));
+
+        HttpJsonResponse response = post(
+                "/v1/agents/weather-agent-llm/routes/resolve?tenantId=" + tenant,
+                new RoutingContext("session-llm-capacity", "corr-llm-capacity", Map.of("message", "ping")));
+
+        assertThat(response.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE.value());
+        assertThat(response.body().path("code").asText()).isEqualTo("RUNTIME_AT_CAPACITY");
+    }
+
+    @Test
+    void httpFacadeRouteResponseCarriesRuntimeCapacitySnapshot() {
+        String tenant = "tenant-http-capacity-route";
+        register(tenant, "runtime-weather-route", "weather-agent-route", "http://runtime-weather-route.local/a2a");
+
+        put(
+                "/v1/runtime-registrations/runtime-weather-route/lease",
+                new RuntimeLeaseRenewalRequest(
+                        RuntimeState.READY,
+                        30,
+                        null,
+                        new RuntimeCapacitySnapshot(
+                                1,
+                                0,
+                                8,
+                                2,
+                                0,
+                                8,
+                                40,
+                                100,
+                                250,
+                                0,
+                                0,
+                                0.25,
+                                Instant.parse("2026-06-08T00:00:01Z")),
+                        Map.of("reason", "healthy")));
+
+        JsonNode response = resolve(tenant, "weather-agent-route", "session-route", "corr-route", "ping");
+
+        assertThat(response.path("capacitySnapshot").path("llmInFlight").asInt()).isEqualTo(2);
+        assertThat(response.path("capacitySnapshot").path("p95FirstTokenMs").asLong()).isEqualTo(100);
     }
 
     @Test


### PR DESCRIPTION
﻿## Why

ADR-0160 defines runtime capacity feedback as the abstraction Service/Gateway facade should use for LLM backpressure-aware routing. The examples gateway needs a small implementation slice so reviewers and customers can see how runtime pressure affects route selection without coupling the facade to any LLM provider SDK.

## What Changed

- Adds `RuntimeCapacitySnapshot` for task and LLM pressure signals reported through runtime registration / lease renewal.
- Treats `READY` runtimes with full task or LLM capacity as effectively `AT_CAPACITY` for route selection.
- Prefers lower-pressure runtime replicas when multiple `READY` replicas are available for the same tenant / agent route.
- Exposes the selected route capacity snapshot in `RuntimeRoute` for observability.
- Documents that this is replica selection only, not K8S HPA/KEDA dynamic scaling.

## Verification

```bash
wsl -d Ubuntu-24.04 -- bash -lc 'cd /mnt/d/repo/spring-ai-ascend && ./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml -Dtest=InMemoryRuntimeRegistryTest,RuntimeRegistryHttpE2eTest test'
```

Result: `Tests run: 13, Failures: 0, Errors: 0, Skipped: 0`.
