### PR TITLE
Enable real A2A push notification delivery through the SDK `BasePushNotificationSender`

### DIFF
--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/boot/A2aJsonRpcController.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/boot/A2aJsonRpcController.java
@@ -1,6 +1,5 @@
 package com.huawei.ascend.runtime.boot;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Flow;
@@ -8,9 +7,21 @@ import org.a2aproject.sdk.grpc.utils.JSONRPCUtils;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonUtil;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.A2ARequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.A2AResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.CancelTaskRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.CancelTaskResponse;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigResponse;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.GetTaskRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.GetTaskResponse;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.GetTaskPushNotificationConfigRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.GetTaskPushNotificationConfigResponse;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.ListTaskPushNotificationConfigsRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.ListTaskPushNotificationConfigsResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SendMessageRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.SendMessageResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SendStreamingMessageResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SendStreamingMessageRequest;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.SubscribeToTaskRequest;
@@ -33,7 +44,6 @@ import reactor.core.publisher.Flux;
 public class A2aJsonRpcController {
     private static final Logger log = LoggerFactory.getLogger(A2aJsonRpcController.class);
     private final RequestHandler handler;
-    private final ObjectMapper mapper = new ObjectMapper();
 
     public A2aJsonRpcController(RequestHandler handler) { this.handler = handler; }
 
@@ -76,15 +86,27 @@ public class A2aJsonRpcController {
 
     ResponseEntity<String> handleBlocking(A2ARequest<?> request) throws A2AError {
         var ctx = serverContext();
-        Object result = switch (request) {
-            case SendMessageRequest send -> handler.onMessageSend(send.getParams(), ctx);
-            case GetTaskRequest get -> handler.onGetTask(get.getParams(), ctx);
-            case CancelTaskRequest cancel -> handler.onCancelTask(cancel.getParams(), ctx);
+        A2AResponse<?> response = switch (request) {
+            case SendMessageRequest send ->
+                    new SendMessageResponse(request.getId(), handler.onMessageSend(send.getParams(), ctx));
+            case GetTaskRequest get ->
+                    new GetTaskResponse(request.getId(), handler.onGetTask(get.getParams(), ctx));
+            case CancelTaskRequest cancel ->
+                    new CancelTaskResponse(request.getId(), handler.onCancelTask(cancel.getParams(), ctx));
+            case CreateTaskPushNotificationConfigRequest create -> new CreateTaskPushNotificationConfigResponse(
+                    request.getId(), handler.onCreateTaskPushNotificationConfig(create.getParams(), ctx));
+            case GetTaskPushNotificationConfigRequest get -> new GetTaskPushNotificationConfigResponse(
+                    request.getId(), handler.onGetTaskPushNotificationConfig(get.getParams(), ctx));
+            case ListTaskPushNotificationConfigsRequest list -> new ListTaskPushNotificationConfigsResponse(
+                    request.getId(), handler.onListTaskPushNotificationConfigs(list.getParams(), ctx));
+            case DeleteTaskPushNotificationConfigRequest delete -> {
+                handler.onDeleteTaskPushNotificationConfig(delete.getParams(), ctx);
+                yield new DeleteTaskPushNotificationConfigResponse(request.getId());
+            }
             default -> throw new IllegalArgumentException("Unknown: " + request.getMethod());
         };
         try {
-            String json = mapper.writeValueAsString(Map.of("jsonrpc","2.0","id",request.getId(),"result",result));
-            return ResponseEntity.ok(json);
+            return ResponseEntity.ok(JsonUtil.toJson(response));
         } catch (Exception e) {
             return ResponseEntity.ok("{}");
         }

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/boot/RuntimeAutoConfiguration.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/boot/RuntimeAutoConfiguration.java
@@ -15,6 +15,7 @@ import org.a2aproject.sdk.server.events.MainEventBusProcessor;
 import org.a2aproject.sdk.server.events.QueueManager;
 import org.a2aproject.sdk.server.requesthandlers.DefaultRequestHandler;
 import org.a2aproject.sdk.server.requesthandlers.RequestHandler;
+import org.a2aproject.sdk.server.tasks.BasePushNotificationSender;
 import org.a2aproject.sdk.server.tasks.InMemoryPushNotificationConfigStore;
 import org.a2aproject.sdk.server.tasks.InMemoryTaskStore;
 import org.a2aproject.sdk.server.tasks.PushNotificationConfigStore;
@@ -46,9 +47,9 @@ public class RuntimeAutoConfiguration {
     public PushNotificationConfigStore a2aPushConfigStore() { return new InMemoryPushNotificationConfigStore(); }
 
     @Bean @ConditionalOnMissingBean
-    public PushNotificationSender a2aPushSender() {
-        return (event, task) -> log.debug("push notification task={} (no-op)",
-                task == null ? "<none>" : task.id());
+    public PushNotificationSender a2aPushSender(PushNotificationConfigStore store) {
+        log.info("A2A push notification sender enabled with {}", store.getClass().getSimpleName());
+        return new BasePushNotificationSender(store);
     }
 
     @Bean @ConditionalOnMissingBean

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/A2aAgentExecutor.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/A2aAgentExecutor.java
@@ -85,7 +85,7 @@ public final class A2aAgentExecutor implements AgentExecutor {
             case OUTPUT -> {
                 String text = outputText(result);
                 LOG.info("[A2A] output stream taskId={} textChars={}", taskId, text.length());
-                emitter.sendMessage(text);
+                emitter.addArtifact(List.<Part<?>>of(new TextPart(text)));
                 // state stays WORKING — more output may follow
             }
             case COMPLETED -> {

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/boot/A2aJsonRpcControllerTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/boot/A2aJsonRpcControllerTest.java
@@ -5,14 +5,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
 import org.a2aproject.sdk.grpc.StreamResponse;
 import org.a2aproject.sdk.grpc.utils.JSONRPCUtils;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.A2ARequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.CreateTaskPushNotificationConfigRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.DeleteTaskPushNotificationConfigRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.GetTaskPushNotificationConfigRequest;
+import org.a2aproject.sdk.jsonrpc.common.wrappers.ListTaskPushNotificationConfigsRequest;
 import org.a2aproject.sdk.server.ServerCallContext;
 import org.a2aproject.sdk.server.requesthandlers.RequestHandler;
+import org.a2aproject.sdk.server.tasks.BasePushNotificationSender;
+import org.a2aproject.sdk.server.tasks.InMemoryPushNotificationConfigStore;
+import org.a2aproject.sdk.server.tasks.PushNotificationSender;
 import org.a2aproject.sdk.spec.A2AError;
 import org.a2aproject.sdk.spec.CancelTaskParams;
+import org.a2aproject.sdk.spec.DeleteTaskPushNotificationConfigParams;
 import org.a2aproject.sdk.spec.EventKind;
+import org.a2aproject.sdk.spec.GetTaskPushNotificationConfigParams;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsParams;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
 import org.a2aproject.sdk.spec.ListTasksParams;
@@ -42,6 +52,36 @@ class A2aJsonRpcControllerTest {
         StepVerifier.create(controller.handleStream(request))
                 .assertNext(event -> assertThat(sdkParsedPayload(event)).isEqualTo(StreamResponse.PayloadCase.MESSAGE))
                 .verifyComplete();
+    }
+
+    @Test
+    void blockingHandlerDispatchesPushNotificationConfigRequests() throws Exception {
+        RecordingPushRequestHandler requestHandler = new RecordingPushRequestHandler();
+        A2aJsonRpcController controller = new A2aJsonRpcController(requestHandler);
+        TaskPushNotificationConfig config = new TaskPushNotificationConfig(
+                "push-1", "task-1", "http://localhost:19090/a2a/push", "token-1", null, null);
+
+        controller.handleBlocking(new CreateTaskPushNotificationConfigRequest("request-1", config));
+        controller.handleBlocking(new GetTaskPushNotificationConfigRequest(
+                "request-2", new GetTaskPushNotificationConfigParams("task-1", "push-1")));
+        controller.handleBlocking(new ListTaskPushNotificationConfigsRequest(
+                "request-3", new ListTaskPushNotificationConfigsParams("task-1")));
+        controller.handleBlocking(new DeleteTaskPushNotificationConfigRequest(
+                "request-4", new DeleteTaskPushNotificationConfigParams("task-1", "push-1")));
+
+        assertThat(requestHandler.lastCreated.get()).isEqualTo(config);
+        assertThat(requestHandler.lastGet.get()).isEqualTo(new GetTaskPushNotificationConfigParams("task-1", "push-1"));
+        assertThat(requestHandler.lastList.get()).isEqualTo(new ListTaskPushNotificationConfigsParams("task-1"));
+        assertThat(requestHandler.lastDelete.get()).isEqualTo(new DeleteTaskPushNotificationConfigParams("task-1", "push-1"));
+    }
+
+    @Test
+    void defaultPushNotificationSenderUsesA2aSdkBaseSender() {
+        RuntimeAutoConfiguration configuration = new RuntimeAutoConfiguration();
+
+        PushNotificationSender sender = configuration.a2aPushSender(new InMemoryPushNotificationConfigStore());
+
+        assertThat(sender).isInstanceOf(BasePushNotificationSender.class);
     }
 
     private static StreamResponse.PayloadCase sdkParsedPayload(ServerSentEvent<String> event) {
@@ -133,6 +173,81 @@ class A2aJsonRpcControllerTest {
 
         @Override
         public void validateRequestedTask(String requestedTaskId) throws A2AError {
+        }
+
+        private static UnsupportedOperationException unsupported() {
+            return new UnsupportedOperationException("not used by this test");
+        }
+    }
+
+    private static final class RecordingPushRequestHandler implements RequestHandler {
+        private final AtomicReference<TaskPushNotificationConfig> lastCreated = new AtomicReference<>();
+        private final AtomicReference<GetTaskPushNotificationConfigParams> lastGet = new AtomicReference<>();
+        private final AtomicReference<ListTaskPushNotificationConfigsParams> lastList = new AtomicReference<>();
+        private final AtomicReference<DeleteTaskPushNotificationConfigParams> lastDelete = new AtomicReference<>();
+
+        @Override
+        public TaskPushNotificationConfig onCreateTaskPushNotificationConfig(
+                TaskPushNotificationConfig params, ServerCallContext context) {
+            lastCreated.set(params);
+            return params;
+        }
+
+        @Override
+        public TaskPushNotificationConfig onGetTaskPushNotificationConfig(
+                GetTaskPushNotificationConfigParams params, ServerCallContext context) {
+            lastGet.set(params);
+            return new TaskPushNotificationConfig(
+                    params.id(), params.taskId(), "http://localhost:19090/a2a/push", null, null, null);
+        }
+
+        @Override
+        public ListTaskPushNotificationConfigsResult onListTaskPushNotificationConfigs(
+                ListTaskPushNotificationConfigsParams params, ServerCallContext context) {
+            lastList.set(params);
+            return new ListTaskPushNotificationConfigsResult(List.of(), null);
+        }
+
+        @Override
+        public void onDeleteTaskPushNotificationConfig(
+                DeleteTaskPushNotificationConfigParams params, ServerCallContext context) {
+            lastDelete.set(params);
+        }
+
+        @Override
+        public Flow.Publisher<StreamingEventKind> onMessageSendStream(
+                MessageSendParams params, ServerCallContext context) {
+            throw unsupported();
+        }
+
+        @Override
+        public Flow.Publisher<StreamingEventKind> onSubscribeToTask(TaskIdParams params, ServerCallContext context) {
+            throw unsupported();
+        }
+
+        @Override
+        public Task onGetTask(TaskQueryParams params, ServerCallContext context) {
+            throw unsupported();
+        }
+
+        @Override
+        public org.a2aproject.sdk.jsonrpc.common.wrappers.ListTasksResult onListTasks(
+                ListTasksParams params, ServerCallContext context) {
+            throw unsupported();
+        }
+
+        @Override
+        public Task onCancelTask(CancelTaskParams params, ServerCallContext context) {
+            throw unsupported();
+        }
+
+        @Override
+        public EventKind onMessageSend(MessageSendParams params, ServerCallContext context) {
+            throw unsupported();
+        }
+
+        @Override
+        public void validateRequestedTask(String requestedTaskId) {
         }
 
         private static UnsupportedOperationException unsupported() {

--- a/architecture/docs/L2/agent-runtime/REMOTE_A2A_TOOL_INVOCATION_DESIGN.md
+++ b/architecture/docs/L2/agent-runtime/REMOTE_A2A_TOOL_INVOCATION_DESIGN.md
@@ -424,10 +424,39 @@ RemoteAgentDescriptor + local policy override + call args
 | --- | --- | --- | --- |
 | `COMPLETED` | `markSucceeded(...)` 保存 tool result，清理 remote waiting metadata。 | tool result 回到本地 agent，继续推理。 | 不直接看到远端结果，只看到 parent agent 最终输出。 |
 | `INPUT_REQUIRED` | `markInputRequired(...)` 写 parent `TASK_STATE_INPUT_REQUIRED`，保存 remote task/context，`waitingTarget=REMOTE_AGENT`，并把远端 status message 投影到 parent status message。 | 当前执行停止为 interrupted/waiting，不能继续让 LLM 编最终答案。 | 看到 parent task 的 input-required message。 |
-| `PROGRESS` | 默认只记录 metadata 或内部观察事件，不写 caller-visible artifact。 | 不恢复本地 agent。 | 默认不直接看到。 |
+| `PROGRESS` / streaming message | 写 parent `EventQueue`，标记为远端过程事件；不改变 parent 的最终输出语义。 | 不恢复本地 agent。 | streaming 调用方可看到；`tasks/get` 按 A2A task/event 能力看到历史或当前 working message。 |
 | `FAILED` | 默认保存 tool error；fatal policy 才写 parent `TASK_STATE_FAILED`。 | 非 fatal 时作为 tool error 恢复本地 agent。 | fatal 才直接看到失败。 |
 | `TIMEOUT` | 默认保存 tool error，可按 policy cancel remote task。 | 非 fatal 时作为 tool error 恢复本地 agent。 | fatal 才直接看到失败。 |
 | parent cancel | parent 写 `TASK_STATE_CANCELED`，传播 remote cancel。 | 停止本地执行。 | 看到取消。 |
+
+#### 远端 streaming 消息与最终状态
+
+远端 `message/stream` 场景下，远端 agent 可能先发若干 message/artifact/status.message，最后才把 task 状态更新为 `TASK_STATE_INPUT_REQUIRED`。这些中间消息不能丢，但也不能被当成 parent agent 的最终答案。
+
+处理原则：
+
+1. access.a2a outbound adapter 读取远端 SSE 事件后，先映射成 neutral remote event，再交给 `RemoteInvocationControl` 写 parent A2A `EventQueue`。
+2. 用户可见的远端 message/artifact 作为 parent 任务的“远端过程事件”发布，metadata 必须包含 `runtime.remoteInvocationId`、`runtime.remoteAgentId`、`runtime.remoteTaskId`、`runtime.remoteEventRole=REMOTE_PROGRESS`。
+3. parent task 在远端最终状态到达前保持 `TASK_STATE_WORKING`；中间 working message 可以作为 working status event 或 artifact event 出现在 stream 中，但不能设置 `waitingTarget=REMOTE_AGENT`。
+4. 只有远端最终 `TASK_STATE_INPUT_REQUIRED` 才能把 parent task 切到 `TASK_STATE_INPUT_REQUIRED`，并写 `runtime.waitingTarget=REMOTE_AGENT`。
+5. 只有 parent agent 消化远端 completed tool result 后生成的回答，才是 parent final output。
+
+事件映射：
+
+| 远端 SSE 事件 | parent 映射 | 用户可见性 | 备注 |
+| --- | --- | --- | --- |
+| remote `TaskStatusUpdateEvent(WORKING, message)` | parent `TaskStatusUpdateEvent(WORKING, projected message)`，metadata 标记 `REMOTE_PROGRESS`。 | 可见。 | 表示远端进度或阶段性说明，不触发用户输入路由。 |
+| remote `TaskArtifactUpdateEvent` / assistant message | parent `TaskArtifactUpdateEvent`，metadata 标记 `REMOTE_PROGRESS`。 | 可见。 | 可用于展示远端阶段性内容；不是 parent final artifact。 |
+| remote `TASK_STATE_INPUT_REQUIRED(status.message)` | parent `TaskStatusUpdateEvent(INPUT_REQUIRED, projected message)`，更新 parent status 和 waiting metadata。 | 可见且需要用户回复。 | 这是下一轮输入路由的唯一触发点。 |
+| remote `TASK_STATE_COMPLETED` | 生成 `RemoteAgentResult.Completed`，作为 tool result 交回 parent agent。 | 不直接作为 final output。 | 若 completed 前已有远端过程消息，保留为过程历史。 |
+| remote `FAILED/TIMEOUT/CANCELED` | 按 policy 写 tool error 或 parent failed/canceled。 | fatal 时可见。 | 非 fatal 时交给 parent agent 消化。 |
+
+去重规则：
+
+- 最终 `INPUT_REQUIRED.status.message` 是权威用户提示。
+- 如果最终 prompt 与最后一条远端过程消息语义相同，`markInputRequired(...)` 仍必须写 parent `INPUT_REQUIRED` status event；UI/egress 可根据 `runtime.remoteMessageId` 或 `runtime.promptSourceEventId` 去重展示。
+- 如果远端最终 `INPUT_REQUIRED` 没有 `status.message`，`A2aRemoteResultMapper` 可用最后一条用户可见远端过程消息作为 fallback prompt；若仍没有可用内容，再生成兜底 text message。
+- 中间过程消息不设置 `runtime.waitingTarget`，所以用户在最终状态前追加输入时，control 仍按 parent `WORKING` 处理：拒绝新输入或返回“仍在工作”。
 
 远端直接 `COMPLETED` 时：
 
@@ -601,7 +630,7 @@ remote completed after resume
 
 如果 OpenJiuwen 当前版本的某个 agent 类型没有可用的 tool interrupt resume 能力，v1 可退化为把远端 tool result 作为追加上下文重新调用本地 agent，但这个降级必须由 `engine.openjiuwen` 封装，不能泄漏到 access/control。对 ReActAgent，优先使用同一个 `sessionId` / `conversation_id` 加 `InteractiveInput.update(toolCallId, remoteToolResult)` 恢复。
 
-用户可见输出只遵循两类：parent agent 最终输出；或者为了继续任务必须让用户输入的 parent `INPUT_REQUIRED`。
+用户可见输出分三类，语义不能混用：远端过程事件只表示 remote agent 的阶段性输出；parent `INPUT_REQUIRED` 表示必须等待用户补充输入；parent agent 最终输出才表示本地任务完成。
 
 ## 实现切片
 
@@ -625,6 +654,7 @@ remote completed after resume
 6. 新增 `A2aRemoteAgentOutboundAdapter.invoke(...)`。
 7. 增加 OpenJiuwen tool injection hook、installer、`OpenJiuwenRemoteAgentInterruptRail`、agent-instance-to-handler adapter/factory，确保 ReActAgent v1 由 rail-first 发起远端调用，占位 tool 不重复调用。
 8. 覆盖 blocking 下的 `COMPLETED`、`FAILED`、`TIMEOUT`、`INPUT_REQUIRED`：其中 `INPUT_REQUIRED` 必须写 parent task status message，并触发 OpenJiuwen 原生 interrupt。
+9. 覆盖远端 `message/stream` 中最终状态前的 message/artifact 投影：写 parent EventQueue 的 `REMOTE_PROGRESS` 事件，但不设置 remote waiting route。
 
 ### Phase 3：Background + Remote Resume
 
@@ -762,6 +792,7 @@ agent-runtime/
 - engine output 写入 `TaskStatusUpdateEvent` / `TaskArtifactUpdateEvent`。
 - OpenJiuwen remote tool/rail bridge 只调用 `RemoteAgentInvocationService`，不直接调用 A2A client，且不会由 rail 与占位 tool 双重触发远端调用。
 - remote tool call 会写 parent task metadata。
+- remote streaming message/artifact 会写 parent EventQueue 的远端过程事件，不会触发 `waitingTarget=REMOTE_AGENT`。
 - `TASK_STATE_INPUT_REQUIRED + runtime.waitingTarget=REMOTE_AGENT` 会路由到 `resumeRemoteInput(...)`。
 - remote terminal success 只作为 tool result，不直接写 parent completed。
 - parent agent final answer 才写 `TASK_STATE_COMPLETED`。

--- a/docs/logs/reviews/2026-06-09-agent-runtime-remote-a2a-tool-invocation-proposal.cn.md
+++ b/docs/logs/reviews/2026-06-09-agent-runtime-remote-a2a-tool-invocation-proposal.cn.md
@@ -31,6 +31,7 @@ affects_artefact:
 - control 仍是状态权威，远端调用生命周期先经过 `RemoteInvocationControl` 写 parent A2A task metadata/event。
 - 真正的 A2A client 只存在于 `access.a2a.A2aRemoteAgentOutboundAdapter` 内部，通过 `RemoteAgentOutboundPort` 隔离协议 I/O。
 - 远端 terminal result 只作为 tool result 回到 parent agent；只有 parent agent 的最终回答才成为 parent caller-visible final output。
+- 远端 SSE 在最终状态前吐出的 message/artifact 要作为 parent EventQueue 的远端过程事件投影给用户，但不能触发下一轮输入路由。
 - 远端 `input-required` 必须把远端 `status.message.parts` 投影到 parent A2A task，让用户能看到远端要求补充的信息；下一轮用户输入按 parent task metadata 路由回同一个 remote task/context。
 
 一句话定位：
@@ -83,6 +84,7 @@ Strongest interpretation：目标不是再加一条旁路 A2A client，而是让
 - OpenJiuwen agent 实例到 runtime handler adapter/factory。
 - `RemoteAgentInvocationService`、`RemoteInvocationControl`、`RemoteAgentOutboundPort` 的边界。
 - blocking / background 两种远端调用模式。
+- 远端 streaming message/artifact 到 parent A2A EventQueue 的过程事件投影规则。
 - 远端 `input-required` 到 parent task status message 的投影与下一轮 resume 分流。
 - 目标文件目录树与实现切片。
 
@@ -210,6 +212,25 @@ OpenJiuwen LLM tool_call
 `AUTO` 只能在 `DefaultRemoteAgentInvocationService` 内解析一次，解析后固化为 `BLOCKING` 或 `BACKGROUND`。不要把 `AUTO` 传到 `access.a2a`。
 
 ### 3.5 远端 input-required 的用户可见投影
+
+远端 `message/stream` 通常不是只在最后返回一个状态。远端 agent 可能先发送若干 message/artifact/status.message，最后才把 task 状态更新为 `TASK_STATE_INPUT_REQUIRED`。
+
+这些最终状态前的消息处理规则如下：
+
+| 远端 SSE 事件 | parent 映射 | 用户可见性 | 路由影响 |
+| --- | --- | --- | --- |
+| remote `TaskStatusUpdateEvent(WORKING, message)` | parent `TaskStatusUpdateEvent(WORKING, projected message)`，metadata 标记 `runtime.remoteEventRole=REMOTE_PROGRESS`。 | streaming 用户可见。 | 不设置 `waitingTarget`。 |
+| remote `TaskArtifactUpdateEvent` / assistant message | parent `TaskArtifactUpdateEvent`，metadata 标记 `REMOTE_PROGRESS`。 | streaming 用户可见。 | 不设置 `waitingTarget`。 |
+| remote `TASK_STATE_INPUT_REQUIRED(status.message)` | parent `TaskStatusUpdateEvent(INPUT_REQUIRED, projected message)`，更新 parent status 和 waiting metadata。 | 可见且需要用户回复。 | 设置 `waitingTarget=REMOTE_AGENT`。 |
+| remote `TASK_STATE_COMPLETED` | 生成 `RemoteAgentResult.Completed`，作为 tool result 交回 parent agent。 | 不直接作为 parent final output。 | 清理 remote waiting metadata。 |
+
+也就是说，最终 `INPUT_REQUIRED` 之前的消息会给 streaming 用户看，但语义是“远端过程事件”。它们不能让 parent task 进入 `INPUT_REQUIRED`，也不能让下一轮用户输入路由到远端。下一轮输入路由只能由最终 `TASK_STATE_INPUT_REQUIRED` 加 parent metadata 触发。
+
+去重与兜底规则：
+
+- 最终 `INPUT_REQUIRED.status.message` 是权威用户提示。
+- 如果最终 prompt 与最后一条远端过程消息相同，仍写 parent `INPUT_REQUIRED` status event；UI/egress 可用 `runtime.remoteMessageId` 或 `runtime.promptSourceEventId` 去重展示。
+- 如果远端最终 `INPUT_REQUIRED` 没有 `status.message`，可用最后一条用户可见远端过程消息作为 fallback prompt；若仍没有内容，再生成兜底 text message。
 
 远端 `TASK_STATE_INPUT_REQUIRED` 不只是状态，还携带用户需要看的 `status.message`。必须投影到 parent task：
 
@@ -394,6 +415,7 @@ agent-runtime/
 4. `RemoteAgentInvocationService` + `RemoteInvocationControl`。
 5. `A2aRemoteAgentOutboundAdapter.invoke(...)`。
 6. 覆盖 blocking 下的 terminal success、failure、timeout、input-required；input-required 必须写 parent task status message 并触发 OpenJiuwen 原生 interrupt。
+7. 覆盖远端 `message/stream` 中最终状态前的 message/artifact 投影：写 parent EventQueue 的 `REMOTE_PROGRESS` 事件，但不设置 remote waiting route。
 
 ### Phase 3 — Background + Remote Resume
 
@@ -418,6 +440,7 @@ agent-runtime/
 - OpenJiuwen remote tool/rail bridge 只调用 `RemoteAgentInvocationService`，不直接调用 A2A client，且不会由 rail 与占位 tool 双重触发远端调用。
 - `RemoteAgentOutboundPort` 可以用 fake 实现测试 engine/control；真实 A2A client 只在 `A2aRemoteAgentOutboundAdapter`。
 - remote tool call 会写 parent task metadata。
+- remote streaming message/artifact 会写 parent EventQueue 的远端过程事件，不会触发 `waitingTarget=REMOTE_AGENT`。
 - `TASK_STATE_INPUT_REQUIRED + runtime.waitingTarget=REMOTE_AGENT` 会路由到 `resumeRemoteInput(...)`。
 - remote input-required 的 `status.message.parts` 会投影到 parent `TaskStatusUpdateEvent` 和 parent task status。
 - remote terminal success 只作为 tool result，不直接写 parent completed。

--- a/examples/agent-runtime-a2a-return-modes-e2e/README.cn.md
+++ b/examples/agent-runtime-a2a-return-modes-e2e/README.cn.md
@@ -1,0 +1,280 @@
+# Agent Runtime A2A 三种返回方式验证示例
+
+## 目的
+
+本示例验证 `agent-runtime` 当前 A2A 入口的三种返回方式：
+
+1. 同步返回：A2A SDK JSON-RPC `SendMessage`，HTTP JSON-RPC 普通响应。
+2. 流式返回：A2A SDK JSON-RPC `SendStreamingMessage`，HTTP SSE 返回多个 A2A streaming event。
+3. Push Notification：当前任务通过 `configuration.taskPushNotificationConfig` 携带 callback，runtime 在任务事件发生时回调本地 callback URL。
+
+示例不依赖真实大模型。它使用一个确定性 `AgentRuntimeHandler`，方便稳定验证协议链路。
+
+## 目录
+
+```text
+examples/agent-runtime-a2a-return-modes-e2e
+  pom.xml
+  README.cn.md
+  src/main/java/com/huawei/ascend/examples/a2a/returnmodes
+    ReturnModesA2aRuntimeApplication.java
+    ReturnModesAgentConfiguration.java
+    ReturnModesA2aClient.java
+    PushNotificationInbox.java
+    PushNotificationInboxController.java
+  scripts
+    push-listener.ps1
+  src/test/java/com/huawei/ascend/examples/a2a/returnmodes
+    ReturnModesA2aE2eTest.java
+```
+
+## 服务行为
+
+示例 agent id 是：
+
+```text
+return-modes-agent
+```
+
+输入包含不同关键字时，agent 返回不同结果：
+
+| 输入 | 行为 |
+| --- | --- |
+| `sync` | 返回 `sync-pong` 并完成任务。 |
+| `stream` | 先输出 `stream-part-1 `、`stream-part-2 `，最后返回 `stream-done` 并完成任务。 |
+| `input` | 返回 input-required prompt：`please provide more input`。 |
+
+## 自动化测试
+
+从仓库根目录执行：
+
+```powershell
+$env:JAVA_HOME='D:\Software\Java\jdk-21.0.11'
+$env:Path='D:\Software\Java\jdk-21.0.11\bin;D:\Software\apache-maven-3.9.16\bin;' + $env:Path
+mvn -f examples/agent-runtime-a2a-return-modes-e2e/pom.xml test
+```
+
+成功标准：
+
+- 测试能启动随机端口的 Spring Boot runtime。
+- AgentCard 中 `capabilities.streaming=true`。
+- AgentCard 中 `capabilities.pushNotifications=true`。
+- 同步 `SendMessage` 返回 A2A `Task`，task 状态为 `TASK_STATE_COMPLETED`，文本包含 `sync-pong`。
+- 流式 `SendStreamingMessage` 返回 SSE event，能看到 `stream-part-1`、`stream-part-2` 和 `stream-done`。
+- 已存在 task 的 push notification config 能 `CreateTaskPushNotificationConfig` / `GetTaskPushNotificationConfig` / `ListTaskPushNotificationConfigs`。
+- 当前任务在 `SendStreamingMessage` 的 `configuration.taskPushNotificationConfig` 里携带 callback 后，`/test/push-notifications` 能收到回调 payload，payload 中包含 `stream-part-1`。
+
+## 手工启动
+
+先确保 `agent-runtime` 可被本示例依赖解析。如果没有安装过：
+
+```powershell
+mvn -pl agent-runtime -am install -DskipTests -Dmaven.test.skip=true
+```
+
+启动示例服务：
+
+```powershell
+mvn -f examples/agent-runtime-a2a-return-modes-e2e/pom.xml spring-boot:run
+```
+
+服务默认监听：
+
+```text
+http://localhost:8080
+```
+
+可通过环境变量改端口：
+
+```powershell
+$env:SAA_RETURN_MODES_PORT='18080'
+mvn -f examples/agent-runtime-a2a-return-modes-e2e/pom.xml spring-boot:run
+```
+
+## 手工验证同步返回
+
+```powershell
+$body = @{
+  jsonrpc = '2.0'
+  id = 'sync-1'
+  method = 'SendMessage'
+  params = @{
+    message = @{
+      role = 'ROLE_USER'
+      messageId = 'msg-sync-1'
+      contextId = 'ctx-sync-1'
+      metadata = @{
+        userId = 'manual-user'
+        agentId = 'return-modes-agent'
+      }
+      parts = @(@{ text = 'sync' })
+    }
+  }
+} | ConvertTo-Json -Depth 10
+
+$response = Invoke-RestMethod http://localhost:8080/a2a -Method Post -ContentType 'application/json' -Body $body
+
+$response | ConvertTo-Json -Depth 20
+$response.result.task.status.state
+$response.result.task.status.message.parts[0].text
+```
+
+说明：PowerShell 直接打印 `Invoke-RestMethod` 的返回值时，嵌套对象可能显示成 `@{task=}`。这只是 PowerShell 的表格折叠展示，不代表 `task` 为空。用 `ConvertTo-Json -Depth 20` 展开后才能看到完整 JSON-RPC result。
+
+成功标准：完整 JSON 中返回 `result.task`；`$response.result.task.status.state` 输出 `TASK_STATE_COMPLETED`；`$response.result.task.status.message.parts[0].text` 输出 `sync-pong`。
+
+## 手工验证流式返回
+
+```powershell
+$body = @{
+  jsonrpc = '2.0'
+  id = 'stream-1'
+  method = 'SendStreamingMessage'
+  params = @{
+    message = @{
+      role = 'ROLE_USER'
+      messageId = 'msg-stream-1'
+      contextId = 'ctx-stream-1'
+      metadata = @{
+        userId = 'manual-user'
+        agentId = 'return-modes-agent'
+      }
+      parts = @(@{ text = 'stream' })
+    }
+  }
+} | ConvertTo-Json -Depth 10
+
+$tmpBody = Join-Path $env:TEMP 'a2a-stream-body.json'
+$body | Set-Content -Path $tmpBody -Encoding UTF8
+
+curl.exe -N http://localhost:8080/a2a `
+  -H "Content-Type: application/json" `
+  -H "Accept: text/event-stream" `
+  --data-binary "@$tmpBody"
+```
+
+成功标准：输出 `data:` 开头的 SSE 事件，事件内容中能看到两段 `artifactUpdate`，分别包含 `stream-part-1` 和 `stream-part-2`，最后还能看到状态更新里的 `stream-done`。
+
+## 手工验证 Push Notification
+
+手工验证 push notification 有两种方式。
+
+方式一：使用示例服务内置 inbox。它适合快速验证，但回调和 runtime 在同一个进程里：
+
+```text
+POST /test/push-notifications
+GET  /test/push-notifications
+```
+
+`POST` 是 runtime 的 push callback 地址，`GET` 用于查看已经收到的 callback payload。
+
+方式二：单独起一个 PowerShell callback listener。它更接近真实 push notification 场景，也能在监听窗口直接看到远端回调。推荐手工验证用这个方式。
+
+### 窗口 1：启动 callback listener
+
+```powershell
+cd D:\Code\spring-ai-ascend
+powershell -ExecutionPolicy Bypass -File examples\agent-runtime-a2a-return-modes-e2e\scripts\push-listener.ps1
+```
+
+成功启动后，窗口会显示：
+
+```text
+Listening for A2A push notifications at http://localhost:19090/test/push-notifications/
+```
+
+### 窗口 2：启动 runtime 服务
+
+```powershell
+cd D:\Code\spring-ai-ascend
+$env:JAVA_HOME='D:\Software\Java\jdk-21.0.11'
+$env:Path='D:\Software\Java\jdk-21.0.11\bin;D:\Software\apache-maven-3.9.16\bin;' + $env:Path
+mvn -f examples/agent-runtime-a2a-return-modes-e2e/pom.xml spring-boot:run
+```
+
+### 窗口 3：发送带 push callback 的 A2A 请求
+
+如果 runtime 使用默认端口 `8080`，执行：
+
+```powershell
+$callbackUrl = 'http://localhost:19090/test/push-notifications/'
+
+$body = @{
+  jsonrpc = '2.0'
+  id = 'push-stream-1'
+  method = 'SendStreamingMessage'
+  params = @{
+    message = @{
+      role = 'ROLE_USER'
+      messageId = 'msg-push-stream-1'
+      contextId = 'ctx-push-stream-1'
+      metadata = @{
+        userId = 'manual-user'
+        agentId = 'return-modes-agent'
+      }
+      parts = @(@{ text = 'stream' })
+    }
+    configuration = @{
+      taskPushNotificationConfig = @{
+        id = 'manual-push-1'
+        url = $callbackUrl
+      }
+    }
+  }
+} | ConvertTo-Json -Depth 12
+
+$response = Invoke-WebRequest `
+  -UseBasicParsing `
+  -Uri http://localhost:8080/a2a `
+  -Method Post `
+  -ContentType 'application/json' `
+  -Headers @{ Accept = 'text/event-stream' } `
+  -Body $body
+
+$response.StatusCode
+$response.Content
+```
+
+成功标准：窗口 3 会看到 SSE 返回，窗口 1 会直接打印 push callback，例如：
+
+```text
+===== A2A Push Notification 2026-06-10 10:30:00 =====
+POST /test/push-notifications/
+...stream-part-1...
+```
+
+只要窗口 1 至少打印出一条 callback payload，并且 payload 中能看到 `stream-part-1`，就说明 push notification 链路成功。
+
+如果一定要用 `curl.exe`，不要直接 `-d $body`。Windows PowerShell 下多行 JSON 变量可能被 curl 参数解析截断，runtime 日志会出现 `MalformedJsonException: Unterminated object ... taskPushNotificationConfig.url`。可以先把请求体写入临时文件，再用 `--data-binary '@文件名'`：
+
+```powershell
+$tmpBody = Join-Path $env:TEMP 'a2a-push-body.json'
+$body | Set-Content -Path $tmpBody -Encoding UTF8
+
+curl.exe -N http://localhost:8080/a2a `
+  -H "Content-Type: application/json" `
+  -H "Accept: text/event-stream" `
+  --data-binary "@$tmpBody"
+```
+
+如果不想另起 listener，也可以把 `$callbackUrl` 改成内置 inbox：
+
+```powershell
+$callbackUrl = 'http://localhost:8080/test/push-notifications'
+```
+
+然后用下面命令查看 runtime 进程内收到的 payload：
+
+```powershell
+Invoke-RestMethod http://localhost:8080/test/push-notifications -Method Get
+```
+
+说明：`CreateTaskPushNotificationConfig` / `GetTaskPushNotificationConfig` / `ListTaskPushNotificationConfigs` 是“已存在 task 的配置管理 API”。如果要在创建当前任务时立刻收到 push，推荐像上面的例子一样把 callback 放进本次 `SendStreamingMessage` 的 `configuration.taskPushNotificationConfig`，此时 `taskId` 可以不填，runtime 会绑定到本次新建的真实 task。
+
+## 说明
+
+本示例验证的是 A2A 返回方式，不验证真实 LLM。真实 OpenJiuwen 调用请看：
+
+```text
+examples/agent-runtime-a2a-openjiuwen-e2e
+```

--- a/examples/agent-runtime-a2a-return-modes-e2e/pom.xml
+++ b/examples/agent-runtime-a2a-return-modes-e2e/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.huawei.ascend</groupId>
+    <artifactId>spring-ai-ascend-parent</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>agent-runtime-a2a-return-modes-e2e-example</artifactId>
+  <packaging>jar</packaging>
+  <name>spring-ai-ascend agent-runtime A2A return modes E2E example</name>
+  <description>Example verifying A2A synchronous, streaming, and push notification return modes.</description>
+
+  <properties>
+    <enforcer.skip>true</enforcer.skip>
+    <a2a.sdk.version>1.0.0.CR1</a2a.sdk.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.huawei.ascend</groupId>
+      <artifactId>agent-runtime</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.a2aproject.sdk</groupId>
+      <artifactId>a2a-java-sdk-client-transport-jsonrpc</artifactId>
+      <version>${a2a.sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.a2aproject.sdk</groupId>
+      <artifactId>a2a-java-sdk-http-client</artifactId>
+      <version>${a2a.sdk.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.6.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <mainClass>com.huawei.ascend.examples.a2a.returnmodes.ReturnModesA2aRuntimeApplication</mainClass>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/agent-runtime-a2a-return-modes-e2e/scripts/push-listener.ps1
+++ b/examples/agent-runtime-a2a-return-modes-e2e/scripts/push-listener.ps1
@@ -1,0 +1,36 @@
+param(
+    [string] $Prefix = "http://localhost:19090/test/push-notifications/"
+)
+
+$listener = [System.Net.HttpListener]::new()
+$listener.Prefixes.Add($Prefix)
+$listener.Start()
+
+Write-Host "Listening for A2A push notifications at $Prefix"
+Write-Host "Press Ctrl+C to stop."
+
+try {
+    while ($listener.IsListening) {
+        $context = $listener.GetContext()
+        $request = $context.Request
+        $reader = [System.IO.StreamReader]::new($request.InputStream, $request.ContentEncoding)
+        $body = $reader.ReadToEnd()
+        $reader.Dispose()
+
+        Write-Host ""
+        Write-Host "===== A2A Push Notification $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss') ====="
+        Write-Host "$($request.HttpMethod) $($request.RawUrl)"
+        Write-Host $body
+
+        $responseBody = [System.Text.Encoding]::UTF8.GetBytes("accepted")
+        $response = $context.Response
+        $response.StatusCode = 202
+        $response.ContentType = "text/plain; charset=utf-8"
+        $response.OutputStream.Write($responseBody, 0, $responseBody.Length)
+        $response.Close()
+    }
+}
+finally {
+    $listener.Stop()
+    $listener.Close()
+}

--- a/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/PushNotificationInbox.java
+++ b/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/PushNotificationInbox.java
@@ -1,0 +1,58 @@
+package com.huawei.ascend.examples.a2a.returnmodes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PushNotificationInbox {
+    private final Object monitor = new Object();
+    private final List<String> payloads = new ArrayList<>();
+    private CountDownLatch latch = new CountDownLatch(1);
+
+    public void reset() {
+        synchronized (monitor) {
+            payloads.clear();
+            latch = new CountDownLatch(1);
+        }
+    }
+
+    public void record(String payload) {
+        synchronized (monitor) {
+            payloads.add(payload);
+            latch.countDown();
+            monitor.notifyAll();
+        }
+    }
+
+    public List<String> payloads() {
+        synchronized (monitor) {
+            return List.copyOf(payloads);
+        }
+    }
+
+    public boolean awaitFirst(long timeout, TimeUnit unit) throws InterruptedException {
+        CountDownLatch current;
+        synchronized (monitor) {
+            current = latch;
+        }
+        return current.await(timeout, unit);
+    }
+
+    public boolean awaitPayload(Predicate<String> predicate, long timeout, TimeUnit unit) throws InterruptedException {
+        long deadlineNanos = System.nanoTime() + unit.toNanos(timeout);
+        synchronized (monitor) {
+            while (payloads.stream().noneMatch(predicate)) {
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    return false;
+                }
+                TimeUnit.NANOSECONDS.timedWait(monitor, remainingNanos);
+            }
+            return true;
+        }
+    }
+}

--- a/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/PushNotificationInboxController.java
+++ b/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/PushNotificationInboxController.java
@@ -1,0 +1,28 @@
+package com.huawei.ascend.examples.a2a.returnmodes;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PushNotificationInboxController {
+    private final PushNotificationInbox inbox;
+
+    public PushNotificationInboxController(PushNotificationInbox inbox) {
+        this.inbox = inbox;
+    }
+
+    @PostMapping("/test/push-notifications")
+    public ResponseEntity<Void> receive(@RequestBody String payload) {
+        inbox.record(payload);
+        return ResponseEntity.accepted().build();
+    }
+
+    @GetMapping("/test/push-notifications")
+    public ResponseEntity<List<String>> list() {
+        return ResponseEntity.ok(inbox.payloads());
+    }
+}

--- a/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesA2aClient.java
+++ b/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesA2aClient.java
@@ -1,0 +1,224 @@
+package com.huawei.ascend.examples.a2a.returnmodes;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.a2aproject.sdk.client.http.A2ACardResolver;
+import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransport;
+import org.a2aproject.sdk.client.transport.spi.interceptors.ClientCallContext;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.EventKind;
+import org.a2aproject.sdk.spec.GetTaskPushNotificationConfigParams;
+import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsParams;
+import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
+import org.a2aproject.sdk.spec.Message;
+import org.a2aproject.sdk.spec.MessageSendConfiguration;
+import org.a2aproject.sdk.spec.MessageSendParams;
+import org.a2aproject.sdk.spec.Part;
+import org.a2aproject.sdk.spec.StreamingEventKind;
+import org.a2aproject.sdk.spec.Task;
+import org.a2aproject.sdk.spec.TaskArtifactUpdateEvent;
+import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
+import org.a2aproject.sdk.spec.TextPart;
+
+public final class ReturnModesA2aClient {
+    private final URI baseUri;
+    private final Duration timeout;
+
+    public ReturnModesA2aClient(URI baseUri, Duration timeout) {
+        this.baseUri = baseUri;
+        this.timeout = timeout;
+    }
+
+    public AgentCard agentCard() throws Exception {
+        return new A2ACardResolver(baseUri.toString()).getAgentCard();
+    }
+
+    public EventKind sendMessage(String text) throws Exception {
+        return sendMessage(messageSendParams(text));
+    }
+
+    private EventKind sendMessage(MessageSendParams params) throws Exception {
+        AgentCard card = agentCard();
+        JSONRPCTransport transport = new JSONRPCTransport(card);
+        try {
+            return transport.sendMessage(params, context());
+        } finally {
+            transport.close();
+        }
+    }
+
+    public List<StreamingEventKind> streamMessage(String text) throws Exception {
+        return streamMessage(messageSendParams(text));
+    }
+
+    public List<StreamingEventKind> streamMessageWithPushConfig(String text, String callbackUrl) throws Exception {
+        TaskPushNotificationConfig pushConfig = new TaskPushNotificationConfig(
+                "push-" + UUID.randomUUID(), null, callbackUrl, null, null, null);
+        MessageSendConfiguration configuration = MessageSendConfiguration.builder()
+                .taskPushNotificationConfig(pushConfig)
+                .build();
+        return streamMessage(messageSendParams(text, configuration));
+    }
+
+    private List<StreamingEventKind> streamMessage(MessageSendParams params) throws Exception {
+        AgentCard card = agentCard();
+        JSONRPCTransport transport = new JSONRPCTransport(card);
+        List<StreamingEventKind> events = new ArrayList<>();
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        try {
+            transport.sendMessageStreaming(
+                    params,
+                    event -> {
+                        events.add(event);
+                        if (isTerminal(event)) {
+                            completed.countDown();
+                        }
+                    },
+                    error -> {
+                        failure.set(error);
+                        completed.countDown();
+                    },
+                    context());
+            if (!completed.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException("A2A stream did not complete before timeout");
+            }
+        } finally {
+            transport.close();
+        }
+        if (failure.get() != null && events.stream().noneMatch(ReturnModesA2aClient::isTerminal)) {
+            throw new IllegalStateException("A2A stream failed", failure.get());
+        }
+        return List.copyOf(events);
+    }
+
+    public TaskPushNotificationConfig createPushConfig(String taskId, String callbackUrl) throws Exception {
+        AgentCard card = agentCard();
+        JSONRPCTransport transport = new JSONRPCTransport(card);
+        try {
+            return transport.createTaskPushNotificationConfiguration(
+                    new TaskPushNotificationConfig("push-" + taskId, taskId, callbackUrl, null, null, null),
+                    context());
+        } finally {
+            transport.close();
+        }
+    }
+
+    public TaskPushNotificationConfig getPushConfig(String taskId, String id) throws Exception {
+        AgentCard card = agentCard();
+        JSONRPCTransport transport = new JSONRPCTransport(card);
+        try {
+            return transport.getTaskPushNotificationConfiguration(
+                    new GetTaskPushNotificationConfigParams(taskId, id),
+                    context());
+        } finally {
+            transport.close();
+        }
+    }
+
+    public ListTaskPushNotificationConfigsResult listPushConfigs(String taskId) throws Exception {
+        AgentCard card = agentCard();
+        JSONRPCTransport transport = new JSONRPCTransport(card);
+        try {
+            return transport.listTaskPushNotificationConfigurations(
+                    new ListTaskPushNotificationConfigsParams(taskId),
+                    context());
+        } finally {
+            transport.close();
+        }
+    }
+
+    static String textFrom(EventKind event) {
+        if (event instanceof Task task) {
+            StringBuilder text = new StringBuilder();
+            if (task.history() != null) {
+                task.history().forEach(message -> text.append(textFromParts(message.parts())));
+            }
+            if (task.artifacts() != null) {
+                task.artifacts().forEach(artifact -> text.append(textFromParts(artifact.parts())));
+            }
+            if (task.status() != null && task.status().message() != null) {
+                text.append(textFromParts(task.status().message().parts()));
+            }
+            return text.toString();
+        }
+        if (event instanceof Message message) {
+            return textFromParts(message.parts());
+        }
+        return "";
+    }
+
+    static String textFrom(List<StreamingEventKind> events) {
+        StringBuilder text = new StringBuilder();
+        for (StreamingEventKind event : events) {
+            if (event instanceof Message message) {
+                text.append(textFromParts(message.parts()));
+            } else if (event instanceof TaskStatusUpdateEvent statusEvent
+                    && statusEvent.status() != null
+                    && statusEvent.status().message() != null) {
+                text.append(textFromParts(statusEvent.status().message().parts()));
+            } else if (event instanceof TaskArtifactUpdateEvent artifactEvent
+                    && artifactEvent.artifact() != null) {
+                text.append(textFromParts(artifactEvent.artifact().parts()));
+            }
+        }
+        return text.toString();
+    }
+
+    static boolean hasTerminalEvent(List<StreamingEventKind> events) {
+        return events.stream().anyMatch(ReturnModesA2aClient::isTerminal);
+    }
+
+    private static boolean isTerminal(StreamingEventKind event) {
+        return event instanceof TaskStatusUpdateEvent statusEvent
+                && statusEvent.status() != null
+                && statusEvent.status().state() != null
+                && (statusEvent.status().state() == TaskState.TASK_STATE_COMPLETED
+                || statusEvent.status().state() == TaskState.TASK_STATE_FAILED
+                || statusEvent.status().state() == TaskState.TASK_STATE_CANCELED
+                || statusEvent.status().state() == TaskState.TASK_STATE_REJECTED);
+    }
+
+    private static String textFromParts(List<Part<?>> parts) {
+        if (parts == null) {
+            return "";
+        }
+        StringBuilder text = new StringBuilder();
+        for (Part<?> part : parts) {
+            if (part instanceof TextPart textPart) {
+                text.append(textPart.text());
+            }
+        }
+        return text.toString();
+    }
+
+    private MessageSendParams messageSendParams(String text) {
+        return messageSendParams(text, null);
+    }
+
+    private MessageSendParams messageSendParams(String text, MessageSendConfiguration configuration) {
+        Message message = Message.builder()
+                .role(Message.Role.ROLE_USER)
+                .messageId(UUID.randomUUID().toString())
+                .contextId("session-" + UUID.randomUUID())
+                .metadata(Map.of(
+                        "userId", "return-modes-user",
+                        "agentId", ReturnModesAgentConfiguration.AGENT_ID))
+                .parts(List.of(new TextPart(text)))
+                .build();
+        return MessageSendParams.builder().message(message).configuration(configuration).build();
+    }
+
+    private static ClientCallContext context() {
+        return new ClientCallContext(Map.of(), Map.of());
+    }
+}

--- a/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesA2aRuntimeApplication.java
+++ b/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesA2aRuntimeApplication.java
@@ -1,0 +1,14 @@
+package com.huawei.ascend.examples.a2a.returnmodes;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {
+        "com.huawei.ascend.examples.a2a.returnmodes",
+        "com.huawei.ascend.runtime.boot"})
+public class ReturnModesA2aRuntimeApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ReturnModesA2aRuntimeApplication.class, args);
+    }
+}

--- a/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesAgentConfiguration.java
+++ b/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesAgentConfiguration.java
@@ -1,0 +1,65 @@
+package com.huawei.ascend.examples.a2a.returnmodes;
+
+import com.huawei.ascend.runtime.engine.AgentExecutionContext;
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenMessageAdapter;
+import com.huawei.ascend.runtime.engine.spi.AgentCards;
+import com.huawei.ascend.runtime.engine.spi.AgentExecutionResult;
+import com.huawei.ascend.runtime.engine.spi.AgentRuntimeHandler;
+import com.huawei.ascend.runtime.engine.spi.StreamAdapter;
+import java.util.Locale;
+import java.util.stream.Stream;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class ReturnModesAgentConfiguration {
+
+    public static final String AGENT_ID = "return-modes-agent";
+
+    @Bean
+    AgentRuntimeHandler returnModesAgentRuntimeHandler() {
+        return new DeterministicReturnModesHandler();
+    }
+
+    @Bean
+    org.a2aproject.sdk.spec.AgentCard returnModesAgentCard() {
+        return AgentCards.create(AGENT_ID, "Deterministic agent for A2A return mode verification.");
+    }
+
+    private static final class DeterministicReturnModesHandler implements AgentRuntimeHandler {
+        private static final StreamAdapter ADAPTER = rawResults -> rawResults.map(AgentExecutionResult.class::cast);
+
+        @Override
+        public String agentId() {
+            return AGENT_ID;
+        }
+
+        @Override
+        public boolean isHealthy() {
+            return true;
+        }
+
+        @Override
+        public Stream<?> execute(AgentExecutionContext context) {
+            String input = context.getMessages().isEmpty()
+                    ? ""
+                    : OpenJiuwenMessageAdapter.messageText(context.getMessages().getLast());
+            String normalized = input.trim().toLowerCase(Locale.ROOT);
+            if (normalized.contains("stream")) {
+                return Stream.of(
+                        AgentExecutionResult.output("stream-part-1 "),
+                        AgentExecutionResult.output("stream-part-2 "),
+                        AgentExecutionResult.completed("stream-done"));
+            }
+            if (normalized.contains("input")) {
+                return Stream.of(AgentExecutionResult.interrupted("please provide more input"));
+            }
+            return Stream.of(AgentExecutionResult.completed("sync-pong"));
+        }
+
+        @Override
+        public StreamAdapter resultAdapter() {
+            return ADAPTER;
+        }
+    }
+}

--- a/examples/agent-runtime-a2a-return-modes-e2e/src/main/resources/application.yaml
+++ b/examples/agent-runtime-a2a-return-modes-e2e/src/main/resources/application.yaml
@@ -1,0 +1,14 @@
+debug: false
+
+spring:
+  application:
+    name: agent-runtime-a2a-return-modes-e2e
+
+server:
+  port: ${SAA_RETURN_MODES_PORT:8080}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info

--- a/examples/agent-runtime-a2a-return-modes-e2e/src/test/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesA2aE2eTest.java
+++ b/examples/agent-runtime-a2a-return-modes-e2e/src/test/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesA2aE2eTest.java
@@ -1,0 +1,75 @@
+package com.huawei.ascend.examples.a2a.returnmodes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.EventKind;
+import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
+import org.a2aproject.sdk.spec.StreamingEventKind;
+import org.a2aproject.sdk.spec.Task;
+import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
+import org.a2aproject.sdk.spec.TaskState;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = ReturnModesA2aRuntimeApplication.class)
+class ReturnModesA2aE2eTest {
+    private static final Duration TIMEOUT = Duration.ofSeconds(15);
+
+    @LocalServerPort
+    private int port;
+
+    @org.springframework.beans.factory.annotation.Autowired
+    private PushNotificationInbox inbox;
+
+    @Test
+    void verifiesSynchronousStreamingAndPushNotificationReturnModes() throws Exception {
+        ReturnModesA2aClient client = new ReturnModesA2aClient(baseUri(), TIMEOUT);
+
+        AgentCard card = client.agentCard();
+        assertThat(card.capabilities().streaming()).isTrue();
+        assertThat(card.capabilities().pushNotifications()).isTrue();
+
+        EventKind syncResult = client.sendMessage("sync");
+        assertThat(syncResult).isInstanceOf(Task.class);
+        Task syncTask = (Task) syncResult;
+        assertThat(syncTask.status().state()).isEqualTo(TaskState.TASK_STATE_COMPLETED);
+        assertThat(ReturnModesA2aClient.textFrom(syncResult)).contains("sync-pong");
+
+        List<StreamingEventKind> streamEvents = client.streamMessage("stream");
+        assertThat(streamEvents).isNotEmpty();
+        assertThat(ReturnModesA2aClient.textFrom(streamEvents))
+                .contains("stream-part-1")
+                .contains("stream-part-2")
+                .contains("stream-done");
+
+        inbox.reset();
+        String taskId = syncTask.id();
+        String callbackUrl = baseUri() + "/test/push-notifications";
+        TaskPushNotificationConfig created = client.createPushConfig(taskId, callbackUrl);
+        assertThat(created.taskId()).isEqualTo(taskId);
+        assertThat(created.url()).isEqualTo(callbackUrl);
+        assertThat(client.getPushConfig(taskId, created.id()).url()).isEqualTo(callbackUrl);
+        ListTaskPushNotificationConfigsResult listed = client.listPushConfigs(taskId);
+        assertThat(listed.configs()).extracting(TaskPushNotificationConfig::id).contains(created.id());
+
+        inbox.reset();
+        List<StreamingEventKind> pushStreamEvents = client.streamMessageWithPushConfig("stream", callbackUrl);
+        assertThat(pushStreamEvents).isNotEmpty();
+
+        assertThat(inbox.awaitPayload(payload -> payload.contains("stream-part-1"), TIMEOUT.toSeconds(), TimeUnit.SECONDS))
+                .isTrue();
+        assertThat(inbox.payloads()).anySatisfy(payload -> assertThat(payload).contains("stream-part-1"));
+    }
+
+    private URI baseUri() {
+        return URI.create("http://localhost:" + port);
+    }
+}


### PR DESCRIPTION
- Add A2A JSON-RPC response wrapping for blocking runtime calls, including task push notification config APIs.
- Enable real A2A push notification delivery through the SDK `BasePushNotificationSender`.
- Emit intermediate runtime outputs as A2A artifact updates so streaming responses expose all chunks.
- Add a deterministic return-modes E2E example covering sync response, SSE streaming, and push notification callback behavior.
- Refresh the remote A2A tool invocation design/proposal docs with the latest implementation direction.
