### PR TITLE
chore(agent-runtime): drop unused OSS dependencies

### DIFF
--- a/agent-runtime/pom.xml
+++ b/agent-runtime/pom.xml
@@ -154,26 +154,11 @@
       <optional>true</optional>
     </dependency>
 
-    <!-- MCP Java SDK + A2A SDK. -->
-    <dependency>
-      <groupId>io.modelcontextprotocol.sdk</groupId>
-      <artifactId>mcp</artifactId>
-    </dependency>
+    <!-- A2A SDK: the protocol reference server (request handler, task store, event queue)
+         the runtime drives as its protocol substrate. -->
     <dependency>
       <groupId>org.a2aproject.sdk</groupId>
       <artifactId>a2a-java-sdk-server-common</artifactId>
-    </dependency>
-
-    <!-- Temporal Java SDK. -->
-    <dependency>
-      <groupId>io.temporal</groupId>
-      <artifactId>temporal-sdk</artifactId>
-    </dependency>
-
-    <!-- Apache Tika for the document-parser tool. -->
-    <dependency>
-      <groupId>org.apache.tika</groupId>
-      <artifactId>tika-core</artifactId>
     </dependency>
 
     <!-- Boot 4 + springdoc 3.0.3 transitively requires YAMLFactory at boot. -->
@@ -199,11 +184,6 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.temporal</groupId>
-      <artifactId>temporal-testing</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What
Remove `agent-runtime` dependencies with **zero source usage across the repo**:
- `io.temporal:temporal-sdk` (compile) + `io.temporal:temporal-testing` (test)
- `io.modelcontextprotocol.sdk:mcp` (compile)
- `org.apache.tika:tika-core` (compile)

## Why
All were declared but never imported anywhere (`grep -r` confirms zero `import io.temporal` / `io.modelcontextprotocol` / `org.apache.tika`). The three compile-scope ones leaked transitively onto consumers (agent-sdk, agent-service, e2e examples) for no benefit. Versions inherit from the parent BOM, so these are pure block deletes — aligns with the "reuse OSS, don't carry unused deps" principle.

## Verification (WSL, Rule G-7)
- `./mvnw -pl agent-runtime -am clean test` → BUILD SUCCESS, agent-runtime tests green
- `RuntimeAppTest` full Spring Boot context boot → green (the a2a server stack wires fine without the removed deps)
- `gate/check_architecture_sync.sh` → **GATE: PASS**
- e2e: `agent-runtime-a2a-openjiuwen-e2e` 5 pass / 1 LLM-skip; `agent-runtime-a2a-return-modes-e2e` 1 pass (deterministic full A2A return-modes path)

## Notes / follow-ups (not in this PR)
- Deleting the unwired `engine.service.AgentStateStore` is **deferred**: on `main` its last referencer is `engine.spi.StateProvider`, which open PR #157 removes — best done after #157 lands.
- `architecture/facts/generated/*` are stale on `main` (stamped at an older commit); regenerating is a separate concern, kept out of this focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)