### PR TITLE
feat(agent-runtime): surface A2A errors to the client (protocol + task layer)

### DIFF
--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/boot/A2aJsonRpcController.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/boot/A2aJsonRpcController.java
@@ -4,8 +4,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Flow;
 import org.a2aproject.sdk.grpc.utils.JSONRPCUtils;
+import org.a2aproject.sdk.jsonrpc.common.json.JsonMappingException;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonProcessingException;
 import org.a2aproject.sdk.jsonrpc.common.json.JsonUtil;
+import org.a2aproject.sdk.jsonrpc.common.json.MethodNotFoundJsonMappingException;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.A2ARequest;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.A2AResponse;
 import org.a2aproject.sdk.jsonrpc.common.wrappers.CancelTaskRequest;
@@ -28,6 +30,7 @@ import org.a2aproject.sdk.jsonrpc.common.wrappers.SubscribeToTaskRequest;
 import org.a2aproject.sdk.server.ServerCallContext;
 import org.a2aproject.sdk.server.requesthandlers.RequestHandler;
 import org.a2aproject.sdk.spec.A2AError;
+import org.a2aproject.sdk.spec.A2AErrorCodes;
 import org.a2aproject.sdk.spec.StreamingEventKind;
 import org.reactivestreams.FlowAdapters;
 import org.slf4j.Logger;
@@ -49,18 +52,31 @@ public class A2aJsonRpcController {
 
     @PostMapping(value = {"/a2a", "/a2a/"}, produces = MediaType.APPLICATION_JSON_VALUE)
     public Object handle(@RequestBody String body) {
+        Object id = null;
         try {
             A2ARequest<?> request = JSONRPCUtils.parseRequestBody(body, null);
-            String method = request.getMethod();
-            Object id = request.getId();
-            log.info("[A2A] {} id={}", method, id);
+            id = request.getId();
+            log.info("[A2A] {} id={}", request.getMethod(), id);
             if (request instanceof SendStreamingMessageRequest || request instanceof SubscribeToTaskRequest) {
                 return handleStream(request);
             }
             return handleBlocking(request);
+        } catch (A2AError e) {
+            // Protocol error raised by the SDK or the request handler — surface it with its own code.
+            return errorResponse(id, ensureCode(e, A2AErrorCodes.INTERNAL));
+        } catch (MethodNotFoundJsonMappingException e) {
+            return errorResponse(e.getId(), error(A2AErrorCodes.METHOD_NOT_FOUND, e.getMessage()));
+        } catch (JsonMappingException e) {
+            // Well-formed JSON whose shape does not match any A2A request.
+            return errorResponse(id, error(A2AErrorCodes.INVALID_REQUEST, e.getMessage()));
+        } catch (JsonProcessingException | com.google.gson.JsonParseException e) {
+            // Body is not parseable JSON (the SDK parses with Gson, whose JsonSyntaxException is unchecked).
+            return errorResponse(id, error(A2AErrorCodes.JSON_PARSE, e.getMessage()));
+        } catch (IllegalArgumentException e) {
+            return errorResponse(id, error(A2AErrorCodes.METHOD_NOT_FOUND, e.getMessage()));
         } catch (Exception e) {
-            log.error("[A2A] error", e);
-            return ResponseEntity.ok("{}");
+            log.error("[A2A] unexpected error id={}", id, e);
+            return errorResponse(id, error(A2AErrorCodes.INTERNAL, e.getMessage()));
         }
     }
 
@@ -108,7 +124,8 @@ public class A2aJsonRpcController {
         try {
             return ResponseEntity.ok(JsonUtil.toJson(response));
         } catch (Exception e) {
-            return ResponseEntity.ok("{}");
+            return errorResponse(request.getId(),
+                    error(A2AErrorCodes.INTERNAL, "failed to serialize A2A response: " + e.getMessage()));
         }
     }
 
@@ -118,6 +135,21 @@ public class A2aJsonRpcController {
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Failed to serialize A2A stream event", e);
         }
+    }
+
+    private static ResponseEntity<String> errorResponse(Object id, A2AError error) {
+        return ResponseEntity.ok(JSONRPCUtils.toJsonRPCErrorResponse(id, error));
+    }
+
+    private static A2AError error(A2AErrorCodes code, String message) {
+        return new A2AError(code.code(), message, null);
+    }
+
+    /** Guarantees a non-null JSON-RPC code so {@code toJsonRPCErrorResponse} never dereferences null. */
+    private static A2AError ensureCode(A2AError error, A2AErrorCodes fallback) {
+        return error.getCode() != null
+                ? error
+                : new A2AError(fallback.code(), error.getMessage(), error.getDetails());
     }
 
     private static ServerCallContext serverContext() { return new ServerCallContext(null, Map.of(), Set.of()); }

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/A2aAgentExecutor.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/A2aAgentExecutor.java
@@ -5,6 +5,7 @@ import com.huawei.ascend.runtime.common.RuntimeIdentity;
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
 import com.huawei.ascend.runtime.engine.spi.AgentExecutionResult;
 import com.huawei.ascend.runtime.engine.spi.AgentRuntimeHandler;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -12,6 +13,7 @@ import java.util.stream.Stream;
 import org.a2aproject.sdk.server.agentexecution.AgentExecutor;
 import org.a2aproject.sdk.server.agentexecution.RequestContext;
 import org.a2aproject.sdk.server.tasks.AgentEmitter;
