### PR TITLE
chore(governance): wind-down residual cleanup (product_claim + ops scope + third_party)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,7 @@ __pycache__/
 .venv/
 venv/
 
-# Tier C: local source clones (gitignored; SHAs tracked in third_party/MANIFEST.md)
+# Tier C: local source clones (gitignored)
 third_party/*/
 third_party/**/
 

--- a/discovery/_gen.py
+++ b/discovery/_gen.py
@@ -200,16 +200,15 @@ def write_adr_index():
     lines.append("")
     lines.append(f"schema_version: 1 | last_updated: 2026-05-28 | count: {len(adrs)}")
     lines.append("")
-    lines.append("Tier-2 progressive-disclosure index over the ADR corpus. Each row: id link, title, `status:`, `product_claim` (`PC-NNN`, `governance_infra`, or `placeholder` pending Wave-4 backfill). Sources: `docs/adr/*.yaml`, `docs/adr/*.md`, `docs/adr/locked/*.md`, `architecture/decisions/*` (precedence in that order on id collision).")
+    lines.append("Tier-2 progressive-disclosure index over the ADR corpus. Each row: id link, title, `status:`. Sources: `docs/adr/*.yaml`, `docs/adr/*.md`, `docs/adr/locked/*.md`, `architecture/decisions/*` (precedence in that order on id collision).")
     lines.append("")
     lines.append("## Index")
     lines.append("")
     for num in sorted(adrs.keys()):
-        idstr, rel, title, status, pc = adrs[num]
+        idstr, rel, title, status, _ = adrs[num]
         title_s = shorten_title(title, cap=80)
         status_s = re.sub(r"\s+", " ", status).strip()
-        pc_s = re.sub(r"\s+", " ", pc).strip()
-        lines.append(f"- [{idstr}]({rel}) — {title_s} — {status_s} — product_claim:{pc_s}")
+        lines.append(f"- [{idstr}]({rel}) — {title_s} — {status_s}")
     lines.append("")
     (DISCOVERY / "adr-index.md").write_text("\n".join(lines), encoding="utf-8")
     return len(adrs)
@@ -256,13 +255,11 @@ def collect_rules():
             rid = mm.group(1) if mm else p.stem
         title = yaml_scalar(fm, "title") or p.stem
         status = yaml_scalar(fm, "status") or "unknown"
-        pc = yaml_scalar(fm, "product_claim") or "placeholder"
         out.append({
             "id": rid,
             "path": p.relative_to(REPO).as_posix(),
             "title": title,
             "status": status,
-            "product_claim": pc,
         })
     out.sort(key=lambda r: rule_sort_key(r["id"]))
     return out
@@ -287,7 +284,7 @@ def write_rule_index():
     lines.append("")
     lines.append("## Usage")
     lines.append("")
-    lines.append("This file is a Tier-2 progressive-disclosure index over the governance rule cards under `docs/governance/rules/`. Each line names one rule by id (D-/G-/R-/M- namespace), its canonical card path, the rule's current `status:` value, and a `product_claim` tag — either an actual `PC-NNN` id, `governance_infra` (when the rule governs framework discipline rather than a product capability), or `placeholder` (Wave-4 backfill target).")
+    lines.append("This file is a Tier-2 progressive-disclosure index over the governance rule cards under `docs/governance/rules/`. Each line names one rule by id (D-/G-/R-/M- namespace), its canonical card path, and the rule's current `status:` value.")
     lines.append("")
     lines.append("Load this index to find rules by id, topic, or status without scanning every card. Each rule's full body (motivation, details, enforcers, exit criteria) lives behind the linked card and is loaded on demand by the `/design-mode`, `/impl-mode`, `/verify-mode`, `/commit-mode`, and `/review-mode` phase-contract skills declared in `CLAUDE.md`. Sort order: namespace (D, G, M, R) then numeric/letter suffix.")
     lines.append("")
@@ -296,8 +293,7 @@ def write_rule_index():
     for r in rules:
         title = re.sub(r"\s+", " ", r["title"]).strip()
         status = re.sub(r"\s+", " ", r["status"]).strip()
-        pc = re.sub(r"\s+", " ", r["product_claim"]).strip()
-        lines.append(f"- [Rule {r['id']}]({r['path']}) — {title} — {status} — product_claim:{pc}")
+        lines.append(f"- [Rule {r['id']}]({r['path']}) — {title} — {status}")
     lines.append("")
     (DISCOVERY / "rule-index.md").write_text("\n".join(lines), encoding="utf-8")
     return len(rules)
@@ -409,13 +405,11 @@ def collect_contracts():
         text = read(p)
         purpose = contract_purpose(text)
         status = contract_status(text)
-        pc = yaml_scalar(text, "product_claim") or "placeholder"
         out.append({
             "name": p.name,
             "path": p.relative_to(REPO).as_posix(),
             "purpose": purpose,
             "status": status,
-            "product_claim": pc,
         })
     return out
 
@@ -439,7 +433,7 @@ def write_contract_index():
     lines.append("")
     lines.append("## Usage")
     lines.append("")
-    lines.append("This file is a Tier-2 progressive-disclosure index over the runtime / SPI / protocol contract schemas under `docs/contracts/`. Each line names one schema file, its one-line purpose, its current `status:` (or `runtime_enforced:` derivative), and a `product_claim` tag — either an actual `PC-NNN` id, `governance_infra` (when the contract governs framework discipline rather than a product capability), or `placeholder` (Wave-4 backfill target).")
+    lines.append("This file is a Tier-2 progressive-disclosure index over the runtime / SPI / protocol contract schemas under `docs/contracts/`. Each line names one schema file, its one-line purpose, and its current `status:` (or `runtime_enforced:` derivative).")
     lines.append("")
     lines.append("Load this index to locate contract schemas by name, purpose, or status. The full schema body lives behind the linked file. Catalog cross-reference: `docs/contracts/contract-catalog.md`. Each contract's authority ADR is named in its leading comment block per Rule M-2 sub-clause .b.")
     lines.append("")
@@ -451,8 +445,7 @@ def write_contract_index():
         if len(purpose) > 240:
             purpose = purpose[:237].rstrip() + "..."
         status = re.sub(r"\s+", " ", c["status"]).strip()
-        pc = re.sub(r"\s+", " ", c["product_claim"]).strip()
-        lines.append(f"- [{c['name']}]({c['path']}) — {purpose} — {status} — product_claim:{pc}")
+        lines.append(f"- [{c['name']}]({c['path']}) — {purpose} — {status}")
     lines.append("")
     (DISCOVERY / "contract-index.md").write_text("\n".join(lines), encoding="utf-8")
     return len(contracts)

--- a/discovery/adr-index.md
+++ b/discovery/adr-index.md
@@ -8,77 +8,76 @@ purpose: "Tier-2 progressive disclosure index — auto-loaded with summary lines
 
 # ADR Discovery Index
 
-schema_version: 1 | last_updated: 2026-05-28 | count: 68
+schema_version: 1 | last_updated: 2026-05-28 | count: 67
 
-Tier-2 progressive-disclosure index over the ADR corpus. Each row: id link, title, `status:`, `product_claim` (`PC-NNN`, `governance_infra`, or `placeholder` pending Wave-4 backfill). Sources: `docs/adr/*.yaml`, `docs/adr/*.md`, `docs/adr/locked/*.md`, `architecture/decisions/*` (precedence in that order on id collision).
+Tier-2 progressive-disclosure index over the ADR corpus. Each row: id link, title, `status:`. Sources: `docs/adr/*.yaml`, `docs/adr/*.md`, `docs/adr/locked/*.md`, `architecture/decisions/*` (precedence in that order on id collision).
 
 ## Index
 
