### PR TITLE
refactor(agent-runtime): centralize openjiuwen checkpointer setup

### DIFF
--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenCheckpointers.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenCheckpointers.java
@@ -1,0 +1,53 @@
+package com.huawei.ascend.runtime.engine.openjiuwen;
+
+import com.huawei.ascend.runtime.common.Guards;
+import com.openjiuwen.core.session.checkpointer.Checkpointer;
+import com.openjiuwen.core.session.checkpointer.CheckpointerFactory;
+import com.openjiuwen.core.session.checkpointer.InMemoryCheckpointer;
+import com.openjiuwen.extensions.checkpointer.redis.RedisCheckpointer;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Small factory for openJiuwen native checkpointers used by runtime samples.
+ *
+ * <p>The runtime does not wrap or replace openJiuwen checkpoint storage. This
+ * helper only centralizes the standard setup shape: create an in-memory
+ * checkpointer for local runs, keep a Redis checkpointer candidate available
+ * for durable runs, and install the selected one into openJiuwen's
+ * {@link CheckpointerFactory}.
+ */
+public final class OpenJiuwenCheckpointers {
+    public static final String IN_MEMORY = "in-memory";
+    public static final String REDIS = "redis";
+
+    private OpenJiuwenCheckpointers() {
+    }
+
+    public static Checkpointer inMemory() {
+        return new InMemoryCheckpointer();
+    }
+
+    public static Checkpointer redis(String redisUrl) {
+        return new RedisCheckpointer.Provider()
+                .create(Map.of("connection", Map.of("url", Guards.requireNonBlank(redisUrl, "redisUrl"))));
+    }
+
+    public static Checkpointer configureDefault(String checkpointerType, String redisUrl) {
+        Checkpointer inMemoryCheckpointer = inMemory();
+        Checkpointer redisCheckpointer = redis(redisUrl);
+        Checkpointer selected = isRedis(checkpointerType) ? redisCheckpointer : inMemoryCheckpointer;
+        return setDefault(selected);
+    }
+
+    public static Checkpointer setDefault(Checkpointer checkpointer) {
+        Checkpointer selected = Objects.requireNonNull(checkpointer, "checkpointer");
+        CheckpointerFactory.setDefaultCheckpointer(selected);
+        return selected;
+    }
+
+    public static boolean isRedis(String checkpointerType) {
+        return REDIS.equals(String.valueOf(checkpointerType).trim().toLowerCase(Locale.ROOT));
+    }
+}

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenAgentRuntimeHandlerTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenAgentRuntimeHandlerTest.java
@@ -103,10 +103,35 @@ class OpenJiuwenAgentRuntimeHandlerTest {
 
     @Test
     void openJiuwenRedisCheckpointerCanBeInstantiatedByUrlConfiguration() {
-        Checkpointer checkpointer = new RedisCheckpointer.Provider()
-                .create(Map.of("connection", Map.of("url", "redis://localhost:6379")));
+        Checkpointer checkpointer = OpenJiuwenCheckpointers.redis("redis://localhost:6379");
 
         assertThat(checkpointer).isInstanceOf(RedisCheckpointer.class);
+    }
+
+    @Test
+    void openJiuwenCheckpointerFactoryConfiguresInMemoryByDefault() {
+        Checkpointer previous = CheckpointerFactory.getCheckpointer();
+        try {
+            Checkpointer selected = OpenJiuwenCheckpointers.configureDefault("in-memory", "redis://localhost:6379");
+
+            assertThat(selected).isInstanceOf(InMemoryCheckpointer.class);
+            assertThat(CheckpointerFactory.getCheckpointer()).isSameAs(selected);
+        } finally {
+            CheckpointerFactory.setDefaultCheckpointer(previous);
+        }
+    }
+
+    @Test
+    void openJiuwenCheckpointerFactoryKeepsRedisOptionAvailable() {
+        Checkpointer previous = CheckpointerFactory.getCheckpointer();
+        try {
+            Checkpointer selected = OpenJiuwenCheckpointers.configureDefault("redis", "redis://localhost:6379");
+
+            assertThat(selected).isInstanceOf(RedisCheckpointer.class);
+            assertThat(CheckpointerFactory.getCheckpointer()).isSameAs(selected);
+        } finally {
+            CheckpointerFactory.setDefaultCheckpointer(previous);
+        }
     }
 
     private static AgentExecutionContext context() {

--- a/docs/logs/reviews/2026-06-09-agent-runtime-agent-state-middleware-proposal.cn.md
+++ b/docs/logs/reviews/2026-06-09-agent-runtime-agent-state-middleware-proposal.cn.md
@@ -150,7 +150,7 @@ OpenJiuwen 文档与源码主线是：
 2. 对外提供 `openJiuwenConversationId(context)`，让子类调用 `Runner.runAgent(agent, input, conversationId, null)`。
 3. 不在每次执行 finally 中调用 `Runner.release(...)`；release 只代表会话结束或业务显式清理，否则会破坏多轮恢复。
 
-当前 sample 在配置阶段同时实例化 `InMemoryCheckpointer` 和 `RedisCheckpointer` 两个 OpenJiuwen 原生 checkpointer 候选，默认通过 `CheckpointerFactory.setDefaultCheckpointer(...)` 选择 `InMemoryCheckpointer`，便于本地 E2E。需要演示持久化路径时，通过 `sample.openjiuwen.checkpointer=redis` / `SAA_SAMPLE_OPENJIUWEN_CHECKPOINTER=redis` 和 `sample.openjiuwen.redis-url` / `SAA_SAMPLE_OPENJIUWEN_REDIS_URL` 切换到 `RedisCheckpointer`；OpenJiuwen adapter 不需要变化。
+当前 runtime 提供 `OpenJiuwenCheckpointers` 小工具类，封装 OpenJiuwen 原生 checkpointer 的标准配置方式。sample 在配置阶段通过该工具类同时实例化 `InMemoryCheckpointer` 和 `RedisCheckpointer` 两个候选，默认通过 `CheckpointerFactory.setDefaultCheckpointer(...)` 选择 `InMemoryCheckpointer`，便于本地 E2E。需要演示持久化路径时，通过 `sample.openjiuwen.checkpointer=redis` / `SAA_SAMPLE_OPENJIUWEN_CHECKPOINTER=redis` 和 `sample.openjiuwen.redis-url` / `SAA_SAMPLE_OPENJIUWEN_REDIS_URL` 切换到 `RedisCheckpointer`；OpenJiuwen adapter 不需要变化。
 
 ## 5. Failure Semantics
 
@@ -171,7 +171,7 @@ OpenJiuwen 文档与源码主线是：
 | State provider marker | Implemented | `StateProvider`，用于可选生命周期桥接，不强制所有框架使用 |
 | Store-free handler | Implemented | handler 只读写 `AgentExecutionContext` |
 | OpenJiuwen native checkpointer configuration | Implemented | 使用稳定 `conversation_id` 接入 OpenJiuwen `Runner` / `Checkpointer` |
-| OpenJiuwen checkpointer direct setup | Implemented | sample 同时实例化 InMemory / Redis 候选，默认 set InMemory，可配置切换 Redis |
+| OpenJiuwen checkpointer direct setup | Implemented | `OpenJiuwenCheckpointers` 同时实例化 InMemory / Redis 候选，sample 默认 set InMemory，可配置切换 Redis |
 | Snapshot/revision | Deferred | 不在当前最小版本实现 |
 | Mem integration | Deferred | 后续作为独立 Provider 或 middleware 扩展 |
 

--- a/examples/agent-runtime-a2a-llm-e2e/README.cn.md
+++ b/examples/agent-runtime-a2a-llm-e2e/README.cn.md
@@ -235,8 +235,9 @@ export SAA_SAMPLE_LLM_MODEL="gpt-5.4-mini"
 export SAA_SAMPLE_A2A_BASE_URL="http://localhost:18080"
 ```
 
-OpenJiuwen 示例在配置阶段会同时创建两个原生 checkpointer 候选。默认路径使用
-`InMemoryCheckpointer`，便于本地 E2E；如果需要切到 Redis 路径，可以设置
+OpenJiuwen 示例通过 runtime 提供的 `OpenJiuwenCheckpointers` 工具类，在配置阶段
+同时创建两个原生 checkpointer 候选。默认路径使用 `InMemoryCheckpointer`，便于
+本地 E2E；如果需要切到 Redis 路径，可以设置
 `SAA_SAMPLE_OPENJIUWEN_CHECKPOINTER=redis`，并通过
 `SAA_SAMPLE_OPENJIUWEN_REDIS_URL` 指定 Redis URL。
 

--- a/examples/agent-runtime-a2a-llm-e2e/README.md
+++ b/examples/agent-runtime-a2a-llm-e2e/README.md
@@ -299,9 +299,10 @@ export SAA_SAMPLE_LLM_MODEL="gpt-5.4-mini"
 export SAA_SAMPLE_A2A_BASE_URL="http://localhost:18080"
 ```
 
-The openJiuwen sample creates both native checkpointer candidates during
-configuration. It sets `InMemoryCheckpointer` as the default path for local E2E
-runs. Set `SAA_SAMPLE_OPENJIUWEN_CHECKPOINTER=redis` and provide
+The openJiuwen sample uses the runtime helper `OpenJiuwenCheckpointers` to
+create both native checkpointer candidates during configuration. It sets
+`InMemoryCheckpointer` as the default path for local E2E runs. Set
+`SAA_SAMPLE_OPENJIUWEN_CHECKPOINTER=redis` and provide
 `SAA_SAMPLE_OPENJIUWEN_REDIS_URL` to switch the same runtime wiring to the
 openJiuwen `RedisCheckpointer` path.
 

--- a/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/OpenJiuwenReactAgentConfiguration.java
+++ b/examples/agent-runtime-a2a-llm-e2e/src/main/java/com/huawei/ascend/examples/a2a/OpenJiuwenReactAgentConfiguration.java
@@ -2,18 +2,15 @@ package com.huawei.ascend.examples.a2a;
 
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
 import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenAgentRuntimeHandler;
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenCheckpointers;
 import com.huawei.ascend.runtime.engine.spi.AgentCards;
 import com.openjiuwen.core.foundation.llm.schema.ModelRequestConfig;
 import com.openjiuwen.core.runner.Runner;
 import com.openjiuwen.core.session.checkpointer.Checkpointer;
-import com.openjiuwen.core.session.checkpointer.CheckpointerFactory;
-import com.openjiuwen.core.session.checkpointer.InMemoryCheckpointer;
 import com.openjiuwen.core.singleagent.ReActAgent;
 import com.openjiuwen.core.singleagent.agents.ReActAgentConfig;
 import com.openjiuwen.core.singleagent.schema.AgentCard;
-import com.openjiuwen.extensions.checkpointer.redis.RedisCheckpointer;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
@@ -33,16 +30,7 @@ public class OpenJiuwenReactAgentConfiguration {
             String checkpointerType,
             @Value("${sample.openjiuwen.redis-url:${SAA_SAMPLE_OPENJIUWEN_REDIS_URL:redis://localhost:6379}}")
             String redisUrl) {
-        Checkpointer inMemoryCheckpointer = new InMemoryCheckpointer();
-        Checkpointer redisCheckpointer = new RedisCheckpointer.Provider()
-                .create(Map.of("connection", Map.of("url", redisUrl)));
-        Checkpointer selected = isRedisCheckpointer(checkpointerType) ? redisCheckpointer : inMemoryCheckpointer;
-        CheckpointerFactory.setDefaultCheckpointer(selected);
-        return selected;
-    }
-
-    private static boolean isRedisCheckpointer(String checkpointerType) {
-        return "redis".equals(String.valueOf(checkpointerType).trim().toLowerCase(Locale.ROOT));
+        return OpenJiuwenCheckpointers.configureDefault(checkpointerType, redisUrl);
     }
 
     @Bean


### PR DESCRIPTION
## Why

PR #150 landed the OpenJiuwen native checkpoint path, but the example still carried the checkpointer wiring details directly in the sample configuration. That makes the recommended setup easy to copy incorrectly.

## What Changed

- Add `OpenJiuwenCheckpointers` as a small runtime helper for OpenJiuwen native checkpoint setup.
- Keep the default local path on `InMemoryCheckpointer` while preserving the configurable `RedisCheckpointer` path.
- Simplify the A2A LLM example configuration to call the helper instead of manually wiring OpenJiuwen internals.
- Extend OpenJiuwen whitebox coverage for default in-memory setup and Redis option selection.
- Update the example README files and the Chinese proposal to describe the helper boundary.

## Verification

```bash
wsl -d Ubuntu-24.04 -- bash -lc 'cd /mnt/d/repo/spring-ai-ascend && ./mvnw -pl agent-runtime -Dtest=OpenJiuwenAgentRuntimeHandlerTest test'
```

Result: `BUILD SUCCESS`, 6 tests, 0 failures.