+import org.a2aproject.sdk.spec.DataPart;
 import org.a2aproject.sdk.spec.Part;
 import org.a2aproject.sdk.spec.TextPart;
 import org.slf4j.Logger;
@@ -20,6 +22,9 @@ import org.slf4j.LoggerFactory;
 public final class A2aAgentExecutor implements AgentExecutor {
 
     private static final Logger LOG = LoggerFactory.getLogger(A2aAgentExecutor.class);
+
+    /** Version of the structured-error payload carried on the failure DataPart/metadata. */
+    private static final String ERROR_SCHEMA_VERSION = "1";
 
     private final AgentRuntimeHandler handler;
 
@@ -32,7 +37,9 @@ public final class A2aAgentExecutor implements AgentExecutor {
         String taskId = ctx.getTaskId();
         if (handler == null) {
             LOG.warn("[A2A] no handler registered taskId={}", taskId);
-            emitter.fail();
+            emitter.reject(failureMessage(emitter, "NO_HANDLER",
+                    "no agent handler registered for this task", false));
+            LOG.info("[A2A] task state=REJECTED taskId={}", taskId);
             return;
         }
         long startedNanos = System.nanoTime();
@@ -67,10 +74,11 @@ public final class A2aAgentExecutor implements AgentExecutor {
                     taskId, (System.nanoTime() - startedNanos) / 1_000_000L);
 
         } catch (Exception e) {
-            LOG.error("[A2A] execute failed taskId={} errorClass={} message={}",
-                    taskId, e.getClass().getSimpleName(), e.getMessage(), e);
+            RuntimeErrorCode code = RuntimeErrorCode.classify(e);
             String detail = e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
-            emitter.fail(failureMessage(emitter, "RUNTIME_ERROR", detail));
+            LOG.error("[A2A] execute failed taskId={} code={} errorClass={} message={}",
+                    taskId, code, e.getClass().getSimpleName(), e.getMessage(), e);
+            emitter.fail(failureMessage(emitter, code.name(), detail, code.retryable()));
             LOG.info("[A2A] task state=FAILED taskId={}", taskId);
         }
     }