-- [ADR-0001](docs/adr/locked/0001-java-21-spring-boot-runtime.md) — Java 21 + Spring Boot 4.0.5 as the runtime baseline — accepted — product_claim:placeholder
-- [ADR-0002](docs/adr/locked/0002-spring-ai-llm-gateway.md) — Spring AI 2.0.0-M5 as the LLM gateway, not LangChain4j — accepted — product_claim:placeholder
-- [ADR-0004](docs/adr/locked/0004-postgres-primary-data-store.md) — PostgreSQL 16 with RLS + pgvector, not separate vector DB — accepted — product_claim:placeholder
-- [ADR-0005](docs/adr/locked/0005-tenant-isolation-guc-set-local.md) — Row-level security with SET LOCAL transaction-scoped GUC, not per-connection re… — accepted — product_claim:placeholder
-- [ADR-0006](docs/adr/locked/0006-posture-model-dev-research-prod.md) — ActionGuard 5-stage chain (cycle-9 truth-cut), not 11-stage — accepted — product_claim:placeholder
-- [ADR-0010](docs/adr/locked/0010-spring-security-oauth2.md) — Keycloak (OSS) as default IdP, but customer can BYO — accepted — product_claim:placeholder
-- [ADR-0011](docs/adr/locked/0011-flyway-schema-migration.md) — Spring Cloud Gateway as ingress, not Kong / Traefik — accepted — product_claim:placeholder
-- [ADR-0014](docs/adr/locked/0014-contract-spine-versioning-policy.md) — 3-posture model (dev/research/prod), not 5 or 2 — accepted — product_claim:placeholder
-- [ADR-0015](docs/adr/locked/0015-layered-architecture-capability-model.md) — Defer multi-framework dispatch (Python sidecar, LangChain4j) to W4+ — accepted — product_claim:placeholder
-- [ADR-0016](docs/adr/0016-a2a-federation-strategic-deferral.yaml) — A2A Federation — Strategic Deferral to Post-W4 — accepted — product_claim:placeholder
-- [ADR-0020](docs/adr/locked/0020-runlifecycle-spi-and-runstatus-formal-dfa.md) — RunLifecycle SPI Separation and RunStatus Formal DFA — accepted — product_claim:placeholder
-- [ADR-0024](docs/adr/0024-suspension-write-atomicity.yaml) — Suspension Write Atomicity: Checkpointer and RunRepository Transactional Contra… — accepted — product_claim:placeholder
-- [ADR-0025](docs/adr/0025-checkpoint-ownership-boundary.yaml) — Checkpoint Ownership Boundary: Executor Resume Cursors vs Orchestrator Run Row — accepted — product_claim:placeholder
-- [ADR-0027](docs/adr/locked/0027-idempotency-scope-w0-header-validation.md) — Idempotency Scope at W0: Header Validation Only, Dedup Deferred to W1 — accepted — product_claim:placeholder
-- [ADR-0029](docs/adr/0029-cognition-action-separation.yaml) — Cognition-Action Separation Principle — accepted — product_claim:placeholder
-- [ADR-0032](docs/adr/0032-scope-based-run-hierarchy-and-planner-contract-minimal.yaml) — Scope-Based Run Hierarchy and Planner Contract Minimal — accepted — product_claim:placeholder
-- [ADR-0033](docs/adr/0033-logical-identity-equivalence-and-deployment-locus-vocabulary.yaml) — Logical Identity Equivalence and Deployment-Locus Vocabulary — accepted — product_claim:placeholder
-- [ADR-0035](docs/adr/0035-posture-enforcement-single-construction-path.yaml) — Posture Enforcement Single-Construction-Path — accepted — product_claim:placeholder
-- [ADR-0038](docs/adr/0038-skill-spi-resource-tier-classification.yaml) — Skill SPI Resource Tier Classification — accepted — product_claim:placeholder
-- [ADR-0039](docs/adr/0039-payload-migration-adapter-strategy.yaml) — Payload Migration Adapter Strategy — accepted — product_claim:placeholder
-- [ADR-0040](docs/adr/0040-w1-http-contract-reconciliation.yaml) — W1 HTTP Contract Reconciliation — accepted — product_claim:placeholder
-- [ADR-0049](docs/adr/0049-c-s-dynamic-hydration-protocol.yaml) — C/S Dynamic Hydration Protocol and Cursor Handoff — accepted — product_claim:placeholder
-- [ADR-0051](docs/adr/0051-memory-knowledge-ownership-boundary.yaml) — Memory and Knowledge Ownership Boundary — accepted — product_claim:placeholder
-- [ADR-0052](docs/adr/0052-skill-topology-scheduler-and-capability-bidding.yaml) — Skill Topology Scheduler and Capability Bidding — accepted — product_claim:placeholder
-- [ADR-0053](docs/adr/0053-cohesive-agent-swarm-execution.yaml) — Cohesive Agent Swarm Execution — Workflow Authority Invariant + SpawnEnvelope — accepted — product_claim:placeholder
-- [ADR-0059](docs/adr/0059-code-as-contract-architectural-enforcement.yaml) — Code-as-Contract Architectural Enforcement (Introduces Rule R-C.a) — accepted — product_claim:placeholder
-- [ADR-0064](docs/adr/0064-layer-0-governing-principles.yaml) — Layer-0 Governing Principles + CLAUDE.md Restructure — accepted — product_claim:placeholder
-- [ADR-0065](docs/adr/0065-competitive-baselines.yaml) — Competitive Baselines (Four Pillars) — accepted — product_claim:placeholder
-- [ADR-0066](docs/adr/0066-independent-module-evolution.yaml) — Independent Module Evolution — accepted — product_claim:placeholder
-- [ADR-0067](docs/adr/0067-spi-dfx-tck-codesign.yaml) — SPI + DFX + TCK Co-Design — accepted — product_claim:placeholder
-- [ADR-0068](docs/adr/0068-layered-4plus1-and-architecture-graph.yaml) — Layered 4+1 and Architecture Graph as Twin Sources of Truth — accepted — product_claim:placeholder
-- [ADR-0069](docs/adr/0069-l0-ironclad-rules.yaml) — Layer-0 Ironclad Rules — promotion of LucioIT W1 §6/§7 to governing principles — accepted — product_claim:placeholder
-- [ADR-0071](docs/adr/0071-engine-contract-structural-wave.yaml) — Engine Contract Structural Wave — umbrella for ADR-0072..0075 + L0 principle P-M — accepted — product_claim:PC-004
-- [ADR-0075](docs/adr/0075-evolution-scope-boundary.yaml) — Evolution Scope Boundary -- server-controlled evolution surface, fourth L1 expr… — accepted — product_claim:PC-005
-- [ADR-0077](docs/adr/0077-schema-first-domain-contracts.yaml) — Schema-First Domain Contracts — codify the W2.x prose-enum prohibition (P-M cro… — accepted — product_claim:placeholder
-- [ADR-0081](docs/adr/0081-resilience-contract-dual-surface-reconciliation.yaml) — ResilienceContract dual-surface reconciliation (operation-policy + skill-capaci… — accepted — product_claim:placeholder
-- [ADR-0089](docs/adr/0089-edge-plane-ingress-gateway-mandate.yaml) — Edge-Plane Ingress Gateway Mandate — client → bus → server is the only allowed… — accepted — product_claim:PC-002
-- [ADR-0101](docs/adr/0101-rc22-polymorphic-deployment-topology.yaml) — rc22 — Polymorphic Deployment Topology (Mode A Platform-Centric + Mode B Busine… — accepted — product_claim:placeholder
-- [ADR-0102](docs/adr/0102-rc22-evolution-plane-online-offline-duality.yaml) — rc22 — Evolution Plane Online/Offline Duality (Offline T+1 + Online Dual-Track… — accepted — product_claim:placeholder
-- [ADR-0103](docs/adr/0103-rc22-agent-middleware-naming-and-capability-services-distribution.yaml) — rc22 — agent-middleware naming resolution (REJECT rename + REJECT 7th module) +… — accepted — product_claim:placeholder
-- [ADR-0117](docs/adr/0117-rc37-ascend-kunpeng-strategic-repositioning.yaml) — rc37 strategic repositioning: Ascend/Kunpeng hardware-synergy platform; drop FS… — accepted — product_claim:placeholder
-- [ADR-0119](architecture/decisions/0119.md) — Single-Source Rendering for derived architecture documents (release notes, READ… — accepted — product_claim:placeholder
-- [ADR-0120](docs/adr/0120-brand-audience-b-alignment.yaml) — Brand & Audience B alignment: KEEP `spring-ai-ascend` identity and Audience B p… — accepted — product_claim:placeholder
-- [ADR-0134](docs/adr/0134-tool-call-iteration-loop.yaml) — Tool-Call Iteration Loop: agent-driven vs. planner-driven execution modes for L… — accepted — product_claim:PC-003
-- [ADR-0135](docs/adr/0135-agent-session-as-run-projection.yaml) — AgentSession as Run-Projection: no separate AgentSession SPI; conversation cont… — accepted — product_claim:PC-001
-- [ADR-0136](docs/adr/0136-vocabulary-reconciliation-pr71-task-vs-run.yaml) — Vocabulary Reconciliation: PR 71 'Task' ≡ existing platform Task entity (not Ru… — accepted — product_claim:placeholder
-- [ADR-0137](docs/adr/0137-suspendsignal-canonical-interruptsignal-glossary.yaml) — SuspendSignal remains canonical; InterruptSignal / InterruptReason are L1 gloss… — accepted — product_claim:PC-003
-- [ADR-0138](docs/adr/0138-agent-service-five-layer-l1-ratification.yaml) — agent-service 5-layer L1 ratification: PR 71 layers (Access / Session&Task / Ev… — accepted — product_claim:placeholder
-- [ADR-0139](docs/adr/0139-fast-slow-path-narrowed-semantics.yaml) — Fast-Path / Slow-Path narrowed semantics: Fast-Path = in-process reactive synch… — accepted — product_claim:PC-003
-- [ADR-0140](docs/adr/0140-engine-adapter-layer-split.yaml) — Engine Adapter Layer split: Layer 5 in ADR-0138 5-layer model decomposes into L… — accepted — product_claim:PC-004
-- [ADR-0141](docs/adr/0141-internal-event-queue-design-only.yaml) — Internal Event Queue (ADR-0138 Layer 3) is a design_only sub-section of agent-s… — accepted — product_claim:PC-003
-- [ADR-0142](docs/adr/0142-run-aggregate-single-owner.yaml) — Run aggregate (Run record + RunStatus + RunStateMachine + RunRepository) is OWN… — accepted — product_claim:PC-001|PC-003
-- [ADR-0144](docs/adr/0144-layer-vs-package-matrix.yaml) — Layer ↔ Package matrix unifies the rc22 ADR-0100 5-component package-structural… — accepted — product_claim:placeholder
-- [ADR-0145](docs/adr/0145-run-event-sealed-hierarchy.yaml) — Sealed RunEvent hierarchy specification: defines the polymorphic event type tha… — accepted — product_claim:PC-001|PC-003
-- [ADR-0146](docs/adr/0146-suspend-reason-taxonomy-alignment-2026-05-22.yaml) — SuspendReason taxonomy canonical alignment to 2026-05-22 expansion-proposal-res… — accepted — product_claim:PC-003
-- [ADR-0147](docs/adr/0147-structurizr-workspace-authority.yaml) — Structurizr workspace closure as the architecture authoring root, with programm… — accepted — product_claim:placeholder
-- [ADR-0148](architecture/decisions/0148.md) — Wave 0 spike results — Structurizr workspace authority feasibility — accepted — product_claim:placeholder
-- [ADR-0149](architecture/decisions/0149.md) — Structurizr workspace authority — W0..W5 shipped; W6/W7 entry-criteria document… — accepted — product_claim:placeholder
-- [ADR-0150](docs/adr/0150-architecture-design-system-unification-under-structurizr.yaml) — Architecture design system unified under architecture/ — L1 corpus + module ARC… — accepted — product_claim:placeholder
-- [ADR-0151](docs/adr/0151-l1-feature-registry-canonical-schema.yaml) — L1 Feature Registry canonical schema — SAA Feature tag + AI Execution Boundary… — accepted — product_claim:placeholder
-- [ADR-0152](docs/adr/0152-uniform-l1-per-view-mechanism-and-l0-mounting.yaml) — Uniform L1 per-view mechanism + L0 mounting under architecture/docs/L0/ — accepted — product_claim:placeholder
-- [ADR-0153](docs/adr/0153-l1-feature-registry-closure.yaml) — L1 Feature Registry closure — Rule G-14 blocking flip + plan completion — accepted — product_claim:placeholder
-- [ADR-0154](docs/adr/0154-fact-layer-authority.yaml) — Fact-Layer Authority — generated structured facts as the AI's primary L1 input — accepted — product_claim:placeholder
-- [ADR-0155](docs/adr/0155-agent-service-l1-v1-2-internal-module-design.yaml) — AgentService L1 v1.2 — internal module design absorption (M1–M6 + 6 boundary re… — accepted — product_claim:PC-003
-- [ADR-0156](docs/adr/0156-product-authority-and-traceability.yaml) — Product Authority and Traceability Chain — ProductClaim as the binding axis bet… — accepted — product_claim:placeholder
-- [ADR-0157](docs/adr/0157-engineering-frame-ontology.yaml) — EngineeringFrame Ontology — structural axis between Module and FunctionPoint fo… — accepted — product_claim:placeholder
-- [ADR-0158](docs/adr/0158-engine-port-transport-agnostic-boundary.yaml) — Engine Boundary (EnginePort) — transport-agnostic Service↔Engine contract absor… — accepted — product_claim:PC-004
-- [ADR-0159](docs/adr/0159-agent-runtime-consolidation-and-service-refounding.yaml) — agent-runtime consolidation — the runtime SDK (today mislabelled agent-service)… — accepted — product_claim:PC-004
+- [ADR-0001](docs/adr/locked/0001-java-21-spring-boot-runtime.md) — Java 21 + Spring Boot 4.0.5 as the runtime baseline — accepted
+- [ADR-0002](docs/adr/locked/0002-spring-ai-llm-gateway.md) — Spring AI 2.0.0-M5 as the LLM gateway, not LangChain4j — accepted
+- [ADR-0004](docs/adr/locked/0004-postgres-primary-data-store.md) — PostgreSQL 16 with RLS + pgvector, not separate vector DB — accepted
+- [ADR-0005](docs/adr/locked/0005-tenant-isolation-guc-set-local.md) — Row-level security with SET LOCAL transaction-scoped GUC, not per-connection re… — accepted
+- [ADR-0006](docs/adr/locked/0006-posture-model-dev-research-prod.md) — ActionGuard 5-stage chain (cycle-9 truth-cut), not 11-stage — accepted
+- [ADR-0010](docs/adr/locked/0010-spring-security-oauth2.md) — Keycloak (OSS) as default IdP, but customer can BYO — accepted
+- [ADR-0011](docs/adr/locked/0011-flyway-schema-migration.md) — Spring Cloud Gateway as ingress, not Kong / Traefik — accepted
+- [ADR-0014](docs/adr/locked/0014-contract-spine-versioning-policy.md) — 3-posture model (dev/research/prod), not 5 or 2 — accepted
+- [ADR-0015](docs/adr/locked/0015-layered-architecture-capability-model.md) — Defer multi-framework dispatch (Python sidecar, LangChain4j) to W4+ — accepted
+- [ADR-0016](docs/adr/0016-a2a-federation-strategic-deferral.yaml) — A2A Federation — Strategic Deferral to Post-W4 — accepted
+- [ADR-0020](docs/adr/locked/0020-runlifecycle-spi-and-runstatus-formal-dfa.md) — RunLifecycle SPI Separation and RunStatus Formal DFA — accepted
+- [ADR-0024](docs/adr/0024-suspension-write-atomicity.yaml) — Suspension Write Atomicity: Checkpointer and RunRepository Transactional Contra… — accepted
+- [ADR-0025](docs/adr/0025-checkpoint-ownership-boundary.yaml) — Checkpoint Ownership Boundary: Executor Resume Cursors vs Orchestrator Run Row — accepted
+- [ADR-0027](docs/adr/locked/0027-idempotency-scope-w0-header-validation.md) — Idempotency Scope at W0: Header Validation Only, Dedup Deferred to W1 — accepted
+- [ADR-0029](docs/adr/0029-cognition-action-separation.yaml) — Cognition-Action Separation Principle — accepted
+- [ADR-0032](docs/adr/0032-scope-based-run-hierarchy-and-planner-contract-minimal.yaml) — Scope-Based Run Hierarchy and Planner Contract Minimal — accepted
+- [ADR-0033](docs/adr/0033-logical-identity-equivalence-and-deployment-locus-vocabulary.yaml) — Logical Identity Equivalence and Deployment-Locus Vocabulary — accepted
+- [ADR-0035](docs/adr/0035-posture-enforcement-single-construction-path.yaml) — Posture Enforcement Single-Construction-Path — accepted
+- [ADR-0038](docs/adr/0038-skill-spi-resource-tier-classification.yaml) — Skill SPI Resource Tier Classification — accepted
+- [ADR-0039](docs/adr/0039-payload-migration-adapter-strategy.yaml) — Payload Migration Adapter Strategy — accepted
+- [ADR-0040](docs/adr/0040-w1-http-contract-reconciliation.yaml) — W1 HTTP Contract Reconciliation — accepted
+- [ADR-0049](docs/adr/0049-c-s-dynamic-hydration-protocol.yaml) — C/S Dynamic Hydration Protocol and Cursor Handoff — accepted
+- [ADR-0051](docs/adr/0051-memory-knowledge-ownership-boundary.yaml) — Memory and Knowledge Ownership Boundary — accepted
+- [ADR-0052](docs/adr/0052-skill-topology-scheduler-and-capability-bidding.yaml) — Skill Topology Scheduler and Capability Bidding — accepted
+- [ADR-0053](docs/adr/0053-cohesive-agent-swarm-execution.yaml) — Cohesive Agent Swarm Execution — Workflow Authority Invariant + SpawnEnvelope — accepted
+- [ADR-0059](docs/adr/0059-code-as-contract-architectural-enforcement.yaml) — Code-as-Contract Architectural Enforcement (Introduces Rule R-C.a) — accepted
+- [ADR-0064](docs/adr/0064-layer-0-governing-principles.yaml) — Layer-0 Governing Principles + CLAUDE.md Restructure — accepted
+- [ADR-0065](docs/adr/0065-competitive-baselines.yaml) — Competitive Baselines (Four Pillars) — accepted
+- [ADR-0066](docs/adr/0066-independent-module-evolution.yaml) — Independent Module Evolution — accepted
+- [ADR-0067](docs/adr/0067-spi-dfx-tck-codesign.yaml) — SPI + DFX + TCK Co-Design — accepted
+- [ADR-0068](docs/adr/0068-layered-4plus1-and-architecture-graph.yaml) — Layered 4+1 and Architecture Graph as Twin Sources of Truth — accepted
+- [ADR-0069](docs/adr/0069-l0-ironclad-rules.yaml) — Layer-0 Ironclad Rules — promotion of LucioIT W1 §6/§7 to governing principles — accepted
+- [ADR-0071](docs/adr/0071-engine-contract-structural-wave.yaml) — Engine Contract Structural Wave — umbrella for ADR-0072..0075 + L0 principle P-M — accepted
+- [ADR-0075](docs/adr/0075-evolution-scope-boundary.yaml) — Evolution Scope Boundary -- server-controlled evolution surface, fourth L1 expr… — accepted
+- [ADR-0077](docs/adr/0077-schema-first-domain-contracts.yaml) — Schema-First Domain Contracts — codify the W2.x prose-enum prohibition (P-M cro… — accepted
+- [ADR-0081](docs/adr/0081-resilience-contract-dual-surface-reconciliation.yaml) — ResilienceContract dual-surface reconciliation (operation-policy + skill-capaci… — accepted
+- [ADR-0089](docs/adr/0089-edge-plane-ingress-gateway-mandate.yaml) — Edge-Plane Ingress Gateway Mandate — client → bus → server is the only allowed… — accepted
+- [ADR-0101](docs/adr/0101-rc22-polymorphic-deployment-topology.yaml) — rc22 — Polymorphic Deployment Topology (Mode A Platform-Centric + Mode B Busine… — accepted
+- [ADR-0102](docs/adr/0102-rc22-evolution-plane-online-offline-duality.yaml) — rc22 — Evolution Plane Online/Offline Duality (Offline T+1 + Online Dual-Track… — accepted
+- [ADR-0103](docs/adr/0103-rc22-agent-middleware-naming-and-capability-services-distribution.yaml) — rc22 — agent-middleware naming resolution (REJECT rename + REJECT 7th module) +… — accepted
+- [ADR-0117](docs/adr/0117-rc37-ascend-kunpeng-strategic-repositioning.yaml) — rc37 strategic repositioning: Ascend/Kunpeng hardware-synergy platform; drop FS… — accepted
+- [ADR-0119](architecture/decisions/0119.md) — Single-Source Rendering for derived architecture documents (release notes, READ… — accepted
+- [ADR-0120](docs/adr/0120-brand-audience-b-alignment.yaml) — Brand & Audience B alignment: KEEP `spring-ai-ascend` identity and Audience B p… — accepted
+- [ADR-0134](docs/adr/0134-tool-call-iteration-loop.yaml) — Tool-Call Iteration Loop: agent-driven vs. planner-driven execution modes for L… — accepted
+- [ADR-0135](docs/adr/0135-agent-session-as-run-projection.yaml) — AgentSession as Run-Projection: no separate AgentSession SPI; conversation cont… — accepted
+- [ADR-0136](docs/adr/0136-vocabulary-reconciliation-pr71-task-vs-run.yaml) — Vocabulary Reconciliation: PR 71 'Task' ≡ existing platform Task entity (not Ru… — accepted
+- [ADR-0137](docs/adr/0137-suspendsignal-canonical-interruptsignal-glossary.yaml) — SuspendSignal remains canonical; InterruptSignal / InterruptReason are L1 gloss… — accepted
+- [ADR-0138](docs/adr/0138-agent-service-five-layer-l1-ratification.yaml) — agent-service 5-layer L1 ratification: PR 71 layers (Access / Session&Task / Ev… — accepted
+- [ADR-0139](docs/adr/0139-fast-slow-path-narrowed-semantics.yaml) — Fast-Path / Slow-Path narrowed semantics: Fast-Path = in-process reactive synch… — accepted
+- [ADR-0140](docs/adr/0140-engine-adapter-layer-split.yaml) — Engine Adapter Layer split: Layer 5 in ADR-0138 5-layer model decomposes into L… — accepted
+- [ADR-0141](docs/adr/0141-internal-event-queue-design-only.yaml) — Internal Event Queue (ADR-0138 Layer 3) is a design_only sub-section of agent-s… — accepted
+- [ADR-0142](docs/adr/0142-run-aggregate-single-owner.yaml) — Run aggregate (Run record + RunStatus + RunStateMachine + RunRepository) is OWN… — accepted
+- [ADR-0144](docs/adr/0144-layer-vs-package-matrix.yaml) — Layer ↔ Package matrix unifies the rc22 ADR-0100 5-component package-structural… — accepted
+- [ADR-0145](docs/adr/0145-run-event-sealed-hierarchy.yaml) — Sealed RunEvent hierarchy specification: defines the polymorphic event type tha… — accepted
+- [ADR-0146](docs/adr/0146-suspend-reason-taxonomy-alignment-2026-05-22.yaml) — SuspendReason taxonomy canonical alignment to 2026-05-22 expansion-proposal-res… — accepted
+- [ADR-0147](docs/adr/0147-structurizr-workspace-authority.yaml) — Structurizr workspace closure as the architecture authoring root, with programm… — accepted
+- [ADR-0148](architecture/decisions/0148.md) — Wave 0 spike results — Structurizr workspace authority feasibility — accepted
+- [ADR-0149](architecture/decisions/0149.md) — Structurizr workspace authority — W0..W5 shipped; W6/W7 entry-criteria document… — accepted
+- [ADR-0150](docs/adr/0150-architecture-design-system-unification-under-structurizr.yaml) — Architecture design system unified under architecture/ — L1 corpus + module ARC… — accepted
+- [ADR-0151](docs/adr/0151-l1-feature-registry-canonical-schema.yaml) — L1 Feature Registry canonical schema — SAA Feature tag + AI Execution Boundary… — accepted
+- [ADR-0152](docs/adr/0152-uniform-l1-per-view-mechanism-and-l0-mounting.yaml) — Uniform L1 per-view mechanism + L0 mounting under architecture/docs/L0/ — accepted
+- [ADR-0153](docs/adr/0153-l1-feature-registry-closure.yaml) — L1 Feature Registry closure — Rule G-14 blocking flip + plan completion — accepted
+- [ADR-0154](docs/adr/0154-fact-layer-authority.yaml) — Fact-Layer Authority — generated structured facts as the AI's primary L1 input — accepted
+- [ADR-0155](docs/adr/0155-agent-service-l1-v1-2-internal-module-design.yaml) — AgentService L1 v1.2 — internal module design absorption (M1–M6 + 6 boundary re… — accepted
+- [ADR-0156](docs/adr/0156-product-authority-and-traceability.yaml) — Product Authority and Traceability Chain — ProductClaim as the binding axis bet… — accepted
+- [ADR-0157](docs/adr/0157-engineering-frame-ontology.yaml) — EngineeringFrame Ontology — structural axis between Module and FunctionPoint fo… — accepted
+- [ADR-0158](docs/adr/0158-engine-port-transport-agnostic-boundary.yaml) — Engine Boundary (EnginePort) — transport-agnostic Service↔Engine contract absor… — accepted

--- a/discovery/contract-index.md
+++ b/discovery/contract-index.md
@@ -14,39 +14,39 @@ purpose: "Tier-2 progressive disclosure index — auto-loaded with summary lines
 
 ## Usage
 
-This file is a Tier-2 progressive-disclosure index over the runtime / SPI / protocol contract schemas under `docs/contracts/`. Each line names one schema file, its one-line purpose, its current `status:` (or `runtime_enforced:` derivative), and a `product_claim` tag — either an actual `PC-NNN` id, `governance_infra` (when the contract governs framework discipline rather than a product capability), or `placeholder` (Wave-4 backfill target).
+This file is a Tier-2 progressive-disclosure index over the runtime / SPI / protocol contract schemas under `docs/contracts/`. Each line names one schema file, its one-line purpose, and its current `status:` (or `runtime_enforced:` derivative).
 
 Load this index to locate contract schemas by name, purpose, or status. The full schema body lives behind the linked file. Catalog cross-reference: `docs/contracts/contract-catalog.md`. Each contract's authority ADR is named in its leading comment block per Rule M-2 sub-clause .b.
 
 ## Index
 
-- [a2a-envelope.v1.yaml](docs/contracts/a2a-envelope.v1.yaml) — contract-layer adoption of the A2A (Agent-to-Agent) protocol envelope shape + Task state vocabulary. Contract-ONLY adoption per ADR-0100 Rejection 3 — NO SDK runtime dep added in agent-service — design_only — product_claim:PC-002|PC-004
-- [access-intent.v1.yaml](docs/contracts/access-intent.v1.yaml) — AccessIntent inter-module data contract, version 1 — design_only — product_claim:PC-002
-- [agent-definition.v1.yaml](docs/contracts/agent-definition.v1.yaml) — AgentDefinition schema, version 1 — design_only — product_claim:PC-001
-- [agent-event.v1.yaml](docs/contracts/agent-event.v1.yaml) — AgentEvent stream emitted by ExecutorAdapter.execute, version 1 — design_only — product_claim:PC-004
-- [agent-invoke-request.v1.yaml](docs/contracts/agent-invoke-request.v1.yaml) — contract between agent-service Reactive Orchestrator and the Execution Engine. Service is the Read-Modify-Write closure boundary; Engine is the Pure-Function compute boundary — schema_shipped — product_claim:PC-001
-- [audit-trail.v1.yaml](docs/contracts/audit-trail.v1.yaml) — declare a regulator-grade, append-only audit-trail schema that captures every Run-level, tool-call-level, and model-invocation-level action a tenant's agent performs on this platform. The schema is designed for direct regulatory submissi... — design_only — product_claim:PC-003
-- [backpressure-request.v1.yaml](docs/contracts/backpressure-request.v1.yaml) — explicit backpressure request channel on the agent-bus control track (Rule R-E). Converts local-push backpressure signals from the Reactive Orchestrator (per ADR-0100 §2.2) into distributed- pull signals across the federation bus — design_only — product_claim:PC-003
-- [checkpoint-record.v1.yaml](docs/contracts/checkpoint-record.v1.yaml) — CheckpointRecord — STM-05 recoverable boundary marker, v1 — design_only — product_claim:PC-003
-- [config-snapshot-ref.v1.yaml](docs/contracts/config-snapshot-ref.v1.yaml) — ConfigSnapshotRef — immutable Run-time configuration binding reference, v1 — design_only — product_claim:PC-003
-- [control-event.v1.yaml](docs/contracts/control-event.v1.yaml) — ControlEvent IEQ-02 control-channel envelope, version 1 — design_only — product_claim:PC-003
-- [correlation-record.v1.yaml](docs/contracts/correlation-record.v1.yaml) — CorrelationRecord — cross-Run / remote-Agent handle, v1 — design_only — product_claim:PC-003
-- [cost-governance.v1.yaml](docs/contracts/cost-governance.v1.yaml) — declare the wire schema + enforcement semantics for per-tenant per-agent token budgets, the enforcement-mode taxonomy, and the spend reporting record. Without this contract, Persona-A cannot answer "what did business center X cost us thi... — design_only — product_claim:PC-003
-- [engine-envelope.v1.yaml](docs/contracts/engine-envelope.v1.yaml) — Engine Envelope schema, version 1 — runtime_enforced — product_claim:PC-004
-- [engine-hooks.v1.yaml](docs/contracts/engine-hooks.v1.yaml) — Engine Lifecycle Hooks schema, version 1 — runtime_enforced — product_claim:PC-004
-- [engine-port.v1.yaml](docs/contracts/engine-port.v1.yaml) — EnginePort wire contract — the transport-agnostic Service-to-Engine boundary, v1 — design_only — product_claim:PC-004
-- [error-class.v1.yaml](docs/contracts/error-class.v1.yaml) — ErrorClass — platform-wide error taxonomy enum, v1 — design_only — product_claim:PC-003
-- [execution-request.v1.yaml](docs/contracts/execution-request.v1.yaml) — ExecutionRequest carrier consumed by ExecutorAdapter.execute, version 1 — design_only — product_claim:PC-004
-- [governed-messages.v1.yaml](docs/contracts/governed-messages.v1.yaml) — GovernedMessages — M6 TTI-02 output (replaces v1-draft BuiltPrompt), v1 — design_only — product_claim:PC-003
-- [iam-bridge.v1.yaml](docs/contracts/iam-bridge.v1.yaml) — declare how the platform CONSUMES an enterprise IDP's OIDC token at the HTTP edge AND PROPAGATES the user's identity through agent execution to downstream business-system calls. The contract closes the Persona-F pain point: "Agent identi... — design_only — product_claim:PC-003
-- [intercept-request.v1.yaml](docs/contracts/intercept-request.v1.yaml) — InterceptRequest — TTI-01 unified intercept entry envelope, v1 — design_only — product_claim:PC-004
-- [interrupt-registration.v1.yaml](docs/contracts/interrupt-registration.v1.yaml) — InterruptRegistration — HITL interrupt site descriptor, v1 — design_only — product_claim:PC-003
-- [openapi-v1.yaml](docs/contracts/openapi-v1.yaml) — spring-ai-ascend API v1 — unknown — product_claim:PC-001|PC-003
-- [plan-projection.v1.yaml](docs/contracts/plan-projection.v1.yaml) — Plan Projection schema, version 1 — design_only — product_claim:PC-001
-- [plan.v1.yaml](docs/contracts/plan.v1.yaml) — Plan / PlanStep schema, version 1 — design_only — product_claim:PC-001
-- [planning-request.v1.yaml](docs/contracts/planning-request.v1.yaml) — PlanningRequest / PlanningResult schema, version 1 — design_only — product_claim:PC-001
-- [run-event.v1.yaml](docs/contracts/run-event.v1.yaml) — closes F-discriminator-without-discriminated-type for the EvolutionExport enum at agent-service/src/main/java/com/huawei/ascend/service/runtime/evolution/EvolutionExport.java whose package-info Javadoc declares it as discriminator for a... — design_only — product_claim:PC-001|PC-003
-- [s2c-callback.v1.yaml](docs/contracts/s2c-callback.v1.yaml) — Server-to-Client (S2C) Capability Callback schema, version 1 — runtime_enforced — product_claim:PC-004
-- [session-snapshot.v1.yaml](docs/contracts/session-snapshot.v1.yaml) — SessionSnapshot — STM-04 read projection, v1 — design_only — product_claim:PC-005
-- [tool-result.v1.yaml](docs/contracts/tool-result.v1.yaml) — ToolResult — normalised tool-invocation result, v1 — design_only — product_claim:PC-004
-- [work-item.v1.yaml](docs/contracts/work-item.v1.yaml) — WorkItem IEQ-03 data-channel envelope, version 1 — design_only — product_claim:PC-003
+- [a2a-envelope.v1.yaml](docs/contracts/a2a-envelope.v1.yaml) — contract-layer adoption of the A2A (Agent-to-Agent) protocol envelope shape + Task state vocabulary. Contract-ONLY adoption per ADR-0100 Rejection 3 — NO SDK runtime dep added in agent-service — design_only
+- [access-intent.v1.yaml](docs/contracts/access-intent.v1.yaml) — AccessIntent inter-module data contract, version 1 — design_only
+- [agent-definition.v1.yaml](docs/contracts/agent-definition.v1.yaml) — AgentDefinition schema, version 1 — design_only
+- [agent-event.v1.yaml](docs/contracts/agent-event.v1.yaml) — AgentEvent stream emitted by ExecutorAdapter.execute, version 1 — design_only
+- [agent-invoke-request.v1.yaml](docs/contracts/agent-invoke-request.v1.yaml) — contract between agent-service Reactive Orchestrator and the Execution Engine. Service is the Read-Modify-Write closure boundary; Engine is the Pure-Function compute boundary — schema_shipped
+- [audit-trail.v1.yaml](docs/contracts/audit-trail.v1.yaml) — declare a regulator-grade, append-only audit-trail schema that captures every Run-level, tool-call-level, and model-invocation-level action a tenant's agent performs on this platform. The schema is designed for direct regulatory submissi... — design_only
+- [backpressure-request.v1.yaml](docs/contracts/backpressure-request.v1.yaml) — explicit backpressure request channel on the agent-bus control track (Rule R-E). Converts local-push backpressure signals from the Reactive Orchestrator (per ADR-0100 §2.2) into distributed- pull signals across the federation bus — design_only
+- [checkpoint-record.v1.yaml](docs/contracts/checkpoint-record.v1.yaml) — CheckpointRecord — STM-05 recoverable boundary marker, v1 — design_only
+- [config-snapshot-ref.v1.yaml](docs/contracts/config-snapshot-ref.v1.yaml) — ConfigSnapshotRef — immutable Run-time configuration binding reference, v1 — design_only
+- [control-event.v1.yaml](docs/contracts/control-event.v1.yaml) — ControlEvent IEQ-02 control-channel envelope, version 1 — design_only
+- [correlation-record.v1.yaml](docs/contracts/correlation-record.v1.yaml) — CorrelationRecord — cross-Run / remote-Agent handle, v1 — design_only
+- [cost-governance.v1.yaml](docs/contracts/cost-governance.v1.yaml) — declare the wire schema + enforcement semantics for per-tenant per-agent token budgets, the enforcement-mode taxonomy, and the spend reporting record. Without this contract, Persona-A cannot answer "what did business center X cost us thi... — design_only
+- [engine-envelope.v1.yaml](docs/contracts/engine-envelope.v1.yaml) — Engine Envelope schema, version 1 — design_only
+- [engine-hooks.v1.yaml](docs/contracts/engine-hooks.v1.yaml) — Engine Lifecycle Hooks schema, version 1 — design_only
+- [engine-port.v1.yaml](docs/contracts/engine-port.v1.yaml) — EnginePort wire contract — the transport-agnostic Service-to-Engine boundary, v1 — design_only
+- [error-class.v1.yaml](docs/contracts/error-class.v1.yaml) — ErrorClass — platform-wide error taxonomy enum, v1 — design_only
+- [execution-request.v1.yaml](docs/contracts/execution-request.v1.yaml) — ExecutionRequest carrier consumed by ExecutorAdapter.execute, version 1 — design_only
+- [governed-messages.v1.yaml](docs/contracts/governed-messages.v1.yaml) — GovernedMessages — M6 TTI-02 output (replaces v1-draft BuiltPrompt), v1 — design_only
+- [iam-bridge.v1.yaml](docs/contracts/iam-bridge.v1.yaml) — declare how the platform CONSUMES an enterprise IDP's OIDC token at the HTTP edge AND PROPAGATES the user's identity through agent execution to downstream business-system calls. The contract closes the Persona-F pain point: "Agent identi... — design_only
+- [intercept-request.v1.yaml](docs/contracts/intercept-request.v1.yaml) — InterceptRequest — TTI-01 unified intercept entry envelope, v1 — design_only
+- [interrupt-registration.v1.yaml](docs/contracts/interrupt-registration.v1.yaml) — InterruptRegistration — HITL interrupt site descriptor, v1 — design_only
+- [openapi-v1.yaml](docs/contracts/openapi-v1.yaml) — spring-ai-ascend API v1 — unknown
+- [plan-projection.v1.yaml](docs/contracts/plan-projection.v1.yaml) — Plan Projection schema, version 1 — design_only
+- [plan.v1.yaml](docs/contracts/plan.v1.yaml) — Plan / PlanStep schema, version 1 — design_only
+- [planning-request.v1.yaml](docs/contracts/planning-request.v1.yaml) — PlanningRequest / PlanningResult schema, version 1 — design_only
+- [run-event.v1.yaml](docs/contracts/run-event.v1.yaml) — closes F-discriminator-without-discriminated-type for the EvolutionExport enum at agent-service/src/main/java/com/huawei/ascend/service/runtime/evolution/EvolutionExport.java whose package-info Javadoc declares it as discriminator for a... — design_only
+- [s2c-callback.v1.yaml](docs/contracts/s2c-callback.v1.yaml) — Server-to-Client (S2C) Capability Callback schema, version 1 — runtime_enforced
+- [session-snapshot.v1.yaml](docs/contracts/session-snapshot.v1.yaml) — SessionSnapshot — STM-04 read projection, v1 — design_only
+- [tool-result.v1.yaml](docs/contracts/tool-result.v1.yaml) — ToolResult — normalised tool-invocation result, v1 — design_only
+- [work-item.v1.yaml](docs/contracts/work-item.v1.yaml) — WorkItem IEQ-03 data-channel envelope, version 1 — design_only

--- a/discovery/rule-index.md
+++ b/discovery/rule-index.md
@@ -10,62 +10,62 @@ purpose: "Tier-2 progressive disclosure index — auto-loaded with summary lines
 
 - **schema_version**: 1
 - **last_updated**: 2026-05-28
-- **count**: 55
+- **count**: 49
 
 ## Usage
 
-This file is a Tier-2 progressive-disclosure index over the governance rule cards under `docs/governance/rules/`. Each line names one rule by id (D-/G-/R-/M- namespace), its canonical card path, the rule's current `status:` value, and a `product_claim` tag — either an actual `PC-NNN` id, `governance_infra` (when the rule governs framework discipline rather than a product capability), or `placeholder` (Wave-4 backfill target).
+This file is a Tier-2 progressive-disclosure index over the governance rule cards under `docs/governance/rules/`. Each line names one rule by id (D-/G-/R-/M- namespace), its canonical card path, and the rule's current `status:` value.
 
 Load this index to find rules by id, topic, or status without scanning every card. Each rule's full body (motivation, details, enforcers, exit criteria) lives behind the linked card and is loaded on demand by the `/design-mode`, `/impl-mode`, `/verify-mode`, `/commit-mode`, and `/review-mode` phase-contract skills declared in `CLAUDE.md`. Sort order: namespace (D, G, M, R) then numeric/letter suffix.
 
 ## Index
 
-- [Rule D-1](docs/governance/rules/rule-D-1.md) — Root-Cause + Strongest-Interpretation Before Plan — active — product_claim:placeholder
-- [Rule D-2](docs/governance/rules/rule-D-2.md) — Simplicity & Surgical Changes — active — product_claim:placeholder
-- [Rule D-3](docs/governance/rules/rule-D-3.md) — Pre-Commit Checklist + Evidence-First Debug — active — product_claim:placeholder
-- [Rule D-4](docs/governance/rules/rule-D-4.md) — Three-Layer Testing, With Honest Assertions — active — product_claim:placeholder
-- [Rule D-5](docs/governance/rules/rule-D-5.md) — Self-Audit is a Ship Gate, Not a Disclosure — active — product_claim:placeholder
-- [Rule D-6](docs/governance/rules/rule-D-6.md) — Posture-Aware Defaults — active — product_claim:PC-003
-- [Rule D-7](docs/governance/rules/rule-D-7.md) — Concurrency / Async Resource Lifetime — active — product_claim:PC-003
-- [Rule D-8](docs/governance/rules/rule-D-8.md) — Single Construction Path Per Resource Class — active — product_claim:PC-003
-- [Rule D-9](docs/governance/rules/rule-D-9.md) — No Version / Log Metadata in Code — unknown — product_claim:placeholder
-- [Rule G-1](docs/governance/rules/rule-G-1.md) — Layered 4+1 Discipline + Architecture Workspace Truth — active — product_claim:placeholder
-- [Rule G-1.1](docs/governance/rules/rule-G-1.1.md) — L1 Architecture Depth & Grounding — active — product_claim:placeholder
-- [Rule G-2](docs/governance/rules/rule-G-2.md) — Authority-Text Reality (doc / status / path / numeric truth) — active — product_claim:placeholder
-- [Rule G-2.1](docs/governance/rules/rule-G-2.1.md) — Deleted-Module Scope Prevention — active — product_claim:placeholder
-- [Rule G-3](docs/governance/rules/rule-G-3.md) — Kernel-Card-Implementation Coherence — active — product_claim:placeholder
-- [Rule G-3.1](docs/governance/rules/rule-G-3.1.md) — Kernel-Implementation Disjunction Truth — active — product_claim:placeholder
-- [Rule G-4](docs/governance/rules/rule-G-4.md) — Always-Loaded Context Budget — active — product_claim:placeholder
-- [Rule G-5](docs/governance/rules/rule-G-5.md) — Gate Self-Consistency (parity / coverage / manifest / freshness) — active — product_claim:placeholder
-- [Rule G-6](docs/governance/rules/rule-G-6.md) — Gate Machinery Integrity (duration + config) — active — product_claim:placeholder
-- [Rule G-7](docs/governance/rules/rule-G-7.md) — Linux-First Dev Environment — active — product_claim:placeholder
-- [Rule G-8](docs/governance/rules/rule-G-8.md) — Cross-Authority Parity (graph baseline / SPI path / module topology / current-claim grammar / structural-carrier parity) — active — product_claim:placeholder
-- [Rule G-9](docs/governance/rules/rule-G-9.md) — Recurring-Defect Family Truth — active — product_claim:placeholder
-- [Rule G-10](docs/governance/rules/rule-G-10.md) — Parallel-Linux-Scripts Mandate — active — product_claim:placeholder
-- [Rule G-11](docs/governance/rules/rule-G-11.md) — Phase-Contract Rule-Allocation Coherence — active — product_claim:placeholder
-- [Rule G-12](docs/governance/rules/rule-G-12.md) — Whitebox Quality Baseline — active — product_claim:placeholder
-- [Rule G-14](docs/governance/rules/rule-G-14.md) — Feature Lifecycle Validity — active_advisory — product_claim:placeholder
-- [Rule G-15](docs/governance/rules/rule-G-15.md) — Fact-Layer Integrity — active_advisory — product_claim:placeholder
-- [Rule G-22](docs/governance/rules/rule-G-22.md) — Accepted-ADR Frame-Map Coherence — active — product_claim:placeholder
-- [Rule G-23](docs/governance/rules/rule-G-23.md) — Shipped-Frame Anchor Integrity — active — product_claim:placeholder
-- [Rule G-24](docs/governance/rules/rule-G-24.md) — Old Orchestration-SPI Package Ban — active — product_claim:placeholder
-- [Rule G-26](docs/governance/rules/rule-G-26.md) — Local Plan-Path Ban — active — product_claim:placeholder
-- [Rule M-1](docs/governance/rules/rule-M-1.md) — Skeleton Module Has No Production Java — active — product_claim:placeholder
-- [Rule M-2](docs/governance/rules/rule-M-2.md) — Domain Contract Discipline (schema-first + design-only registration + DFX-stem truth) — active — product_claim:placeholder
-- [Rule R-A](docs/governance/rules/rule-R-A.md) — Business/Platform Decoupling Enforcement — active — product_claim:PC-001
-- [Rule R-A.c](docs/governance/rules/rule-R-A.c.md) — Quickstart CI Smoke Run — active — product_claim:PC-001
-- [Rule R-B](docs/governance/rules/rule-R-B.md) — Competitive Baselines Required — active — product_claim:PC-001|PC-002|PC-003|PC-005
-- [Rule R-C](docs/governance/rules/rule-R-C.md) — Code-as-Contract — active — product_claim:PC-003
-- [Rule R-C.1](docs/governance/rules/rule-R-C.1.md) — Independent Module Evolution — active — product_claim:PC-003
-- [Rule R-C.2](docs/governance/rules/rule-R-C.2.md) — Run Contract Spine — active — product_claim:PC-001|PC-003
-- [Rule R-D](docs/governance/rules/rule-R-D.md) — SPI + DFX + TCK Co-Design + Catalog Integrity — active — product_claim:PC-001
-- [Rule R-E](docs/governance/rules/rule-R-E.md) — Three-Track Channel Isolation — active — product_claim:PC-002
-- [Rule R-F](docs/governance/rules/rule-R-F.md) — Cursor Flow Mandate — active — product_claim:PC-003
-- [Rule R-G](docs/governance/rules/rule-R-G.md) — Reactive External I/O — active — product_claim:PC-003
-- [Rule R-H](docs/governance/rules/rule-R-H.md) — No Thread.sleep in Business Code — active — product_claim:PC-003
-- [Rule R-I](docs/governance/rules/rule-R-I.md) — Five-Plane Manifest — active — product_claim:PC-002
-- [Rule R-I.1](docs/governance/rules/rule-R-I.1.md) — Edge↔Compute Ingress Routing — design_only — product_claim:PC-002
-- [Rule R-J](docs/governance/rules/rule-R-J.md) — Storage-Engine Tenant Isolation + Cancel Re-Authorization — active — product_claim:PC-003
-- [Rule R-K](docs/governance/rules/rule-R-K.md) — Skill Capacity Matrix — active — product_claim:PC-003
-- [Rule R-L](docs/governance/rules/rule-R-L.md) — Sandbox Permission Subsumption — active — product_claim:PC-003
-- [Rule R-M](docs/governance/rules/rule-R-M.md) — Engine Contract (envelope / matching / hooks / S2C / scope / historical) — active — product_claim:PC-004
+- [Rule D-1](docs/governance/rules/rule-D-1.md) — Root-Cause + Strongest-Interpretation Before Plan — active
+- [Rule D-2](docs/governance/rules/rule-D-2.md) — Simplicity & Surgical Changes — active
+- [Rule D-3](docs/governance/rules/rule-D-3.md) — Pre-Commit Checklist + Evidence-First Debug — active
+- [Rule D-4](docs/governance/rules/rule-D-4.md) — Three-Layer Testing, With Honest Assertions — active
+- [Rule D-5](docs/governance/rules/rule-D-5.md) — Self-Audit is a Ship Gate, Not a Disclosure — active
+- [Rule D-6](docs/governance/rules/rule-D-6.md) — Posture-Aware Defaults — active
+- [Rule D-7](docs/governance/rules/rule-D-7.md) — Concurrency / Async Resource Lifetime — active
+- [Rule D-8](docs/governance/rules/rule-D-8.md) — Single Construction Path Per Resource Class — active
+- [Rule D-9](docs/governance/rules/rule-D-9.md) — No Version / Log Metadata in Code — unknown
+- [Rule G-1](docs/governance/rules/rule-G-1.md) — Layered 4+1 Discipline + Architecture Workspace Truth — active
+- [Rule G-1.1](docs/governance/rules/rule-G-1.1.md) — L1 Architecture Depth & Grounding — active
+- [Rule G-2](docs/governance/rules/rule-G-2.md) — Authority-Text Reality (doc / status / path / numeric truth) — active
+- [Rule G-2.1](docs/governance/rules/rule-G-2.1.md) — Deleted-Module Scope Prevention — active
+- [Rule G-3](docs/governance/rules/rule-G-3.md) — Kernel-Card-Implementation Coherence — active
+- [Rule G-3.1](docs/governance/rules/rule-G-3.1.md) — Kernel-Implementation Disjunction Truth — active
+- [Rule G-4](docs/governance/rules/rule-G-4.md) — Always-Loaded Context Budget — active
+- [Rule G-5](docs/governance/rules/rule-G-5.md) — Gate Self-Consistency (parity / coverage / manifest / freshness) — active
+- [Rule G-6](docs/governance/rules/rule-G-6.md) — Gate Machinery Integrity (duration + config) — active
+- [Rule G-7](docs/governance/rules/rule-G-7.md) — Linux-First Dev Environment — active
+- [Rule G-8](docs/governance/rules/rule-G-8.md) — Cross-Authority Parity (graph baseline / SPI path / module topology / current-claim grammar / structural-carrier parity) — active
+- [Rule G-9](docs/governance/rules/rule-G-9.md) — Recurring-Defect Family Truth — active
+- [Rule G-10](docs/governance/rules/rule-G-10.md) — Parallel-Linux-Scripts Mandate — active
+- [Rule G-11](docs/governance/rules/rule-G-11.md) — Phase-Contract Rule-Allocation Coherence — active
+- [Rule G-12](docs/governance/rules/rule-G-12.md) — Whitebox Quality Baseline — active
+- [Rule G-14](docs/governance/rules/rule-G-14.md) — Feature Lifecycle Validity — active_advisory
+- [Rule G-15](docs/governance/rules/rule-G-15.md) — Fact-Layer Integrity — active_advisory
+- [Rule G-22](docs/governance/rules/rule-G-22.md) — Accepted-ADR Frame-Map Coherence — active
+- [Rule G-23](docs/governance/rules/rule-G-23.md) — Shipped-Frame Anchor Integrity — active
+- [Rule G-24](docs/governance/rules/rule-G-24.md) — Old Orchestration-SPI Package Ban — active
+- [Rule G-26](docs/governance/rules/rule-G-26.md) — Local Plan-Path Ban — active
+- [Rule M-1](docs/governance/rules/rule-M-1.md) — Skeleton Module Has No Production Java — active
+- [Rule M-2](docs/governance/rules/rule-M-2.md) — Domain Contract Discipline (schema-first + design-only registration + DFX-stem truth) — active
+- [Rule R-A](docs/governance/rules/rule-R-A.md) — Business/Platform Decoupling Enforcement — active
+- [Rule R-A.c](docs/governance/rules/rule-R-A.c.md) — Quickstart CI Smoke Run — active
+- [Rule R-B](docs/governance/rules/rule-R-B.md) — Competitive Baselines Required — active
+- [Rule R-C](docs/governance/rules/rule-R-C.md) — Code-as-Contract — active
+- [Rule R-C.1](docs/governance/rules/rule-R-C.1.md) — Independent Module Evolution — active
+- [Rule R-C.2](docs/governance/rules/rule-R-C.2.md) — Run Contract Spine — active
+- [Rule R-D](docs/governance/rules/rule-R-D.md) — SPI + DFX + TCK Co-Design + Catalog Integrity — active
+- [Rule R-E](docs/governance/rules/rule-R-E.md) — Three-Track Channel Isolation — active
+- [Rule R-F](docs/governance/rules/rule-R-F.md) — Cursor Flow Mandate — active
+- [Rule R-G](docs/governance/rules/rule-R-G.md) — Reactive External I/O — active
+- [Rule R-H](docs/governance/rules/rule-R-H.md) — No Thread.sleep in Business Code — active
+- [Rule R-I](docs/governance/rules/rule-R-I.md) — Five-Plane Manifest — active
+- [Rule R-I.1](docs/governance/rules/rule-R-I.1.md) — Edge↔Compute Ingress Routing — design_only
+- [Rule R-J](docs/governance/rules/rule-R-J.md) — Storage-Engine Tenant Isolation + Cancel Re-Authorization — active
+- [Rule R-K](docs/governance/rules/rule-R-K.md) — Skill Capacity Matrix — active
+- [Rule R-L](docs/governance/rules/rule-R-L.md) — Sandbox Permission Subsumption — active
+- [Rule R-M](docs/governance/rules/rule-R-M.md) — Engine Contract (envelope / matching / hooks / S2C / scope / historical) — active

--- a/docs/adr/0071-engine-contract-structural-wave.yaml
+++ b/docs/adr/0071-engine-contract-structural-wave.yaml
@@ -1,7 +1,6 @@
 id: ADR-0071
 title: "Engine Contract Structural Wave — umbrella for ADR-0072..0075 + L0 principle P-M"
 status: accepted
-product_claim: "PC-004"
 date: 2026-05-16
 level: L0
 view: scenarios

--- a/docs/adr/0075-evolution-scope-boundary.yaml
+++ b/docs/adr/0075-evolution-scope-boundary.yaml
@@ -1,7 +1,6 @@
 id: ADR-0075
 title: "Evolution Scope Boundary -- server-controlled evolution surface, fourth L1 expression of P-M"
 status: accepted
-product_claim: "PC-005"
 date: 2026-05-16
 level: L1
 view: logical

--- a/docs/adr/0089-edge-plane-ingress-gateway-mandate.yaml
+++ b/docs/adr/0089-edge-plane-ingress-gateway-mandate.yaml
@@ -1,7 +1,6 @@
 id: ADR-0089
 title: "Edge-Plane Ingress Gateway Mandate — client → bus → server is the only allowed C2S topology"
 status: accepted
-product_claim: "PC-002"
 date: 2026-05-20
 level: L0
 view: physical

--- a/docs/adr/0134-tool-call-iteration-loop.yaml
+++ b/docs/adr/0134-tool-call-iteration-loop.yaml
@@ -1,7 +1,6 @@
 id: ADR-0134
 title: "Tool-Call Iteration Loop: agent-driven vs. planner-driven execution modes for LLM <-> Tool <-> LLM iteration"
 status: accepted
-product_claim: "PC-003"
 date: 2026-05-25
 level: L0
 view: process

--- a/docs/adr/0135-agent-session-as-run-projection.yaml
+++ b/docs/adr/0135-agent-session-as-run-projection.yaml
@@ -1,7 +1,6 @@
 id: ADR-0135
 title: "AgentSession as Run-Projection: no separate AgentSession SPI; conversation continuity is a (tenantId, conversationId) projection over the Run sequence + M2_EPISODIC ConversationMemory"
 status: accepted
-product_claim: "PC-001"
 date: 2026-05-25
 level: L0
 view: development

--- a/docs/adr/0137-suspendsignal-canonical-interruptsignal-glossary.yaml
+++ b/docs/adr/0137-suspendsignal-canonical-interruptsignal-glossary.yaml
@@ -1,7 +1,6 @@
 id: ADR-0137
 title: "SuspendSignal remains canonical; InterruptSignal / InterruptReason are L1 glossary synonyms only (no Java rename per ADR-0100 §rejected-framings)"
 status: accepted
-product_claim: "PC-003"
 date: 2026-05-26
 level: L1
 view: logical

--- a/docs/adr/0139-fast-slow-path-narrowed-semantics.yaml
+++ b/docs/adr/0139-fast-slow-path-narrowed-semantics.yaml
@@ -1,7 +1,6 @@
 id: ADR-0139
 title: "Fast-Path / Slow-Path narrowed semantics: Fast-Path = in-process reactive synchronous + tenantId/RLS preserved + metadata persistence mandatory; Slow-Path = persistent reactive + SuspendSignal + ResumeDispatcher; neither path may violate Rule R-G / R-H / R-J.a"
 status: accepted
-product_claim: "PC-003"
 date: 2026-05-26
 level: L1
 view: process

--- a/docs/adr/0140-engine-adapter-layer-split.yaml
+++ b/docs/adr/0140-engine-adapter-layer-split.yaml
@@ -16,7 +16,6 @@ id: ADR-0140
 # a follow-up impl-mode wave (not in the audit's PR scope).
 title: "Engine Adapter Layer split: Layer 5 in ADR-0138 5-layer model decomposes into Layer 5a (Engine Dispatch & Execution: EngineRegistry + ExecutorAdapter impls) and Layer 5b (Translation & Tool-Intercept: ContextProjector + PromptTemplate + StructuredOutputConverter + ChatAdvisor); RuntimeMiddleware moves exclusively into Layer 4 Control"
 status: accepted
-product_claim: "PC-004"
 date: 2026-05-26
 level: L1
 view: logical

--- a/docs/adr/0141-internal-event-queue-design-only.yaml
+++ b/docs/adr/0141-internal-event-queue-design-only.yaml
@@ -1,7 +1,6 @@
 id: ADR-0141
 title: "Internal Event Queue (ADR-0138 Layer 3) is a design_only sub-section of agent-service L1 until a service.queue/ sub-package + Boundary Contract land; current state shows the Layer 3 binding-only role over the three-track bus; no peer-layer code home exists at rc55"
 status: accepted
-product_claim: "PC-003"
 date: 2026-05-26
 level: L1
 view: logical

--- a/docs/adr/0142-run-aggregate-single-owner.yaml
+++ b/docs/adr/0142-run-aggregate-single-owner.yaml
@@ -1,7 +1,6 @@
 id: ADR-0142
 title: "Run aggregate (Run record + RunStatus + RunStateMachine + RunRepository) is OWNED EXCLUSIVELY by Layer 2 Session & Task Manager in the ADR-0138 5-layer L1 model; Layer 4 Task-Centric Control holds a typed reference and invokes RunRepository.updateIfNotTerminal(...) — Layer 4 never writes Run state directly"
 status: accepted
-product_claim: "PC-001|PC-003"
 date: 2026-05-26
 level: L1
 view: logical

--- a/docs/adr/0145-run-event-sealed-hierarchy.yaml
+++ b/docs/adr/0145-run-event-sealed-hierarchy.yaml
@@ -1,7 +1,6 @@
 id: ADR-0145
 title: "Sealed RunEvent hierarchy specification: defines the polymorphic event type that EvolutionExport enum was designed to discriminate; specifies sealed variants required by S1-S5 scenarios; promotes Rule R-M.e (Every emitted RunEvent declares EvolutionExport) from vacuously-true to actively-gated; the actual Java sealed type lands in a follow-up impl-mode wave"
 status: accepted
-product_claim: "PC-001|PC-003"
 date: 2026-05-26
 level: L1
 view: logical

--- a/docs/adr/0146-suspend-reason-taxonomy-alignment-2026-05-22.yaml
+++ b/docs/adr/0146-suspend-reason-taxonomy-alignment-2026-05-22.yaml
@@ -1,7 +1,6 @@
 id: ADR-0146
 title: "SuspendReason taxonomy canonical alignment to 2026-05-22 expansion-proposal-response mapping table: ratifies the 6-variant set {AwaitClientCallback, AwaitChildRun, AwaitToolResult, AwaitTimer, RequiresApproval, RateLimited} as the L1 authority; reconciles prior naming drift across ADR-0019 (AwaitChildren / AwaitExternal / AwaitApproval), ADR-0070 (AwaitChild), ADR-0074 (AwaitClientCallback canonical), and ADR-0112 Part B mapping table (ChildRun / AwaitTool / AwaitApproval); applies the audit's user-directive precedence rule (doc > ADR) to settle the drift"
 status: accepted
-product_claim: "PC-003"
 date: 2026-05-27
 level: L1
 view: logical

--- a/docs/adr/0155-agent-service-l1-v1-2-internal-module-design.yaml
+++ b/docs/adr/0155-agent-service-l1-v1-2-internal-module-design.yaml
@@ -1,7 +1,6 @@
 id: ADR-0155
 title: "AgentService L1 v1.2 — internal module design absorption (M1–M6 + 6 boundary reversals)"
 status: accepted
-product_claim: "PC-003"
 date: 2026-05-28
 level: L1
 view: logical

--- a/docs/adr/0158-engine-port-transport-agnostic-boundary.yaml
+++ b/docs/adr/0158-engine-port-transport-agnostic-boundary.yaml
@@ -1,7 +1,6 @@
 id: ADR-0158
 title: "Engine Boundary (EnginePort) — transport-agnostic Service↔Engine contract absorbed into agent-bus for the three deployment forms"
 status: accepted
-product_claim: "PC-004"
 date: 2026-05-29
 level: L1
 view: development

--- a/docs/adr/archive/0159-agent-runtime-consolidation-and-service-refounding.yaml
+++ b/docs/adr/archive/0159-agent-runtime-consolidation-and-service-refounding.yaml
@@ -1,7 +1,6 @@
 id: ADR-0159
 title: "agent-runtime consolidation — the runtime SDK (today mislabelled agent-service) and the execution engine merge into one run-owning agent-runtime module; agent-service is re-founded as the enterprise serviceization façade"
 status: accepted
-product_claim: "PC-004"
 date: 2026-06-03
 level: L1
 view: development

--- a/docs/adr/locked/0020-runlifecycle-spi-and-runstatus-formal-dfa.md
+++ b/docs/adr/locked/0020-runlifecycle-spi-and-runstatus-formal-dfa.md
@@ -1,6 +1,5 @@
 ---
 adr_id: ADR-0020
-product_claim: "PC-001|PC-003"
 binds_features: [FEAT-RUN-LIFECYCLE-CONTROL]
 binds_rules: [R-C.2]
 ---

--- a/docs/architecture/l0/cross-cutting/v1.0-perf-baselines.yaml
+++ b/docs/architecture/l0/cross-cutting/v1.0-perf-baselines.yaml
@@ -1,6 +1,5 @@
 ---
 file_id: PERF-V1-0-BASELINES
-product_claim: PC-003
 status: design_only
 authority: ADR-0156
 target_personas: ["Persona-D"]
@@ -107,7 +106,6 @@ run_admission:
     It MUST return a Task Cursor immediately and MUST NOT hold the connection
     while work executes. The latency target below covers cursor-issuance only,
     NOT downstream execution.
-  product_claim: PC-003
   target_persona: Persona-D
   metric:
     name: springai_ascend_runs_admit_seconds
@@ -140,7 +138,6 @@ tool_call:
     API class is the fastest; external API class crosses the bank's
     perimeter; model gateway class is provider-dependent and inherits from
     `model_invocation` below.
-  product_claim: PC-003
   target_persona: Persona-D
   metric:
     name: springai_ascend_tool_call_seconds
@@ -197,7 +194,6 @@ model_invocation:
     Persona-D (long first-token + fast streaming = bad UX for chat
     workloads; the inverse = good UX). Streaming token rate matters for
     chunked-output workloads (loan-narrative drafting, AML report).
-  product_claim: PC-003
   target_persona: Persona-D
   metric:
     name: springai_ascend_model_invoke_seconds
@@ -266,7 +262,6 @@ throughput:
     SLA declared above. A Run is "in-flight" when its status ∈ {ADMITTED,
     RUNNING, SUSPENDED_WAITING_S2C, SUSPENDED_RATE_LIMITED}. Terminal
     statuses (COMPLETED, FAILED, CANCELLED) are NOT counted.
-  product_claim: PC-003
   target_persona: Persona-D
   targets:
     concurrent_runs_per_instance: 100
@@ -296,7 +291,6 @@ tenant_isolation_overhead:
     + Persona-F need to know the cost; the target below is the upper
     bound on that cost relative to a `SET ROLE bypass_rls` baseline run
     against the same dataset.
-  product_claim: PC-003
   target_personas: ["Persona-D", "Persona-F"]
   targets:
     p95_latency_overhead_percent_max: 5
@@ -323,7 +317,6 @@ memory_cap:
     instance (per ADR-0128); a single tenant may have many agents, but
     each individual agent's resident footprint is bounded so capacity
     planning is linear.
-  product_claim: PC-003
   target_persona: Persona-D
   targets:
     resident_megabytes_p95: 512

--- a/docs/contracts/a2a-envelope.v1.yaml
+++ b/docs/contracts/a2a-envelope.v1.yaml
@@ -11,7 +11,6 @@
 # translation at the contract boundary; A2A interoperability is
 # achieved via mapping, not by importing an A2A SDK.
 
-product_claim: "PC-002|PC-004"
 
 schema: a2a-envelope/v1
 authority: ADR-0016

--- a/docs/contracts/access-intent.v1.yaml
+++ b/docs/contracts/access-intent.v1.yaml
@@ -4,7 +4,6 @@
 # Wave: design_only at this commit; runtime_enforced when M1 Access
 # Layer's normalisation step ships the Java record carrier.
 
-product_claim: "PC-002"
 
 schema: access-intent/v1
 authority: ADR-0155

--- a/docs/contracts/agent-definition.v1.yaml
+++ b/docs/contracts/agent-definition.v1.yaml
@@ -6,7 +6,6 @@
 # Java record com.huawei.ascend.service.agent.spi.AgentDefinition
 # mirrors this schema and validates required fields on construction.
 
-product_claim: "PC-001"
 
 schema: agent-definition/v1
 status: design_only

--- a/docs/contracts/agent-event.v1.yaml
+++ b/docs/contracts/agent-event.v1.yaml
@@ -6,7 +6,6 @@
 # emission stream; RunEvent is the platform-internal projection stream
 # emitted on the IEQ-04 egress channel after STM-09 cursor assignment.
 
-product_claim: "PC-004"
 
 schema: agent-event/v1
 authority: ADR-0155

--- a/docs/contracts/agent-invoke-request.v1.yaml
+++ b/docs/contracts/agent-invoke-request.v1.yaml
@@ -10,7 +10,6 @@
 # This contract operationalizes the Run ≤ Task ≤ Session ≤ Memory
 # lifecycle (per ADR-0100 §decision).
 
-product_claim: "PC-001"
 
 schema: agent-invoke-request/v1
 authority: ADR-0138

--- a/docs/contracts/audit-trail.v1.yaml
+++ b/docs/contracts/audit-trail.v1.yaml
@@ -1,7 +1,6 @@
 ---
 contract_id: audit-trail.v1
 status: design_only
-product_claim: "PC-003"
 authority: "ADR-0156 (to be filed)"
 v1_0_ship_blocker: true
 target_persona: "Persona-F"

--- a/docs/contracts/backpressure-request.v1.yaml
+++ b/docs/contracts/backpressure-request.v1.yaml
@@ -8,7 +8,6 @@
 # from the Reactive Orchestrator (per ADR-0100 §2.2) into distributed-
 # pull signals across the federation bus.
 
-product_claim: "PC-003"
 
 schema: backpressure-request/v1
 authority: ADR-0141

--- a/docs/contracts/checkpoint-record.v1.yaml
+++ b/docs/contracts/checkpoint-record.v1.yaml
@@ -2,7 +2,6 @@
 #
 # Authority: ADR-0155. Wave: design_only.
 
-product_claim: "PC-003"
 
 schema: checkpoint-record/v1
 authority: ADR-0155

--- a/docs/contracts/config-snapshot-ref.v1.yaml
+++ b/docs/contracts/config-snapshot-ref.v1.yaml
@@ -3,7 +3,6 @@
 # Authority: ADR-0155.
 # Wave: design_only.
 
-product_claim: "PC-003"
 
 schema: config-snapshot-ref/v1
 authority: ADR-0155

--- a/docs/contracts/control-event.v1.yaml
+++ b/docs/contracts/control-event.v1.yaml
@@ -4,7 +4,6 @@
 # Wave: design_only; runtime_enforced when M3 IEQ ships the Java
 # envelope record + M4 control-channel consumer.
 
-product_claim: "PC-003"
 
 schema: control-event/v1
 authority: ADR-0155

--- a/docs/contracts/correlation-record.v1.yaml
+++ b/docs/contracts/correlation-record.v1.yaml
@@ -3,7 +3,6 @@
 # Authority: ADR-0155.
 # Wave: design_only.
 
-product_claim: "PC-003"
 
 schema: correlation-record/v1
 authority: ADR-0155

--- a/docs/contracts/cost-governance.v1.yaml
+++ b/docs/contracts/cost-governance.v1.yaml
@@ -1,6 +1,5 @@
 ---
 contract_id: cost-governance.v1
-product_claim: PC-003
 status: design_only
 authority: ADR-0156
 target_personas: ["Persona-A", "Persona-B", "Persona-D"]

--- a/docs/contracts/engine-envelope.v1.yaml
+++ b/docs/contracts/engine-envelope.v1.yaml
@@ -20,7 +20,6 @@
 # Self-enforced by gate Rule 55 (engine_envelope_yaml_present_and_wellformed)
 # and gate Rule 56 (engine_registry_covers_all_known_engines).
 
-product_claim: "PC-004"
 
 schema: engine-envelope/v1
 # Retired in the pure rebuild — not runtime-enforced (no EngineRegistry exists).

--- a/docs/contracts/engine-hooks.v1.yaml
+++ b/docs/contracts/engine-hooks.v1.yaml
@@ -12,7 +12,6 @@
 #
 # Self-enforced by gate Rule 57 (engine_hooks_yaml_present_and_wellformed).
 
-product_claim: "PC-004"
 
 schema: engine-hooks/v1
 authority: ADR-0073

--- a/docs/contracts/engine-port.v1.yaml
+++ b/docs/contracts/engine-port.v1.yaml
@@ -2,7 +2,6 @@
 #
 # Authority: ADR-0158 (Engine Boundary / EnginePort). Wave: design_only.
 
-product_claim: "PC-004"
 
 schema: engine-port/v1
 authority: ADR-0158

--- a/docs/contracts/error-class.v1.yaml
+++ b/docs/contracts/error-class.v1.yaml
@@ -5,7 +5,6 @@
 # TCC-07, M6 TTI policy denials, and all adapter failures route to one
 # of these 14 values. Modules MUST NOT invent additional classes.
 
-product_claim: "PC-003"
 
 schema: error-class/v1
 authority: ADR-0155

--- a/docs/contracts/execution-request.v1.yaml
+++ b/docs/contracts/execution-request.v1.yaml
@@ -3,7 +3,6 @@
 # Authority: ADR-0155.
 # Wave: design_only.
 
-product_claim: "PC-004"
 
 schema: execution-request/v1
 authority: ADR-0155

--- a/docs/contracts/governed-messages.v1.yaml
+++ b/docs/contracts/governed-messages.v1.yaml
@@ -3,7 +3,6 @@
 # Authority: ADR-0155 §3 (M6 prompt-reversal).
 # Wave: design_only.
 
-product_claim: "PC-003"
 
 schema: governed-messages/v1
 authority: ADR-0155

--- a/docs/contracts/iam-bridge.v1.yaml
+++ b/docs/contracts/iam-bridge.v1.yaml
@@ -1,7 +1,6 @@
 ---
 contract_id: iam-bridge.v1
 status: design_only
-product_claim: "PC-003"
 authority: "ADR-0156 (to be filed)"
 v1_0_ship_blocker: true
 target_persona: "Persona-F + Persona-D"

--- a/docs/contracts/intercept-request.v1.yaml
+++ b/docs/contracts/intercept-request.v1.yaml
@@ -3,7 +3,6 @@
 # Authority: ADR-0155.
 # Wave: design_only.
 
-product_claim: "PC-004"
 
 schema: intercept-request/v1
 authority: ADR-0155

--- a/docs/contracts/interrupt-registration.v1.yaml
+++ b/docs/contracts/interrupt-registration.v1.yaml
@@ -4,7 +4,6 @@
 # consumes via ControlEvent.payloadRef).
 # Wave: design_only.
 
-product_claim: "PC-003"
 
 schema: interrupt-registration/v1
 authority: ADR-0155

--- a/docs/contracts/openapi-v1.yaml
+++ b/docs/contracts/openapi-v1.yaml
@@ -1,4 +1,3 @@
-product_claim: "PC-001|PC-003"
 
 openapi: "3.0.1"
 info:

--- a/docs/contracts/plan-projection.v1.yaml
+++ b/docs/contracts/plan-projection.v1.yaml
@@ -32,7 +32,6 @@
 # admit against the SkillResourceMatrix and tenant quota. Without this
 # projection, planner output and capacity arbitration are unjoinable.
 
-product_claim: "PC-001"
 
 schema: plan-projection/v1
 status: design_only

--- a/docs/contracts/plan.v1.yaml
+++ b/docs/contracts/plan.v1.yaml
@@ -7,7 +7,6 @@
 # plan-projection.v1.yaml) is the per-step scheduler INPUT
 # derived from Plan + PlanStep.
 
-product_claim: "PC-001"
 
 schema: plan/v1
 status: design_only

--- a/docs/contracts/planning-request.v1.yaml
+++ b/docs/contracts/planning-request.v1.yaml
@@ -3,7 +3,6 @@
 # Authority: ADR-0126 (Planner SPI; extends ADR-0032).
 # Wave: rc43 Wave B6.
 
-product_claim: "PC-001"
 
 schema: planning-request/v1
 status: design_only

--- a/docs/contracts/run-event.v1.yaml
+++ b/docs/contracts/run-event.v1.yaml
@@ -19,7 +19,6 @@
 #   S4 S2C Client Callback             -> + S2cCallbackRequested, S2cCallbackCompleted
 #   S5 Cancel During Execution         -> + CancelRequested
 
-product_claim: "PC-001|PC-003"
 
 schema: run-event/v1
 authority: ADR-0145

--- a/docs/contracts/s2c-callback.v1.yaml
+++ b/docs/contracts/s2c-callback.v1.yaml
@@ -17,7 +17,6 @@
 #
 # Self-enforced by gate Rule 58 (s2c_callback_yaml_present_and_wellformed).
 
-product_claim: "PC-004"
 
 schema: s2c-callback/v1
 # Post-review status label (plan G / §5): S2C protocol is runtime_enforced --

--- a/docs/contracts/session-snapshot.v1.yaml
+++ b/docs/contracts/session-snapshot.v1.yaml
@@ -3,7 +3,6 @@
 # Authority: ADR-0155 §3 (PlatformMemoryProvider return shape).
 # Wave: design_only.
 
-product_claim: "PC-005"
 
 schema: session-snapshot/v1
 authority: ADR-0155

--- a/docs/contracts/tool-result.v1.yaml
+++ b/docs/contracts/tool-result.v1.yaml
@@ -2,7 +2,6 @@
 #
 # Authority: ADR-0155. Wave: design_only.
 
-product_claim: "PC-004"
 
 schema: tool-result/v1
 authority: ADR-0155

--- a/docs/contracts/work-item.v1.yaml
+++ b/docs/contracts/work-item.v1.yaml
@@ -3,7 +3,6 @@
 # Authority: ADR-0155.
 # Wave: design_only.
 
-product_claim: "PC-003"
 
 schema: work-item/v1
 authority: ADR-0155

--- a/docs/governance/enforcers.yaml
+++ b/docs/governance/enforcers.yaml
@@ -47,7 +47,6 @@
   view: logical
   artifact: agent-runtime/src/main/resources/db/migration/V2__idempotency_dedup.sql
   asserts: "PRIMARY KEY (tenant_id, idempotency_key) prevents duplicate inserts at storage layer"
-  product_claim: "PC-001|PC-003"
 
 - id: E15
   constraint_ref: "CLAUDE.md Rule R-C.a; L1 plan §11 row E15"
@@ -56,7 +55,6 @@
   view: logical
   artifact: gate/check_architecture_sync.sh#tenant_column_present
   asserts: "every CREATE TABLE under src/main/resources/db/migration/ has a tenant_id column"
-  product_claim: "PC-003"
 
 - id: E19
   constraint_ref: "CLAUDE.md Rule R-C.a; L1 plan §10"
@@ -65,7 +63,6 @@
   view: development
   artifact: gate/check_architecture_sync.sh#high_cardinality_tag_guard
   asserts: "no source registers Tag.of(\"run_id\"|\"idempotency_key\"|\"jwt_sub\"|\"body\", …) on a springai_ascend_* metric"
-  product_claim: "PC-003"
 
 - id: E20
   constraint_ref: "CLAUDE.md Rule R-C.a; architect guidance §9.3"
@@ -74,7 +71,6 @@
   view: development
   artifact: gate/check_architecture_sync.sh#no_secret_patterns
   asserts: "no AKIA/sk-/-----BEGIN PRIVATE KEY-----/etc. patterns in tracked files (allow-list inline-annotated)"
-  product_claim: "PC-003"
 
 - id: E26
   constraint_ref: "CLAUDE.md Rule R-C.a; L1 plan §13 out-of-scope"
@@ -83,7 +79,6 @@
   view: development
   artifact: gate/check_architecture_sync.sh#out_of_scope_name_guard
   asserts: "names LLMGateway/PostgresCheckpointer/SkillRegistry/HookChain/SpawnEnvelope/LogicalCallHandle/ConnectionLease/AdmissionDecision/BackpressureSignal/ChronosHydration/SandboxExecutor do not appear in agent-*/src/main/java"
-  product_claim: "PC-003"
 
 - id: E29
   constraint_ref: "CLAUDE.md Rule R-C.a; ADR-0059 §1"
@@ -92,7 +87,6 @@
   view: scenarios
   artifact: gate/check_architecture_sync.sh#enforcers_yaml_wellformed
   asserts: "every row in this file has id+constraint_ref+kind+level+view+artifact+asserts; kind is one of the five legal values; level is L0|L1|L2; view is one of the five legal values"
-  product_claim: "PC-003"
 
 - id: E33
   constraint_ref: "CLAUDE.md Rule R-C.a; L1 plan §18.3 step 1; Phase K audit fix F6; ADR-0059"
@@ -101,7 +95,6 @@
   view: scenarios
   artifact: gate/check_architecture_sync.sh#enforcer_artifact_paths_exist
   asserts: "every artifact: path in this file resolves to a real file on disk (strips #anchor suffix). Closes the gate-gap that let E12 ship pointing at a non-existent test."
-  product_claim: "PC-003"
 
 - id: E35
   constraint_ref: "CLAUDE.md Rule R-C.a; ADR-0060 §1; Phase L reviewer P0-2 root cause"
@@ -110,7 +103,6 @@
   view: scenarios
   artifact: gate/check_architecture_sync.sh#enforcer_artifact_paths_exist
   asserts: "every artifact: path#anchor in enforcers.yaml resolves to a real method (.java/.sh) or heading (.md) inside the target file; closes the gate gap where E5/E6/E24 shipped pointing at non-existent test methods."
-  product_claim: "PC-003"
 
 - id: E39
   constraint_ref: "CLAUDE.md Rule G-2 sub-clause .a; ARCHITECTURE.md §4 #54 (run_trace_session_identity_spi); ADR-0062"
@@ -137,7 +129,6 @@
   view: development
   artifact: gate/check_architecture_sync.sh#domain_module_has_spi_package
   asserts: "Every kind:domain module declares at least one entry under spi_packages: and each declared package resolves to a directory under <module>/src/main/java/."
-  product_claim: "PC-001"
 
 # --- W1 Layered-4+1 + Architecture-Graph wave (Rules 33-34; ADR-0068; §4 #64-#65) ---
 
@@ -180,7 +171,6 @@
   view: physical
   artifact: gate/check_architecture_sync.sh#rls_for_new_tenant_tables
   asserts: "every Flyway migration creating a table with a tenant_id column either includes ENABLE ROW LEVEL SECURITY in the same file OR is listed in gate/rls-baseline-grandfathered.txt."
-  product_claim: "PC-003"
 
 # ---------------------------------------------------------------------------
 # W1.x Phase 8 — Cursor Flow runtime activation (Rule R-F.b / ADR-0070)
@@ -193,7 +183,6 @@
   view: logical
   artifact: gate/check_architecture_sync.sh#s2c_callback_yaml_present_and_wellformed
   asserts: "docs/contracts/s2c-callback.v1.yaml exists; declares schema header, request: and response: blocks, the 6 mandatory request fields (callback_id, server_run_id, capability_ref, request_payload, trace_id, idempotency_key per Phase 3a audit §5.2), and outcome_values closed at {ok, error, timeout}."
-  product_claim: "PC-004"
 
 - id: E89
   constraint_ref: "CLAUDE.md Rule R-M sub-clause .d (S2C Callback) -- Phase 3a Cross-Rule Co-Design Audit Matrix freeze; ADR-0074; P-M"
@@ -202,7 +191,6 @@
   view: scenarios
   artifact: docs/logs/reviews/2026-05-16-engine-contract-structural-response.en.md
   asserts: "The Phase 3a section 5 Cross-Rule Co-Design Audit Matrix is referenced by ADR-0074 line 47 and CLAUDE.md Rule R-M sub-clause .d prose as the canonical Rules 20/35/38/41/42 interlock specification. Freeze invariant: this file MUST exist on disk; a future rename or split MUST update both anchors AND this enforcer row in the same PR. Today the assertion is structural (file exists); the matrix content itself is reviewed under PR review per Rule D-5 ship-gate posture."
-  product_claim: "PC-004"
 
 # ---------------------------------------------------------------------------
 # v2.0.0-rc1 post-release review response -- Rule R-M sub-clause .d FAILED-transition + R2 classpath fallback
@@ -215,7 +203,6 @@
   view: development
   artifact: gate/check_architecture_sync.sh#contract_spine_tenant_id_required
   asserts: "Every public record under agent-runtime/src/main/java/com/huawei/ascend/service/{runtime,task,session}/ declares a String tenantId component (relocated from agent-runtime-core per ADR-0088 rc13 dissolution; scope widened to task + session per rc34 audit closure). Process-internal opt-out via 'scope: process-internal' reason comment."
-  product_claim: "PC-001|PC-003"
 
 # ---------------------------------------------------------------------------
 # 2026-05-18 rc4 cross-constraint review response prevention wave — E116
@@ -248,7 +235,6 @@
   view: logical
   artifact: gate/check_architecture_sync.sh#spi_catalog_exhaustiveness
   asserts: "Every `public interface ...` declaration in a Java source file under any `*/spi/*` path (excluding `target/`) MUST appear in docs/contracts/contract-catalog.md as a backtick-wrapped interface name (either as an Active SPI table row OR explicitly marked `(internal)`). Closes rc8 post-corrective P1-2: SkillCapacityRegistry was public under .spi but missing from the catalog (11 total claimed)."
-  product_claim: "PC-001"
 
 - id: E132
   constraint_ref: "CLAUDE.md Rule R-D sub-clause .g (spi_catalog_exhaustiveness); ADR-0083"
@@ -257,7 +243,6 @@
   view: logical
   artifact: gate/test_architecture_sync_gate.sh#test_rule_95_spi_catalog_pos
   asserts: "Positive + negative self-test fixtures for Rule R-D sub-clause .g. Positive: every public interface under */spi/* appears in catalog → pass. Negative: a synthetic public interface under */spi/* not in catalog → fail."
-  product_claim: "PC-001"
 
 - id: E144
   constraint_ref: "CLAUDE.md Rule R-I sub-clause .b (Edge↔Compute Ingress Routing); ADR-0089"
@@ -266,7 +251,6 @@
   view: physical
   artifact: gate/check_architecture_sync.sh#edge_no_direct_compute_link
   asserts: "Rule 105 — for every agent-*/module-metadata.yaml whose deployment_plane is `edge`, NO .java file under <module>/src/main/java/**/*.java may carry an `import com.huawei.ascend.{service,engine,middleware}.*` line, AND NO file may construct a RestTemplate or WebClient targeting a host other than the bus ingress endpoint. Source-level guard complementing E143 (bytecode-level)."
-  product_claim: "PC-002"
 
 # ---------------------------------------------------------------------------
 # rc14 (2026-05-20) — Cross-Authority Parity wave (Rule G-8 / Rule 106).

--- a/docs/governance/principles/P-A.md
+++ b/docs/governance/principles/P-A.md
@@ -5,7 +5,6 @@ level: L0
 view: development
 authority: "Layer 0 governing principle (CLAUDE.md)"
 enforced_by_rules: [R-A]   # formerly Rule 29 (numeric pre-ADR-0086)
-product_claim: "PC-001"
 kernel: |
   P-A — Business / Platform Decoupling + Developer Self-Service.
   Business code and Platform code are decoupled.

--- a/docs/governance/principles/P-B.md
+++ b/docs/governance/principles/P-B.md
@@ -5,7 +5,6 @@ level: L0
 view: scenarios
 authority: "Layer 0 governing principle (CLAUDE.md)"
 enforced_by_rules: [R-B]   # formerly Rule 30 (numeric pre-ADR-0086)
-product_claim: "PC-001|PC-002|PC-003|PC-005"
 kernel: |
   P-B — Four Competitive Pillars.
   Platform competitiveness rests on four continuously-improvable dimensions —

--- a/docs/governance/principles/P-D.md
+++ b/docs/governance/principles/P-D.md
@@ -5,7 +5,6 @@ level: L0
 view: development
 authority: "Layer 0 governing principle (CLAUDE.md)"
 enforced_by_rules: [R-D]   # formerly Rule 32 (numeric pre-ADR-0086)
-product_claim: "PC-001"
 kernel: |
   P-D — SPI-Aligned, DFX-Explicit, Spec-Driven, TCK-Tested.
   Every domain module ships an SPI;

--- a/docs/governance/principles/P-E.md
+++ b/docs/governance/principles/P-E.md
@@ -5,7 +5,6 @@ level: L0
 view: physical
 authority: "Layer 0 governing principle (CLAUDE.md); LucioIT W1 L0 §6-§7"
 enforced_by_rules: [R-E]   # formerly Rule 35 (numeric pre-ADR-0086)
-product_claim: "PC-002"
 kernel: |
   P-E — Multi-Track Bus Physical Channel Isolation.
   Cross-service internal communication is sliced into three physically

--- a/docs/governance/principles/P-F.md
+++ b/docs/governance/principles/P-F.md
@@ -5,7 +5,6 @@ level: L0
 view: logical
 authority: "Layer 0 governing principle (CLAUDE.md); LucioIT W1 L0 §6-§7"
 enforced_by_rules: [R-F]   # formerly Rule 36 (numeric pre-ADR-0086)
-product_claim: "PC-003"
 kernel: |
   P-F — Cursor Flow & Asynchronous Client Boundary.
   The Client → Runtime boundary is non-blocking by ironclad rule.

--- a/docs/governance/principles/P-G.md
+++ b/docs/governance/principles/P-G.md
@@ -5,7 +5,6 @@ level: L0
 view: process
 authority: "Layer 0 governing principle (CLAUDE.md); LucioIT W1 L0 §6-§7"
 enforced_by_rules: [R-G]   # formerly Rule 37 (numeric pre-ADR-0086)
-product_claim: "PC-003"
 kernel: |
   P-G — Absolute Non-Blocking I/O.
   External I/O calls (model gateway, vector DB, sandbox dispatch) MUST use

--- a/docs/governance/principles/P-H.md
+++ b/docs/governance/principles/P-H.md
@@ -5,7 +5,6 @@ level: L0
 view: process
 authority: "Layer 0 governing principle (CLAUDE.md); LucioIT W1 L0 §6-§7"
 enforced_by_rules: [R-H]   # formerly Rule 38 (numeric pre-ADR-0086)
-product_claim: "PC-003"
 kernel: |
   P-H — Chronos Hydration.
   Long-horizon waits in business code MUST be declarative suspension

--- a/docs/governance/principles/P-I.md
+++ b/docs/governance/principles/P-I.md
@@ -5,7 +5,6 @@ level: L0
 view: physical
 authority: "Layer 0 governing principle (CLAUDE.md); LucioIT W1 L0 §6-§7"
 enforced_by_rules: [R-I]   # formerly Rule 39 (numeric pre-ADR-0086)
-product_claim: "PC-002"
 kernel: |
   P-I — Five-Plane Distributed Topology.
   Production deployment is divided into five physically isolated planes —

--- a/docs/governance/principles/P-J.md
+++ b/docs/governance/principles/P-J.md
@@ -5,7 +5,6 @@ level: L0
 view: physical
 authority: "Layer 0 governing principle (CLAUDE.md); LucioIT W1 L0 §6-§7"
 enforced_by_rules: [R-J]   # formerly Rule 40 (numeric pre-ADR-0086)
-product_claim: "PC-003"
 kernel: |
   P-J — Storage-Engine Tenant Isolation.
   Tenant isolation lives at the storage engine, not the application code.

--- a/docs/governance/principles/P-K.md
+++ b/docs/governance/principles/P-K.md
@@ -5,7 +5,6 @@ level: L0
 view: physical
 authority: "Layer 0 governing principle (CLAUDE.md); LucioIT W1 L0 §6-§7"
 enforced_by_rules: [R-K]   # formerly Rule 41 (numeric pre-ADR-0086)
-product_claim: "PC-003"
 kernel: |
   P-K — Skill-Dimensional Resource Arbitration.
   A 2D defence net — Tenant Quota × Global Skill Capacity — protects the

--- a/docs/governance/principles/P-L.md
+++ b/docs/governance/principles/P-L.md
@@ -5,7 +5,6 @@ level: L0
 view: physical
 authority: "Layer 0 governing principle (CLAUDE.md); LucioIT W1 L0 §6-§7"
 enforced_by_rules: [R-L]   # formerly Rule 42 (numeric pre-ADR-0086)
-product_claim: "PC-003"
 kernel: |
   P-L — Sandbox Permission Subsumption.
   Logical authorizations issued by the bus MUST 1:1 map to physical sandbox

--- a/docs/governance/principles/P-M.md
+++ b/docs/governance/principles/P-M.md
@@ -5,7 +5,6 @@ level: L0
 view: logical
 authority: "Layer 0 governing principle (CLAUDE.md); W2.x engine contract structural wave"
 enforced_by_rules: [R-M.a, R-M.b, R-M.c, R-M.d, R-M.e, M-2.a]   # formerly Rules 43, 44, 45, 46, 47, 48 (numeric pre-ADR-0086)
-product_claim: "PC-004"
 kernel: |
   P-M — Heterogeneous Engine Contract & Server-Sovereign Boundary.
   The platform supports heterogeneous execution engines through a structured

--- a/docs/governance/rules/rule-D-6.md
+++ b/docs/governance/rules/rule-D-6.md
@@ -7,7 +7,6 @@ principle_ref: P-A
 authority_refs: []
 enforcer_refs: []
 status: active
-product_claim: "PC-003"
 scope_phase: design
 kernel_cap: 12
 kernel: |

--- a/docs/governance/rules/rule-D-7.md
+++ b/docs/governance/rules/rule-D-7.md
@@ -7,7 +7,6 @@ principle_ref: P-A
 authority_refs: []
 enforcer_refs: []
 status: active
-product_claim: "PC-003"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-D-8.md
+++ b/docs/governance/rules/rule-D-8.md
@@ -7,7 +7,6 @@ principle_ref: P-A
 authority_refs: []
 enforcer_refs: []
 status: active
-product_claim: "PC-003"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-G-2.1.md
+++ b/docs/governance/rules/rule-G-2.1.md
@@ -15,14 +15,13 @@ scope_surfaces:
   - "agent-*/ARCHITECTURE.md"
   - "docs/governance/rules/rule-*.md"
   - "agent-*/src/test/java/**/*{Test,IT}.java Javadoc"
-  - "ops/**/*.{yaml,yml,tpl}"
   - "docs/contracts/*.yaml"
   - "**/module-metadata.yaml"
   - Dockerfile
   - ".github/workflows/*.yml"
   - "docs/**/*.puml"
 kernel: |
-  **Deleted-module-name leakage across the active corpus: `architecture-status.yaml#allowed_claim` text (sub-clause .a, from former G-2.e), every active `.md/.yaml/.yml/.java` outside historical-by-location exemptions (sub-clause .b, from former G-2.f), AND files under `ops/**/*.{yaml,yml,tpl,md}` / `docs/contracts/*.yaml` / `**/module-metadata.yaml` / Dockerfile / `.github/workflows/*.yml` / `docs/**/*.puml` (sub-clause .c, from former G-2.h + Rule 103) MUST NOT contain current-tense pre-Phase-C module names (`agent-platform`, `agent-runtime` with negative lookahead on `agent-runtime-core`) outside marker windows listed in `gate/active-corpus-name-exemption-markers.txt`; file-path exemptions in `gate/active-corpus-name-exemption-paths.txt`. Detection uses the word-boundary regex `\bagent-platform\b` OR (`\bagent-runtime\b` AND NOT `\bagent-runtime-core\b`) with ±3-line historical-marker scan.**
+  **Deleted-module-name leakage across the active corpus: `architecture-status.yaml#allowed_claim` text (sub-clause .a, from former G-2.e), every active `.md/.yaml/.yml/.java` outside historical-by-location exemptions (sub-clause .b, from former G-2.f), AND files under `docs/contracts/*.yaml` / `**/module-metadata.yaml` / Dockerfile / `.github/workflows/*.yml` / `docs/**/*.puml` (sub-clause .c, from former G-2.h + Rule 103) MUST NOT contain current-tense pre-Phase-C module names (`agent-platform`, `agent-runtime` with negative lookahead on `agent-runtime-core`) outside marker windows listed in `gate/active-corpus-name-exemption-markers.txt`; file-path exemptions in `gate/active-corpus-name-exemption-paths.txt`. Detection uses the word-boundary regex `\bagent-platform\b` OR (`\bagent-runtime\b` AND NOT `\bagent-runtime-core\b`) with ±3-line historical-marker scan.**
 ---
 
 # Rule G-2.1 — Deleted-Module Scope Prevention
@@ -99,8 +98,6 @@ exemption markers in `gate/active-corpus-name-exemption-markers.txt`.
 
 Scans the surfaces NOT covered by sub-clause .b:
 
-- `ops/**/*.{yaml,yml,tpl,md}` — operational infra (Helm charts, K8s
-  manifests, ops READMEs).
 - `docs/contracts/*.yaml` — live API contracts.
 - `**/module-metadata.yaml` (any depth ≤ 3) — per-module metadata.
 - `Dockerfile` — deploy entrypoint.

--- a/docs/governance/rules/rule-G-2.md
+++ b/docs/governance/rules/rule-G-2.md
@@ -344,7 +344,7 @@ The rc9 impl scanned 3 narrow surfaces; the rc11 widening flips the model to "sc
 
 **Surfaces that necessarily name the deleted modules** — `docs/governance/architecture-status.yaml` (allowed_claim narrative tracks wave history), `docs/governance/enforcers.yaml` (enforcer descriptions name what they check), `docs/governance/rule-history.md` (historical rule scope catalog), `docs/governance/principles/*` (principle cards reference deferred sub-clauses naming pre-Phase-C modules), `docs/governance/whitepaper-alignment-matrix.md`, `docs/governance/rules/rule-{87,93,94,98,33,37,21}.md` (rule cards about the leakage rule itself + retargeted-Rule-R-C.e/33/37 cards), `docs/telemetry/policy.md` (backward-compat metric tag), `docs/dfx/*` (DFX yaml descriptions naming subsumed prior artifacts), `agent-runtime-core/ARCHITECTURE.md` (kernel module names the legacy loop it broke), `perf/*` (perf docs name pre-Phase-C tests as W4 targets), `spring-ai-ascend-dependencies/module-metadata.yaml` (BoM description).
 
-**Rule-G-2.h domain (avoid duplicate-fail)** — `ops/*` and `docs/contracts/*` are Rule G-2 sub-clause .h's primary scope; Rule G-2 sub-clause .f skips them to prevent both rules failing on the same hit.
+**Rule-G-2.h domain (avoid duplicate-fail)** — `docs/contracts/*` is Rule G-2 sub-clause .h's primary scope; Rule G-2 sub-clause .f skips it to prevent both rules failing on the same hit.
 
 **Live contract** — `docs/contracts/openapi-v1.yaml` (carries `x-contract-owner` metadata; separate update plan).
 
@@ -450,7 +450,6 @@ Rule G-2 sub-clause .h reuses Rule G-2 sub-clause .f's word-boundary awk regex (
 
 The DIFFERENCE is file-discovery scope. Rule G-2 sub-clause .h scans:
 
-- `ops/**/*.yaml`, `ops/**/*.yml`, `ops/**/*.tpl` — operational infra (Helm charts, Kubernetes manifests)
 - `docs/contracts/*.yaml` — live API contracts (single-level, excludes versioned subdirectories like `docs/contracts/openapi-v1.yaml-pinned/` if they exist)
 - `**/module-metadata.yaml` (any depth ≤ 3, excludes `target/`, `.git/`, `docs/archive/`) — per-module metadata that often describes BoM contents, allowed/forbidden deps, etc.
 

--- a/docs/governance/rules/rule-R-A.c.md
+++ b/docs/governance/rules/rule-R-A.c.md
@@ -7,7 +7,6 @@ principle_ref: P-A
 authority_refs: [ADR-0064]
 enforcer_refs: [E107]
 status: active
-product_claim: "PC-001"
 scope_phase: design
 kernel_cap: 12
 kernel: |

--- a/docs/governance/rules/rule-R-A.md
+++ b/docs/governance/rules/rule-R-A.md
@@ -7,7 +7,6 @@ principle_ref: P-A
 authority_refs: [ADR-0064]
 enforcer_refs: [E48, E49]
 status: active
-product_claim: "PC-001"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-B.md
+++ b/docs/governance/rules/rule-R-B.md
@@ -7,7 +7,6 @@ principle_ref: P-B
 authority_refs: [ADR-0065]
 enforcer_refs: [E50, E51]
 status: active
-product_claim: "PC-001|PC-002|PC-003|PC-005"
 scope_phase: commit
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-C.1.md
+++ b/docs/governance/rules/rule-R-C.1.md
@@ -7,7 +7,6 @@ principle_ref: P-C
 authority_refs: [ADR-0066, ADR-0068, "ADR-0094 (retired)"]
 enforcer_refs: [E31]
 status: active
-product_claim: "PC-003"
 scope_phase: design
 kernel_cap: 6
 scope_surfaces:

--- a/docs/governance/rules/rule-R-C.2.md
+++ b/docs/governance/rules/rule-R-C.2.md
@@ -9,7 +9,6 @@ enforcer_refs: [E2, E4, E9, E11]
 status: active
 scope_phase: impl
 kernel_cap: 8
-product_claim: "PC-001|PC-003"
 scope_surfaces:
   - "agent-service/src/main/java/com/huawei/ascend/service/runtime/runs/**/*.java"
   - "agent-service/src/main/java/com/huawei/ascend/service/runtime/idempotency/**/*.java"

--- a/docs/governance/rules/rule-R-C.md
+++ b/docs/governance/rules/rule-R-C.md
@@ -7,7 +7,6 @@ principle_ref: P-C
 authority_refs: [ADR-0064, ADR-0068, "ADR-0094 (retired)"]
 enforcer_refs: [E15, E16, E17, E18, E19, E27, E28, E29, E30]
 status: active
-product_claim: "PC-003"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-D.md
+++ b/docs/governance/rules/rule-R-D.md
@@ -7,7 +7,6 @@ principle_ref: P-D
 authority_refs: [ADR-0067, ADR-0083, ADR-0085]
 enforcer_refs: [E3, E32, E105, E106, E107, E108, E117, E118, E131]
 status: active
-product_claim: "PC-001"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-E.md
+++ b/docs/governance/rules/rule-R-E.md
@@ -7,7 +7,6 @@ principle_ref: P-E
 authority_refs: [ADR-0069]
 enforcer_refs: [E64]
 status: active
-product_claim: "PC-002"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-F.md
+++ b/docs/governance/rules/rule-R-F.md
@@ -7,7 +7,6 @@ principle_ref: P-F
 authority_refs: [ADR-0069, "ADR-0070 (retired)"]
 enforcer_refs: [E65, E72]
 status: active
-product_claim: "PC-003"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-G.md
+++ b/docs/governance/rules/rule-R-G.md
@@ -7,7 +7,6 @@ principle_ref: P-G
 authority_refs: [ADR-0069]
 enforcer_refs: [E66]
 status: active
-product_claim: "PC-003"
 scope_phase: impl
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-H.md
+++ b/docs/governance/rules/rule-R-H.md
@@ -7,7 +7,6 @@ principle_ref: P-H
 authority_refs: [ADR-0069]
 enforcer_refs: [E67]
 status: active
-product_claim: "PC-003"
 scope_phase: impl
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-I.1.md
+++ b/docs/governance/rules/rule-R-I.1.md
@@ -7,7 +7,6 @@ principle_ref: P-I
 authority_refs: [ADR-0049, ADR-0089, "ADR-0094 (retired)"]
 enforcer_refs: [E143]
 status: design_only
-product_claim: "PC-002"
 scope_phase: design
 kernel_cap: 6
 scope_surfaces:

--- a/docs/governance/rules/rule-R-I.md
+++ b/docs/governance/rules/rule-R-I.md
@@ -7,7 +7,6 @@ principle_ref: P-I
 authority_refs: [ADR-0069, "ADR-0094 (retired)"]
 enforcer_refs: [E68]
 status: active
-product_claim: "PC-002"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-J.md
+++ b/docs/governance/rules/rule-R-J.md
@@ -7,7 +7,6 @@ principle_ref: P-J
 authority_refs: [ADR-0069, ADR-0020, "ADR-0078 (retired)"]
 enforcer_refs: [E69, E106]
 status: active
-product_claim: "PC-003"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-K.md
+++ b/docs/governance/rules/rule-R-K.md
@@ -7,7 +7,6 @@ principle_ref: P-K
 authority_refs: [ADR-0069, "ADR-0070 (retired)", ADR-0085]
 enforcer_refs: [E70, E73]
 status: active
-product_claim: "PC-003"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-L.md
+++ b/docs/governance/rules/rule-R-L.md
@@ -7,7 +7,6 @@ principle_ref: P-L
 authority_refs: [ADR-0069]
 enforcer_refs: [E71]
 status: active
-product_claim: "PC-003"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/rules/rule-R-M.md
+++ b/docs/governance/rules/rule-R-M.md
@@ -7,7 +7,6 @@ principle_ref: P-M
 authority_refs: [ADR-0071, "ADR-0072 (retired)", "ADR-0073 (retired)", "ADR-0074 (retired)", ADR-0075, ADR-0077]
 enforcer_refs: [E73, E81, E82, E83, E84, E89, E90, E92, E113]  # E74/E75/E76/E78 removed: retired with the .b/.c envelope/registry/hook design (no current Java type or enforcers.yaml row)
 status: active
-product_claim: "PC-004"
 scope_phase: design
 kernel_cap: 8
 kernel: |

--- a/docs/governance/sandbox-policies.yaml
+++ b/docs/governance/sandbox-policies.yaml
@@ -63,7 +63,6 @@ financial_default:
   wall_clock_cap_seconds: 60                          # Conservative: 1 minute per skill invocation
   pii_egress_to_model: false                          # No PII to LLM without explicit redaction
   syscall_allowlist: []                               # Per-deployment override
-  product_claim: "PC-003"
   target_persona: "Persona-F"
 
 # Per-skill overrides. Each explicitly widens the default policy and the

--- a/docs/governance/skill-capacity.yaml
+++ b/docs/governance/skill-capacity.yaml
@@ -26,7 +26,6 @@ v1_0_financial_default_budget:
   monthly_input_tokens: 30_000_000
   monthly_output_tokens: 6_000_000
   enforcement_mode: block
-  product_claim: PC-003
 
 
 # Post-rc2 status label (gate Rule 62 `contract_yaml_declares_status`): this

--- a/gate/active-corpus-name-exemption-paths.txt
+++ b/gate/active-corpus-name-exemption-paths.txt
@@ -4,7 +4,7 @@
 # Path prefixes may end with `/` (directory match) or `.md`/`.yaml` (single file match).
 #
 # Authority: Authority-Surface Cleanup migration plan (2026-05-19) — Wave 2 externalisation.
-# Rule 98 has its OWN file-discovery scope (ops/, docs/contracts/, module-metadata.yaml)
+# Rule 98 has its OWN file-discovery scope (docs/contracts/, module-metadata.yaml)
 # and consumes only the marker file below, not this paths file.
 
 # Build artefacts / version control are skipped at find time, not via this file.
@@ -69,8 +69,7 @@ spring-ai-ascend-dependencies/module-metadata.yaml
 # (Line retained as comment so historians can trace why rc12 listed it.)
 # agent-runtime-core/ARCHITECTURE.md  # REMOVED rc13 — module dissolved per ADR-0088
 
-# Rule-98 domain — avoid duplicate-fail by skipping ops/ and docs/contracts/ in Rule 94.
-ops/
+# Rule-98 domain — avoid duplicate-fail by skipping docs/contracts/ in Rule 94.
 docs/contracts/
 
 # Phase C competitive analyses (added 2026-05-28). These files legitimately quote

--- a/gate/always-loaded-budget.txt
+++ b/gate/always-loaded-budget.txt
@@ -117,7 +117,7 @@ CLAUDE.md=10000
 #   rule-index.md       52 entries   8195 bytes
 #   contract-index.md   25 entries   6506 bytes
 # adr-index.md ceiling raised from the originally-proposed 10000 to 30000:
-# the format spec (id link + title + status + product_claim) cannot fit
+# the format spec (id link + title + status) cannot fit
 # 150 rows in 10K — line average is ~150 bytes after clipping titles at 80
 # chars. Future shrink targets: ratchet down ~2K per cleanup wave as the
 # docs/adr/locked/ folder is pruned and obsolete ADRs are archived.


### PR DESCRIPTION
Finishes the design-month wind-down by clearing the references that were intentionally left inert in #166, now that the corpus is settled.

## A — `product_claim` schema field (97c6612a)
The product-traceability spine (`product/`, `claims.yaml`, rules G-16..G-21) was retired in #166, leaving `product_claim:`/`PC-NNN` as dead metadata. **No active gate validates it** (the only enforcers were the retired rules). Stripped entirely:
- **82 source files**: 16 ADRs, 35 contracts, 20 rule cards, 12 principle cards, `enforcers.yaml` (per-row), `sandbox-policies.yaml`, `skill-capacity.yaml`, `v1.0-perf-baselines.yaml`
- `discovery/_gen.py`: dropped the product_claim column from the ADR/rule/contract index row format + headers (+ removed the now-dead parsing)
- `discovery/{adr,rule,contract}-index.md`: regenerated (no product_claim column)

## C — `ops/**` scan-scope (6b5f745b)
`ops/` was permanently removed, so the deleted-module-name leakage rule's `ops/**` scan-scope is dead. Narrowed `rule-G-2.1` (scope_surfaces + kernel + explanation), `rule-G-2` (sub-clause .h domain + scan list), and the exemption file. Kept the rule's historical narrative + the recurring-defect-families ledger (those record history, not current scope).

## third_party (6b5f745b)
`.gitignore`: dropped the dead `third_party/MANIFEST.md` reference from the Tier-C comment. Kept the `third_party/*/` gitignore rules + clone-path convention (OpenJiuwen source is still referenced there).

## Validation
Each part validated GREEN on WSL against the full CI gate set incl `sync_baseline --check` (no baseline drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)