### PR TITLE
[codex] Fix runtime example docs and E2E clean test

### DIFF
--- a/agent-runtime/README.md
+++ b/agent-runtime/README.md
@@ -159,8 +159,12 @@ Important Java extension points and related types include:
 
 The example application shows the intended consumer shape from outside the module:
 
-- app boot class: `com.huawei.ascend.examples.a2a.OpenJiuwenA2aAgentRuntimeApplication`
+- app boot class: `com.huawei.ascend.examples.a2a.A2aAgentRuntimeApplication`
 - console client: `com.huawei.ascend.examples.a2a.A2aConsoleClientApplication`
+
+The dedicated OpenJiuwen A2A E2E example lives separately at
+`examples/agent-runtime-a2a-openjiuwen-e2e` and uses
+`com.huawei.ascend.examples.a2a.OpenJiuwenA2aAgentRuntimeApplication`.
 
 For OpenJiuwen memory integration, prefer OpenJiuwen's native memory hooks when the concrete agent supports them. The runtime keeps only the narrow `MemoryProvider` SPI; the adapter that maps it to OpenJiuwen external memory semantics lives under `runtime.engine.openjiuwen`, so future OpenJiuwen memory module splits do not leak into the public runtime SPI.
 
@@ -203,7 +207,7 @@ Then run the example-module test:
 
 ```bash
 export SAA_SAMPLE_LLM_API_KEY=sk-x00550472
-./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml test
+./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml clean test -DskipTests=false
 ```
 
 If needed, also override the local gateway settings:

--- a/architecture/docs/L2/agent-runtime/A2A_EXTERNAL_CALLING_MODES.md
+++ b/architecture/docs/L2/agent-runtime/A2A_EXTERNAL_CALLING_MODES.md
@@ -904,16 +904,16 @@ Accept: application/json
 | `A2aJsonRpcControllerTest#blockingHandlerDispatchesPushNotificationConfigRequests` | push config 的 create/get/list/delete 请求进入 SDK handler。 |
 | `A2aJsonRpcControllerTest#defaultPushNotificationSenderUsesA2aSdkBaseSender` | 默认 push sender 是 A2A SDK `BasePushNotificationSender`。 |
 
-示例客户端验证位于 `examples/agent-runtime-a2a-llm-e2e`，需要该示例模块依赖可解析后单独运行：
+AgentScope/LangGraph 示例客户端验证位于 `examples/agent-runtime-a2a-llm-e2e`，需要该示例模块依赖可解析后单独运行：
 
 ```bash
 ./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml -Dtest=SampleA2aClientTest test
 ```
 
-示例端到端验证需要真实 LLM key 环境变量：
+OpenJiuwen 端到端验证位于独立示例模块 `examples/agent-runtime-a2a-openjiuwen-e2e`，需要真实 LLM key 环境变量：
 
 ```bash
-SAA_SAMPLE_LLM_API_KEY=... ./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml -Dtest=OpenJiuwenReactAgentA2aE2eTest test
+SAA_SAMPLE_LLM_API_KEY=... ./mvnw -f examples/agent-runtime-a2a-openjiuwen-e2e/pom.xml -Dtest=OpenJiuwenReactAgentA2aE2eTest test
 ```
 
 示例验证覆盖点：
@@ -921,4 +921,4 @@ SAA_SAMPLE_LLM_API_KEY=... ./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml 
 | 测试 | 覆盖 |
 |---|---|
 | `SampleA2aClientTest` | 示例客户端从 message/status/artifact 三类 streaming event 提取文本，并正确识别 terminal。 |
-| `OpenJiuwenReactAgentA2aE2eTest` | 端到端读取 Agent Card，通过 A2A streaming 调用本地 OpenJiuwen runtime。该测试需要真实 LLM key 环境变量。 |
+| `OpenJiuwenReactAgentA2aE2eTest` | 在 `agent-runtime-a2a-openjiuwen-e2e` 中端到端读取 Agent Card，通过 A2A streaming 调用本地 OpenJiuwen runtime。该测试需要真实 LLM key 环境变量。 |

--- a/examples/agent-runtime-a2a-llm-e2e/README.md
+++ b/examples/agent-runtime-a2a-llm-e2e/README.md
@@ -233,7 +233,7 @@ If you have already exported the required variables and want to run Maven direct
 (the module pom defaults `skipTests=true`, so the override is required):
 
 ```bash
-./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml test -DskipTests=false
+./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml clean test -DskipTests=false
 ```
 
 ## LangGraph remote-runtime sample (not shipped)

--- a/examples/agent-runtime-a2a-llm-e2e/scripts/test-e2e.sh
+++ b/examples/agent-runtime-a2a-llm-e2e/scripts/test-e2e.sh
@@ -13,10 +13,10 @@ if [[ -f "$ENV_FILE" ]]; then
   set -a; . "$ENV_FILE"; set +a
   echo "loaded env: $ENV_FILE  (apiBase=${SAA_SAMPLE_AGENTSCOPE_API_BASE:-} model=${SAA_SAMPLE_LLM_MODEL:-})"
 else
-  echo "env file not found: $ENV_FILE — using process env / application.yaml defaults"
+  echo "env file not found: $ENV_FILE - using process env / application.yaml defaults"
 fi
 if [[ -z "${SAA_SAMPLE_LLM_API_KEY:-}" ]]; then
-  echo "WARNING: SAA_SAMPLE_LLM_API_KEY is blank — the real-LLM e2e branch will be SKIPPED (assumeTrue)."
+  echo "WARNING: SAA_SAMPLE_LLM_API_KEY is blank - the real-LLM e2e branch will be SKIPPED (assumeTrue)."
 fi
 cd "$REPO"
 ./mvnw -pl agent-runtime -am install -DskipTests -Dmaven.test.skip=true
@@ -24,8 +24,8 @@ cd "$REPO"
 # purpose is to run the suite, so the override is mandatory here.
 LOG_FILE="$(mktemp)"
 trap 'rm -f "$LOG_FILE"' EXIT
-./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml test -DskipTests=false | tee "$LOG_FILE"
+./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml clean test -DskipTests=false | tee "$LOG_FILE"
 if grep -q "Tests are skipped." "$LOG_FILE"; then
-  echo "ERROR: surefire skipped the tests — the E2E suite did not run." >&2
+  echo "ERROR: surefire skipped the tests - the E2E suite did not run." >&2
   exit 1
 fi


### PR DESCRIPTION
﻿## Summary

- update agent-runtime README to point the generic A2A LLM example at `A2aAgentRuntimeApplication`
- clarify that OpenJiuwen A2A E2E now lives in `examples/agent-runtime-a2a-openjiuwen-e2e`
- make the `agent-runtime-a2a-llm-e2e` helper and README use `clean test -DskipTests=false` to avoid stale target test classes

## Root Cause

#208 split/cleaned the example modules, but the runtime docs still referenced the old OpenJiuwen test surface. The E2E helper also ran `test` without `clean`, which can pick up deleted test classes after large sample migrations.

## Validation

- `./mvnw -f examples/agent-runtime-a2a-llm-e2e/pom.xml clean test -DskipTests=false`
- `git diff --check`

Fixes #222
Fixes #223