@@ -81,9 +89,14 @@ public final class A2aAgentExecutor implements AgentExecutor {
 
     @Override
     public void cancel(RequestContext ctx, AgentEmitter emitter) {
-        LOG.info("[A2A] cancel requested taskId={}", ctx.getTaskId());
-        emitter.cancel();
-        LOG.info("[A2A] task state=CANCELED taskId={}", ctx.getTaskId());
+        String taskId = ctx.getTaskId();
+        LOG.info("[A2A] cancel requested taskId={}", taskId);
+        try {
+            emitter.cancel();
+            LOG.info("[A2A] task state=CANCELED taskId={}", taskId);
+        } catch (Exception e) {
+            LOG.error("[A2A] cancel failed taskId={} message={}", taskId, e.getMessage(), e);
+        }
     }
 
     private void route(AgentExecutionResult result, AgentEmitter emitter, String taskId,
@@ -113,7 +126,8 @@ public final class A2aAgentExecutor implements AgentExecutor {
                 String code = result.errorCode() == null ? "RUNTIME_ERROR" : result.errorCode();
                 String msg = result.errorMessage() == null ? code : result.errorMessage();
                 LOG.warn("[A2A] task state=FAILED taskId={} code={} message={}", taskId, code, msg);
-                emitter.fail(failureMessage(emitter, code, result.errorMessage()));
+                // Adapter-supplied codes pass through unchanged; retryability is unknown → conservative false.
+                emitter.fail(failureMessage(emitter, code, result.errorMessage(), false));
             }
             case INTERRUPTED -> {
                 String prompt = result.prompt() == null ? "" : result.prompt();
@@ -131,12 +145,23 @@ public final class A2aAgentExecutor implements AgentExecutor {
     }
 
     /**
-     * Builds an agent message carrying the failure reason so the A2A client sees
-     * why the task failed instead of a bare FAILED status with no detail.
+     * Builds an agent message carrying the failure both as human-readable text (a {@link TextPart})
+     * and as a machine-readable {@link DataPart} ({@code code}, {@code message}, {@code retryable},
+     * {@code schema_version}) so an A2A client can render the reason AND branch on it
+     * programmatically. The same structure is mirrored on the message metadata for clients that read
+     * {@code status.message.metadata} rather than the message parts.
      */
-    private static Message failureMessage(AgentEmitter emitter, String code, String detail) {
+    private static Message failureMessage(AgentEmitter emitter, String code, String detail, boolean retryable) {
+        String message = (detail == null || detail.isBlank()) ? code : detail;
         String text = (detail == null || detail.isBlank()) ? code : code + ": " + detail;
-        return emitter.newAgentMessage(List.<Part<?>>of(new TextPart(text)), null);
+        Map<String, Object> error = new LinkedHashMap<>();
+        error.put("kind", "error");
+        error.put("code", code);
+        error.put("message", message);
+        error.put("retryable", retryable);
+        error.put("schema_version", ERROR_SCHEMA_VERSION);
+        List<Part<?>> parts = List.of(new TextPart(text), new DataPart(error));
+        return emitter.newAgentMessage(parts, Map.of("a2a.error", error));
     }
 
     private AgentExecutionContext toExecutionContext(RequestContext ctx) {

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/RuntimeErrorCode.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/RuntimeErrorCode.java
@@ -1,0 +1,60 @@
+package com.huawei.ascend.runtime.engine.a2a;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Stable, client-facing classification for an uncaught runtime failure. The A2A client
+ * branches on the {@code name()} (a small closed set) and on {@link #retryable()} rather than
+ * parsing a free-text message. Adapter-supplied error codes are passed through unchanged and are
+ * NOT routed through this enum; this only classifies exceptions that escape to the executor.
+ */
+public enum RuntimeErrorCode {
+
+    /** Caller sent something the agent cannot act on. Not retryable as-is. */
+    INVALID_INPUT(false),
+    /** The work did not finish in time. Retrying may succeed. */
+    TIMEOUT(true),
+    /** A dependency (LLM, tool, downstream service) was unreachable. Retrying may succeed. */
+    UPSTREAM_UNAVAILABLE(true),
+    /** The task was cancelled. Not an error to retry. */
+    CANCELLED(false),
+    /** Anything else — an unexpected internal failure. */
+    INTERNAL(false);
+
+    private final boolean retryable;
+
+    RuntimeErrorCode(boolean retryable) {
+        this.retryable = retryable;
+    }
+
+    public boolean retryable() {
+        return retryable;
+    }
+
+    /**
+     * Walks the cause chain (async failures wrap the real cause, e.g. {@code CompletionException})
+     * and maps the first recognised exception type to a stable code; defaults to {@link #INTERNAL}.
+     */
+    public static RuntimeErrorCode classify(Throwable error) {
+        for (Throwable cause = error; cause != null; cause = cause.getCause()) {
+            if (cause instanceof TimeoutException) {
+                return TIMEOUT;
+            }
+            if (cause instanceof CancellationException) {
+                return CANCELLED;
+            }
+            if (cause instanceof IllegalArgumentException) {
+                return INVALID_INPUT;
+            }
+            if (cause instanceof IOException) {
+                return UPSTREAM_UNAVAILABLE;
+            }
+            if (cause == cause.getCause()) {
+                break;
+            }
+        }
+        return INTERNAL;
+    }
+}

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/boot/A2aJsonRpcControllerTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/boot/A2aJsonRpcControllerTest.java
@@ -2,6 +2,8 @@ package com.huawei.ascend.runtime.boot;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Flow;
@@ -19,6 +21,7 @@ import org.a2aproject.sdk.server.tasks.BasePushNotificationSender;
 import org.a2aproject.sdk.server.tasks.InMemoryPushNotificationConfigStore;
 import org.a2aproject.sdk.server.tasks.PushNotificationSender;
 import org.a2aproject.sdk.spec.A2AError;
+import org.a2aproject.sdk.spec.A2AErrorCodes;
 import org.a2aproject.sdk.spec.CancelTaskParams;
 import org.a2aproject.sdk.spec.DeleteTaskPushNotificationConfigParams;
 import org.a2aproject.sdk.spec.EventKind;
@@ -36,6 +39,7 @@ import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
 import org.a2aproject.sdk.spec.TaskQueryParams;
 import org.a2aproject.sdk.spec.TextPart;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
 import org.springframework.http.codec.ServerSentEvent;
 import reactor.test.StepVerifier;
 
@@ -82,6 +86,39 @@ class A2aJsonRpcControllerTest {
         PushNotificationSender sender = configuration.a2aPushSender(new InMemoryPushNotificationConfigStore());
 
         assertThat(sender).isInstanceOf(BasePushNotificationSender.class);
+    }
+
+    /** A malformed request body must surface a JSON-RPC parse error, never a silent empty {}. */
+    @Test
+    void malformedRequestBodyReturnsJsonRpcParseErrorNotEmptyObject() throws Exception {
+        A2aJsonRpcController controller = new A2aJsonRpcController(new SingleEventRequestHandler());
+
+        Object response = controller.handle("{ this is not valid json ");
+
+        String json = (String) ((ResponseEntity<?>) response).getBody();
+        assertThat(json).isNotEqualTo("{}");
+        JsonObject error = JsonParser.parseString(json).getAsJsonObject().getAsJsonObject("error");
+        assertThat(error).as("response must carry a JSON-RPC error object").isNotNull();
+        assertThat(error.get("code").getAsInt()).isEqualTo(A2AErrorCodes.JSON_PARSE.code());
+        assertThat(error.get("message").getAsString()).isNotBlank();
+    }
+
+    /** An unknown JSON-RPC method must surface METHOD_NOT_FOUND, not a silent empty {}. */
+    @Test
+    void unknownMethodReturnsMethodNotFoundError() throws Exception {
+        A2aJsonRpcController controller = new A2aJsonRpcController(new SingleEventRequestHandler());
+        String body = """
+                {"jsonrpc":"2.0","id":"req-unknown","method":"NoSuchMethod","params":{}}
+                """;
+
+        Object response = controller.handle(body);
+
+        String json = (String) ((ResponseEntity<?>) response).getBody();
+        assertThat(json).isNotEqualTo("{}");
+        JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
+        assertThat(obj.getAsJsonObject("error").get("code").getAsInt())
+                .isEqualTo(A2AErrorCodes.METHOD_NOT_FOUND.code());
+        assertThat(obj.get("id").getAsString()).as("request id must be echoed back").isEqualTo("req-unknown");
     }
 
     private static StreamResponse.PayloadCase sdkParsedPayload(ServerSentEvent<String> event) {

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/a2a/A2aAgentExecutorTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/a2a/A2aAgentExecutorTest.java
@@ -14,9 +14,11 @@ import com.huawei.ascend.runtime.engine.spi.AgentExecutionResult;
 import com.huawei.ascend.runtime.engine.spi.AgentRuntimeHandler;
 import com.huawei.ascend.runtime.engine.spi.StreamAdapter;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.a2aproject.sdk.server.agentexecution.RequestContext;
 import org.a2aproject.sdk.server.tasks.AgentEmitter;
+import org.a2aproject.sdk.spec.DataPart;
 import org.a2aproject.sdk.spec.Message;
 import org.a2aproject.sdk.spec.Part;
 import org.a2aproject.sdk.spec.TextPart;
@@ -51,7 +53,54 @@ class A2aAgentExecutorTest {
         AgentEmitter emitter = newEmitter();
         new A2aAgentExecutor(handler).execute(requestContext(), emitter);
 
-        assertThat(failureText(emitter)).isEqualTo("RUNTIME_ERROR: boom");
+        // An unrecognised exception is classified INTERNAL by RuntimeErrorCode.
+        assertThat(failureText(emitter)).isEqualTo("INTERNAL: boom");
+    }
+
+    /** A thrown exception must reach the client as a machine-readable DataPart, not only free text. */
+    @Test
+    void executionException_carriesStructuredErrorDataPart() {
+        AgentRuntimeHandler handler = mock(AgentRuntimeHandler.class);
+        when(handler.agentId()).thenReturn("agent-x");
+        when(handler.execute(any())).thenThrow(new IllegalArgumentException("missing slot"));
+
+        AgentEmitter emitter = newEmitter();
+        new A2aAgentExecutor(handler).execute(requestContext(), emitter);
+
+        Map<String, Object> data = failureData(emitter);
+        assertThat(data).containsEntry("code", "INVALID_INPUT");
+        assertThat(data).containsEntry("retryable", false);
+        assertThat(data).containsEntry("message", "missing slot");
+    }
+
+    /** A retryable failure (upstream unavailable) must surface retryable=true to the client. */
+    @Test
+    void executionException_marksUpstreamFailureRetryable() {
+        AgentRuntimeHandler handler = mock(AgentRuntimeHandler.class);
+        when(handler.agentId()).thenReturn("agent-x");
+        when(handler.execute(any())).thenThrow(new RuntimeException(new java.io.IOException("conn reset")));
+
+        AgentEmitter emitter = newEmitter();
+        new A2aAgentExecutor(handler).execute(requestContext(), emitter);
+
+        Map<String, Object> data = failureData(emitter);
+        assertThat(data).containsEntry("code", "UPSTREAM_UNAVAILABLE");
+        assertThat(data).containsEntry("retryable", true);
+    }
+
+    /** No registered handler is a rejection, not a runtime failure: reject() with a reason, never a bare fail(). */
+    @Test
+    void noHandler_rejectsTaskWithReason() {
+        AgentEmitter emitter = newEmitter();
+        new A2aAgentExecutor(null).execute(requestContext(), emitter);
+
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(emitter).reject(captor.capture());
+        String text = captor.getValue().parts().stream()
+                .filter(TextPart.class::isInstance)
+                .map(p -> ((TextPart) p).text())
+                .reduce("", String::concat);
+        assertThat(text).contains("NO_HANDLER");
     }
 
     /** The lifecycle must announce SUBMITTED before WORKING, matching the A2A task lifecycle. */
@@ -124,5 +173,17 @@ class A2aAgentExecutorTest {
                 .filter(TextPart.class::isInstance)
                 .map(p -> ((TextPart) p).text())
                 .reduce("", String::concat);
+    }
+
+    /** Capture the structured error DataPart handed to fail(Message). */
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> failureData(AgentEmitter emitter) {
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(emitter).fail(captor.capture());
+        return captor.getValue().parts().stream()
+                .filter(DataPart.class::isInstance)
+                .map(p -> (Map<String, Object>) ((DataPart) p).data())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("fail(Message) carried no structured DataPart"));
     }
 }

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/a2a/RuntimeErrorCodeTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/a2a/RuntimeErrorCodeTest.java
@@ -1,0 +1,49 @@
+package com.huawei.ascend.runtime.engine.a2a;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeoutException;
+import org.junit.jupiter.api.Test;
+
+class RuntimeErrorCodeTest {
+
+    @Test
+    void classifiesTimeoutAsRetryable() {
+        assertThat(RuntimeErrorCode.classify(new TimeoutException("slow"))).isEqualTo(RuntimeErrorCode.TIMEOUT);
+        assertThat(RuntimeErrorCode.TIMEOUT.retryable()).isTrue();
+    }
+
+    @Test
+    void classifiesIllegalArgumentAsNonRetryableInvalidInput() {
+        assertThat(RuntimeErrorCode.classify(new IllegalArgumentException("bad")))
+                .isEqualTo(RuntimeErrorCode.INVALID_INPUT);
+        assertThat(RuntimeErrorCode.INVALID_INPUT.retryable()).isFalse();
+    }
+
+    @Test
+    void classifiesIoFailureAsRetryableUpstreamUnavailable() {
+        assertThat(RuntimeErrorCode.classify(new IOException("conn reset")))
+                .isEqualTo(RuntimeErrorCode.UPSTREAM_UNAVAILABLE);
+        assertThat(RuntimeErrorCode.UPSTREAM_UNAVAILABLE.retryable()).isTrue();
+    }
+
+    @Test
+    void classifiesCancellation() {
+        assertThat(RuntimeErrorCode.classify(new CancellationException())).isEqualTo(RuntimeErrorCode.CANCELLED);
+    }
+
+    /** Async failures wrap the real cause — the classifier must unwrap to find it. */
+    @Test
+    void unwrapsCauseChainToFindTimeout() {
+        assertThat(RuntimeErrorCode.classify(new CompletionException(new TimeoutException())))
+                .isEqualTo(RuntimeErrorCode.TIMEOUT);
+    }
+
+    @Test
+    void defaultsToInternal() {
+        assertThat(RuntimeErrorCode.classify(new RuntimeException("weird"))).isEqualTo(RuntimeErrorCode.INTERNAL);
+    }
+}

--- a/architecture/docs/L1/agent-runtime/process.md
+++ b/architecture/docs/L1/agent-runtime/process.md
@@ -247,20 +247,43 @@ Client                Controller         RequestHandler      A2aAgentExecutor
 
 ### 3.4 错误处理流程
 
+错误分两层，各走各的载体：协议层（请求本身有问题，无 Task）与任务层（执行失败）。
+
+**协议层（`A2aJsonRpcController`）**：请求无法解析 / 未知方法 / 非法参数时，不再静默返回
+`{}`，而是返回标准 JSON-RPC 错误响应 `A2AErrorResponse(id, A2AError)`，错误码取自
+`A2AErrorCodes`：
+
+- 畸形 JSON → `JSON_PARSE` (-32700)
+- 结构不匹配任何 A2A 请求 → `INVALID_REQUEST` (-32600)
+- 未知方法 → `METHOD_NOT_FOUND` (-32601)
+- handler 抛出的 `A2AError` → 原码透传；其余 → `INTERNAL` (-32603)
+
+**任务层（`A2aAgentExecutor`）**：
+
 ```
 AgentRuntimeHandler.execute() 抛出异常:
   → AgentRuntimeProviderChain.closeEntered() 关闭已进入的 providers
   → A2aAgentExecutor 捕获异常:
-      LOG.error("[A2A] execute failed ...")
-      emitter.fail()
+      RuntimeErrorCode.classify(e)        // 走 cause 链 → 稳定码 + retryable
+      LOG.error("[A2A] execute failed ... code=...")
+      emitter.fail(failureMessage(code, detail, retryable))
+  → 失败 Message 同时携带:
+      TextPart  "code: detail"                                  // 人读
+      DataPart  {kind, code, message, retryable, schema_version} // 机器可读
   → Task 状态推进到 FAILED
-  → 客户端收到失败通知
 
-AgentRuntimeProvider.beforeExecute() 抛出异常:
-  → AgentRuntimeProviderChain 关闭已进入的 providers，重新抛出异常
-  → A2aAgentExecutor 捕获 → emitter.fail()
+未注册 handler:
+  → emitter.reject(failureMessage("NO_HANDLER", ...))
+  → Task 状态推进到 REJECTED（前置拒绝，未进入 WORKING）
+
+adapter 产出的 FAILED 结果:
+  → errorCode 原样透传（不经分类器），retryable 保守为 false
 
 AgentRuntimeProvider.afterExecute() 抛出异常:
   → AgentRuntimeProviderChain 捕获并 LOG.warn()，不中断主流程
-  → 其他 providers 的 afterExecute 继续执行
 ```
+
+未捕获异常的稳定错误码集合：`INVALID_INPUT` / `TIMEOUT` / `UPSTREAM_UNAVAILABLE` /
+`CANCELLED` / `INTERNAL`，各带 `retryable` 标志，供 Client 编程式判别——这是 AgentScope
+纯文本任务级错误的超集。更丰富的执行轨迹面（步内 工具/推理/重试 事件）为前瞻设计，见
+`docs/logs/reviews/2026-06-10-a2a-error-flow-and-trajectory-observability.md`。

--- a/docs/logs/reviews/2026-06-10-a2a-error-flow-and-trajectory-observability.md
+++ b/docs/logs/reviews/2026-06-10-a2a-error-flow-and-trajectory-observability.md
@@ -1,0 +1,123 @@
+---
+level: L1
+view: process
+module: agent-runtime
+status: proposal
+authority: "design proposal — to graduate to an ADR when the trajectory seam is implemented"
+---
+
+# A2A 异常流补齐 + 轨迹可观测设计提案
+
+> 状态：proposal（设计提案，gate 排除目录）。本提案的 **Phase 0 急症修复已实现并 TDD 验证**；
+> **双平面轨迹 seam（Plane A/B）为前瞻设计，本次不实现**，待实现时升格为正式 ADR。
+
+## 1. 动机：从"黑盒答案"到"可观测、可进化"
+
+智能体最大的价值是**可进化**，而进化的前提是**可观测**——把尽量丰富的执行轨迹
+（推理、工具调用、LLM 调用、检索、重试、token/时延/成本）暴露给 Client，
+而不仅是最终答案或一句失败原因。
+
+当前 `A2aAgentExecutor` 把引擎产出的事件流**坍缩**为四态
+（`OUTPUT / COMPLETED / FAILED / INTERRUPTED`，见
+`agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/spi/AgentExecutionResult.java`），
+把进化最需要的步内信号丢弃了。异常流只是这条轨迹里的一条**终态车道**。
+
+## 2. 源码证据（结论靠源码，不靠猜）
+
+- **A2A SDK 能力**（`org.a2aproject.sdk:a2a-java-sdk 1.0.0.CR1`，javap 实证）：
+  - `AgentEmitter` 提供 `fail(Message)` / `reject(Message)`（→REJECTED）/ `requiresInput` /
+    `requiresAuth`（→AUTH_REQUIRED）/ `sendMessage(Message)`（非终态）/ `emitEvent` /
+    `newAgentMessage(parts, metadata)`。
+  - **决定性字节码事实**：`AgentEmitter.fail(A2AError)` 只 `enqueueEvent(error)` 并锁
+    `terminalStateReached`，**不构造 `TaskStatusUpdateEvent`、不转 `TASK_STATE_FAILED`**；
+    只有 `fail(Message)` → `updateStatus(TASK_STATE_FAILED, msg)` 才真正流转状态。
+    故**任务层终态失败必须 `fail(Message)`**，`A2AError` 归协议层。
+  - `Message` 带 `metadata` map；`DataPart` 可载结构化 JSON——A2A 原生的机器可读载体。
+  - `TaskState` 自带 `isFinal()` / `isInterrupted()`；协议层有 `A2AErrorResponse(id, A2AError)`
+    + `A2AErrorCodes`（每码带 JSON-RPC code / httpCode / grpcStatus）+
+    `JSONRPCUtils.toJsonRPCErrorResponse(id, error)`。
+- **AgentScope-Java 对齐实情**：
+  - 任务级错误是**纯文本**（`"Handle Agent execute error: " + t.getMessage()`，
+    `AgentScopeAgentExecutor.java`），**无结构化错误码**；流式 `doOnError`→`taskUpdater.fail(msg)`→FAILED。
+  - 其 A2A server `AgentExecuteProperties{completeWithMessage, requireInnerMessage}`——
+    `requireInnerMessage=true` 时把 `EventType.TOOL_RESULT / HINT` 等**内部轨迹**也流给 client。
+  - 轨迹建模为 `Event{sequence_number, object, status, error}`
+    （`agentscope-runtime-java/.../engine/schemas/Event.java`），状态
+    `CREATED→IN_PROGRESS→COMPLETED/FAILED/REJECTED/CANCELED`。
+  - 可观测面用 **OpenTelemetry GenAI 语义约定**（`gen_ai.*`，`AgentScopeIncubatingAttributes`）。
+- **LangGraph4j**：**无 A2A 面**；价值在图执行层——节点异常→`GraphRunnerException`→`Data.error()`；
+  **中断是状态 `Data.done(InterruptionMetadata)` 不是异常**（我们 `INTERRUPTED→requiresInput()` 已对齐）。
+
+> 诚实结论：结构化机器可读错误/轨迹 **超越** AgentScope（其任务级为纯文本）——是业界更优实践
+> （对齐 OTel GenAI + AgentScope 的事件流形状），不是"对齐底线"。
+
+## 3. 设计：轨迹 = 带类型的事件流，双平面暴露
+
+### Plane A — 带内轨迹（in-band，给"调用方 Agent / Client"实时看）
+
+引擎产出的每个轨迹事件 → 映射到 A2A 的**非终态**载体 `sendMessage(Message)`（保持 WORKING）：
+
+- `Message` = `DataPart{ kind, object, seq, name, args/result, gen_ai.usage.*, latency, attempt, error? }`
+  （机器可读）+ `TextPart{人读摘要}` + `Message.metadata{ trace.kind, gen_ai.*, traceId, spanId }`。
+- 终态答案 → artifact + `complete(Message)`。
+- **终态失败** → `fail(Message{DataPart 结构化错误})`（字节码证据：唯一能转 FAILED 的路径）。
+- **步内可恢复错误/重试** → 非终态轨迹事件（`status=FAILED` 但非 terminal，带 `attempt`、`retryable`）——
+  失败但被救回的工具调用全程可见，是评测/进化最值钱的数据。
+- **详细度开关** `trajectory level` ∈ {OFF, SUMMARY, FULL}（对齐 AgentScope `requireInnerMessage`/
+  `completeWithMessage`），经请求 metadata 传入，默认 SUMMARY + 敏感参数脱敏。
+- **关联与可演化**：每事件带 `sequence_number` + `taskId/contextId` + `traceId/spanId` +
+  `schema_version`（轨迹契约自身的进化钩子，老消费者不被破坏）。
+
+### Plane B — 带外 OTel GenAI span（out-of-band，给运维/评测/进化流水线）
+
+- 用 OpenTelemetry GenAI 约定（`gen_ai.system / request.model / usage.input_tokens / operation.name`、
+  工具 span）发全保真 trace——进化数据湖的规范来源，AgentScope 已这么做。
+- **两平面用同一 `traceId/spanId` + `gen_ai.*` 键**：Client 能把带内事件缝合到带外 trace，
+  评测/RLAIF/微调流水线零翻译直接吃。
+
+### 轨迹事件 schema（草案，对齐 AgentScope `Event`）
+
+```
+{ "kind": "error|tool_call|tool_result|reasoning|llm_call|progress",
+  "object": "<细分类型>",
+  "seq": <int>, "schema_version": "1",
+  "code": "<stable code | adapter code>", "retryable": <bool>,   // 仅 error
+  "name": "...", "result": {...},                                 // 工具/llm
+  "gen_ai": { "usage": {...}, "request.model": "..." },           // OTel 对齐
+  "trace": { "traceId": "...", "spanId": "..." } }
+```
+
+## 4. 异常流三车道（归位）
+
+| 车道 | 载体 | 状态 | Phase 0 状态 |
+|---|---|---|---|
+| 协议级错误（解析/未知方法/校验） | `A2AErrorResponse(id, A2AError)` 替代 `{}` | 无 task，JSON-RPC error | **已实现** |
+| 终态失败 | `fail(Message{ TextPart + DataPart })` | `TASK_STATE_FAILED` | **已实现** |
+| 无 handler | `reject(Message)` | `TASK_STATE_REJECTED` | **已实现** |
+| 步内可恢复错误/重试 | `sendMessage(Message{DataPart, retryable})` | 非终态，仍 WORKING | 前瞻（Plane A） |
+
+## 5. 约束对账（诚实）
+
+- **不做业务投影**：轨迹是 A2A 原生 `metadata/DataPart` 上的**附加遥测，只发不回读**；
+  运行时仍是唯一真相源，A2A 只承载 best-effort 可观测 trace。这是它不沦为投影层的红线。
+- **最大化 OSS 复用**：复用 AgentScope `Event{object,seq,status,error}` 形状 + OTel GenAI 约定 +
+  A2A 原生 `DataPart/metadata/sendMessage`，零自造 schema、零 SPI 镜像。
+- **最小爆破面（Rule D-2）**：Plane A 落地时仅需拓宽 `AgentExecutionResult`（加 `TRAJECTORY` 变体承载
+  原始类型化事件）+ `A2aAgentExecutor.route()` 加一个分支 + 适配器停止坍缩上游事件；executor 改动很小。
+
+## 6. Phase 0 已实现（本次落地，TDD 验证）
+
+- 协议层 `A2aJsonRpcController`：`handle()`/`handleBlocking()` 把异常映射成 `A2AError` 子码
+  （JSON_PARSE / INVALID_REQUEST / METHOD_NOT_FOUND / INTERNAL）→ `A2AErrorResponse`，**不再返回 `{}`**。
+- 任务层 `A2aAgentExecutor`：失败 `Message` 带 `TextPart`（`code: detail`）+ `DataPart`
+  `{kind,code,message,retryable,schema_version}` + `Message.metadata`；新增 `RuntimeErrorCode`
+  薄分类器（INVALID_INPUT/TIMEOUT/UPSTREAM_UNAVAILABLE/CANCELLED/INTERNAL + retryable，
+  走 cause 链，仅分类未捕获异常，adapter 码透传）；`handler==null → reject(Message)`；`cancel()` 加守护。
+- 测试：`A2aJsonRpcControllerTest`（+2）、`A2aAgentExecutorTest`（+3，更新 1）、`RuntimeErrorCodeTest`（6）。
+
+## 7. 后续 wave（前瞻，未实现）
+
+1. 拓宽 `AgentExecutionResult` 加 `TRAJECTORY` 变体 + `A2aAgentExecutor.route()` 分支（Plane A，SUMMARY 级）。
+2. 适配器（`AgentScopeStreamAdapter` / `OpenJiuwenStreamAdapter`）停止坍缩，透传 tool_call/tool_result/error-recovered。
+3. Plane B OTel GenAI span + 一致 key + 详细度级别 + 脱敏。
+4. 升格为正式 ADR（架构记录 + baseline/契约 lockstep）。

--- a/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesAgentConfiguration.java
+++ b/examples/agent-runtime-a2a-return-modes-e2e/src/main/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesAgentConfiguration.java
@@ -45,6 +45,11 @@ public class ReturnModesAgentConfiguration {
                     ? ""
                     : OpenJiuwenMessageAdapter.messageText(context.getMessages().getLast());
             String normalized = input.trim().toLowerCase(Locale.ROOT);
+            if (normalized.contains("fail")) {
+                // Mirror the common case: the agent simply throws. The runtime must translate this
+                // into a FAILED task carrying a structured, machine-readable error for the client.
+                throw new IllegalArgumentException("deliberate failure for return-mode verification");
+            }
             if (normalized.contains("stream")) {
                 return Stream.of(
                         AgentExecutionResult.output("stream-part-1 "),

--- a/examples/agent-runtime-a2a-return-modes-e2e/src/test/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesA2aE2eTest.java
+++ b/examples/agent-runtime-a2a-return-modes-e2e/src/test/java/com/huawei/ascend/examples/a2a/returnmodes/ReturnModesA2aE2eTest.java
@@ -7,6 +7,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.DataPart;
 import org.a2aproject.sdk.spec.EventKind;
 import org.a2aproject.sdk.spec.ListTaskPushNotificationConfigsResult;
 import org.a2aproject.sdk.spec.StreamingEventKind;
@@ -80,6 +81,31 @@ class ReturnModesA2aE2eTest {
         assertThat(inbox.awaitPayload(payload -> payload.contains("stream-part-1"), TIMEOUT.toSeconds(), TimeUnit.SECONDS))
                 .isTrue();
         assertThat(inbox.payloads()).anySatisfy(payload -> assertThat(payload).contains("stream-part-1"));
+    }
+
+    /** A turn whose agent throws must return a FAILED task carrying a structured, client-readable error. */
+    @Test
+    void failingTurnReturnsFailedTaskWithStructuredError() throws Exception {
+        ReturnModesA2aClient client = new ReturnModesA2aClient(baseUri(), TIMEOUT);
+
+        EventKind result = client.sendMessage("fail");
+
+        assertThat(result).isInstanceOf(Task.class);
+        Task task = (Task) result;
+        assertThat(task.status().state()).isEqualTo(TaskState.TASK_STATE_FAILED);
+        // Human-readable reason reaches the client...
+        assertThat(ReturnModesA2aClient.textFrom(result)).contains("INVALID_INPUT");
+        // ...and a machine-readable structured error (code + retryable) survives the A2A round-trip.
+        String structured = String.valueOf(structuredErrorData(task));
+        assertThat(structured).contains("INVALID_INPUT").contains("retryable");
+    }
+
+    private static Object structuredErrorData(Task task) {
+        return task.status().message().parts().stream()
+                .filter(DataPart.class::isInstance)
+                .map(part -> ((DataPart) part).data())
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("FAILED task carried no structured error DataPart"));
     }
 
     private URI baseUri() {


### PR DESCRIPTION
## Summary
- **Protocol layer** (`A2aJsonRpcController`): malformed body / unknown method / invalid params / internal faults now return a JSON-RPC `A2AErrorResponse` (with the matching `A2AErrorCodes`) instead of a silent HTTP 200 `{}` — the previous behaviour left the caller unable to see any error at all.
- **Task layer** (`A2aAgentExecutor`): `fail(message)` now carries a structured `DataPart` `{code, message, retryable, schema_version}` alongside the human-readable `TextPart` (and mirrors it on message metadata), so an A2A client can both render and programmatically branch on a failure. No registered handler → `reject` (`REJECTED`); `cancel()` is guarded.
- **`RuntimeErrorCode`**: a thin, stable classifier (`INVALID_INPUT` / `TIMEOUT` / `UPSTREAM_UNAVAILABLE` / `CANCELLED` / `INTERNAL` + `retryable`, walking the cause chain) for uncaught exceptions; adapter-supplied codes pass through unchanged.
- Grounded in source, not guesswork (a2a-java-sdk bytecode, AgentScope-Java, LangGraph4j): `AgentEmitter.fail(A2AError)` does **not** transition the task to `FAILED`, so the task layer must use `fail(message)`; AgentScope's task-level error is free text, so the structured `DataPart` is a deliberate superset. The dual-plane (in-band A2A + OTel GenAI) trajectory-observability design is captured as a `docs/logs/reviews/` proposal (the seam itself is deferred).

## Test Plan
- [x] `agent-runtime` unit/integration suite green (67 tests): controller (+2 protocol-error cases), executor (+3), `RuntimeErrorCode` (6).
- [x] `return-modes` e2e green (2 tests): new failure round-trip asserts a `FAILED` task whose structured error (`code` + `retryable`) survives a real A2A client JSON-RPC + SDK round-trip.
- [x] Architecture sync gate `gate/check_architecture_sync.sh` green (real-repo checks all PASS + self-test 226/226).
- [x] L1 `process.md` error-flow updated in lockstep with the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
