### PR TITLE
fix(runtime): inject OpenJiuwen memory into ReAct prompt

### DIFF
--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenAgentRuntimeHandler.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenAgentRuntimeHandler.java
@@ -14,6 +14,7 @@ import com.openjiuwen.core.foundation.llm.schema.BaseMessage;
 import com.openjiuwen.core.foundation.llm.schema.SystemMessage;
 import com.openjiuwen.core.runner.Runner;
 import com.openjiuwen.core.singleagent.BaseAgent;
+import com.openjiuwen.core.singleagent.agents.ReActAgent;
 import com.openjiuwen.core.singleagent.rail.AgentCallbackContext;
 import com.openjiuwen.core.singleagent.rail.AgentRail;
 import com.openjiuwen.harness.rails.ExternalMemoryRail;
@@ -263,6 +264,8 @@ public abstract class OpenJiuwenAgentRuntimeHandler extends AbstractAgentRuntime
      */
     public static final class MemoryRuntimeRail extends AgentRail {
         private static final int DEFAULT_MEMORY_SEARCH_LIMIT = 5;
+        private static final String MEMORY_SECTION_NAME = "runtime_long_term_memory";
+        private static final int MEMORY_SECTION_PRIORITY = 50;
 
         private final AgentExecutionContext executionContext;
         private final MemoryProvider memoryProvider;
@@ -338,18 +341,23 @@ public abstract class OpenJiuwenAgentRuntimeHandler extends AbstractAgentRuntime
         private void injectMemory(AgentCallbackContext callbackContext) {
             String query = latestUserInput();
             if (query.isBlank()) {
+                clearPromptBuilderMemory(callbackContext);
                 return;
             }
             List<MemoryProvider.MemoryHit> hits =
                     memoryProvider.search(executionContext, query, DEFAULT_MEMORY_SEARCH_LIMIT);
             if (hits.isEmpty()) {
+                clearPromptBuilderMemory(callbackContext);
+                return;
+            }
+            String memoryBlock = runtimeMemoryBlock(formatMemoryBlock(hits));
+            if (mergeMemoryIntoPromptBuilder(callbackContext, memoryBlock)) {
                 return;
             }
             ModelContext modelContext = callbackContext == null ? null : callbackContext.getContext();
-            if (modelContext == null) {
-                return;
+            if (modelContext != null) {
+                mergeMemoryIntoSystemMessage(modelContext, memoryBlock);
             }
-            mergeMemoryIntoSystemMessage(modelContext, runtimeMemoryBlock(formatMemoryBlock(hits)));
         }
 
         private MemoryProvider.MemoryRecord toLongTermMemoryRecord(BaseMessage message) {
@@ -388,6 +396,28 @@ public abstract class OpenJiuwenAgentRuntimeHandler extends AbstractAgentRuntime
             }
             updatedMessages.add(0, new SystemMessage(memoryBlock));
             modelContext.setMessages(updatedMessages, true);
+        }
+
+        private static boolean mergeMemoryIntoPromptBuilder(AgentCallbackContext callbackContext, String memoryBlock) {
+            ReActAgent reactAgent = reactAgent(callbackContext);
+            if (reactAgent == null) {
+                return false;
+            }
+            reactAgent.addPromptBuilderSection(MEMORY_SECTION_NAME, memoryBlock, MEMORY_SECTION_PRIORITY);
+            return true;
+        }
+
+        private static void clearPromptBuilderMemory(AgentCallbackContext callbackContext) {
+            ReActAgent reactAgent = reactAgent(callbackContext);
+            if (reactAgent != null) {
+                // OpenJiuwen treats blank section content as removeSection(name).
+                reactAgent.addPromptBuilderSection(MEMORY_SECTION_NAME, "", MEMORY_SECTION_PRIORITY);
+            }
+        }
+
+        private static ReActAgent reactAgent(AgentCallbackContext callbackContext) {
+            Object agent = callbackContext == null ? null : callbackContext.getAgent();
+            return agent instanceof ReActAgent reactAgent ? reactAgent : null;
         }
 
         private static String runtimeMemoryBlock(String memoryBlock) {

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenAgentRuntimeHandlerTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenAgentRuntimeHandlerTest.java
@@ -26,6 +26,7 @@ import com.openjiuwen.core.foundation.tool.schema.ToolInfo;
 import com.openjiuwen.core.session.Session;
 import com.openjiuwen.core.session.stream.StreamMode;
 import com.openjiuwen.core.singleagent.BaseAgent;
+import com.openjiuwen.core.singleagent.ReActAgent;
 import com.openjiuwen.core.singleagent.rail.AgentCallbackContext;
 import com.openjiuwen.core.singleagent.rail.AgentRail;
 import com.openjiuwen.core.singleagent.rail.ModelCallInputs;
@@ -146,6 +147,46 @@ class OpenJiuwenAgentRuntimeHandlerTest {
                 .satisfies(message -> assertThat(message.getContentAsString())
                         .contains("existing system prompt")
                         .contains("remembered ping"));
+    }
+
+    @Test
+    void memoryRuntimeRailInjectsSearchResultsIntoRealReActPromptBuilder() {
+        AgentExecutionContext context = context(Map.of());
+        FakeMemoryProvider memoryProvider = new FakeMemoryProvider();
+        OpenJiuwenAgentRuntimeHandler.MemoryRuntimeRail rail =
+                new OpenJiuwenAgentRuntimeHandler.MemoryRuntimeRail(
+                        context, memoryProvider, new OpenJiuwenMemoryMessageAdapter());
+        ReActAgent reactAgent = new ReActAgent(
+                AgentCard.builder().id("agent").name("agent").description("test").build());
+        RecordingModelContext modelContext = new RecordingModelContext();
+
+        rail.beforeInvoke(AgentCallbackContext.builder()
+                .agent(reactAgent)
+                .context(modelContext)
+                .build());
+
+        assertThat(reactAgent.getPromptBuilder().build())
+                .contains("remembered ping")
+                .contains("recalled memory context from runtime memory");
+        assertThat(modelContext.messages).isEmpty();
+    }
+
+    @Test
+    void memoryRuntimeRailClearsRealReActPromptBuilderWhenNoMemoryHits() {
+        AgentExecutionContext context = context(Map.of());
+        FakeMemoryProvider memoryProvider = new FakeMemoryProvider();
+        OpenJiuwenAgentRuntimeHandler.MemoryRuntimeRail rail =
+                new OpenJiuwenAgentRuntimeHandler.MemoryRuntimeRail(
+                        context, memoryProvider, new OpenJiuwenMemoryMessageAdapter());
+        ReActAgent reactAgent = new ReActAgent(
+                AgentCard.builder().id("agent").name("agent").description("test").build());
+        AgentCallbackContext callbackContext = AgentCallbackContext.builder().agent(reactAgent).build();
+
+        rail.beforeInvoke(callbackContext);
+        memoryProvider.returnHits = false;
+        rail.beforeInvoke(callbackContext);
+
+        assertThat(reactAgent.getPromptBuilder().build()).doesNotContain("remembered ping");
     }
 
     @Test
@@ -430,6 +471,7 @@ class OpenJiuwenAgentRuntimeHandlerTest {
         private String searchedQuery;
         private List<MemoryRecord> savedRecords = List.of();
         private Double score = 0.9;
+        private boolean returnHits = true;
 
         @Override
         public void init(AgentExecutionContext context) {
@@ -439,6 +481,9 @@ class OpenJiuwenAgentRuntimeHandlerTest {
         @Override
         public List<MemoryHit> search(AgentExecutionContext context, String query, int limit) {
             searchedQuery = query;
+            if (!returnHits) {
+                return List.of();
+            }
             return List.of(new MemoryHit("m1", "remembered " + query, score, Map.of()));
         }
 

--- a/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MiddlewareTestFixtures.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MiddlewareTestFixtures.java
@@ -1,11 +1,9 @@
 package com.huawei.ascend.examples.runtime.middleware.memory.inmemory;
 
 import com.huawei.ascend.runtime.common.RuntimeIdentity;
+import com.huawei.ascend.runtime.common.RuntimeMessage;
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
-import java.util.List;
 import java.util.Map;
-import org.a2aproject.sdk.spec.Message;
-import org.a2aproject.sdk.spec.TextPart;
 
 final class MiddlewareTestFixtures {
     private MiddlewareTestFixtures() {
@@ -14,10 +12,7 @@ final class MiddlewareTestFixtures {
     static AgentExecutionContext context(String stateKey) {
         RuntimeIdentity identity =
                 new RuntimeIdentity("tenant", "user", "session", "task", "openjiuwen-simple-agent");
-        Message message = Message.builder()
-                .role(Message.Role.ROLE_USER)
-                .parts(List.of(new TextPart("green tea")))
-                .build();
-        return new AgentExecutionContext(identity, "USER_MESSAGE", List.of(message), Map.of(), stateKey, null);
+        return new AgentExecutionContext(identity, "USER_MESSAGE",
+                java.util.List.of(RuntimeMessage.user("green tea")), Map.of(), stateKey, null);
     }
 }

--- a/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MiddlewareTestFixtures.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MiddlewareTestFixtures.java
@@ -1,11 +1,9 @@
 package com.huawei.ascend.examples.runtime.middleware.memory.mem0;
 
 import com.huawei.ascend.runtime.common.RuntimeIdentity;
+import com.huawei.ascend.runtime.common.RuntimeMessage;
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
-import java.util.List;
 import java.util.Map;
-import org.a2aproject.sdk.spec.Message;
-import org.a2aproject.sdk.spec.TextPart;
 
 final class MiddlewareTestFixtures {
     private MiddlewareTestFixtures() {
@@ -14,10 +12,7 @@ final class MiddlewareTestFixtures {
     static AgentExecutionContext context(String stateKey) {
         RuntimeIdentity identity =
                 new RuntimeIdentity("tenant", "user", "session", "task", "openjiuwen-simple-agent");
-        Message message = Message.builder()
-                .role(Message.Role.ROLE_USER)
-                .parts(List.of(new TextPart("green tea")))
-                .build();
-        return new AgentExecutionContext(identity, "USER_MESSAGE", List.of(message), Map.of(), stateKey, null);
+        return new AgentExecutionContext(identity, "USER_MESSAGE",
+                java.util.List.of(RuntimeMessage.user("green tea")), Map.of(), stateKey, null);
     }
 }


### PR DESCRIPTION
﻿## Why

Fixes #247.

`MemoryRuntimeRail` previously merged recalled memory into `ModelContext` system messages. That does not reliably affect a real OpenJiuwen `ReActAgent`, because the ReAct prompt is rebuilt from OpenJiuwen's prompt builder and prompt template before the model call. As a result, tests using `RecordingModelContext` could pass while the actual ReAct prompt never received the runtime memory block.

## What Changed

- Route runtime long-term memory into a real OpenJiuwen `ReActAgent` via `ReActAgent.addPromptBuilderSection(...)` when the callback agent is a ReAct agent.
- Keep the `ModelContext` merge path as a fallback for non-ReAct agents and test doubles.
- Clear the named memory prompt-builder section when the query is blank or no memory hits are found, so a reused agent instance does not retain stale memory.
- Align the memory middleware example fixtures with the current runtime-neutral `RuntimeMessage` execution context shape.

No OpenJiuwen agent-core-java source changes are required.

## Memory Prompt Shape

The runtime now inserts memory as an OpenJiuwen prompt-builder section named `runtime_long_term_memory` with priority `50`.

The section content is:

```text
[System note: recalled memory context from runtime memory, not new user input.]

Relevant memory:
- <memory hit content>
```

So the real ReAct prompt seen by OpenJiuwen is shaped like:

```text
<existing ReActAgent prompt sections from promptTemplate / identity / tools / skills>

[System note: recalled memory context from runtime memory, not new user input.]

Relevant memory:
- remembered ping
```

The OpenJiuwen input map stays focused on the current user turn:

```json
{
  "query": "<latest RuntimeMessage user text>",
  "conversation_id": "<agentStateKey>"
}
```

The memory block is not appended to `query`; it is provided through the ReAct prompt builder so it participates in the real prompt construction path.

## Verification

- `./mvnw -pl agent-runtime -Dtest=OpenJiuwenAgentRuntimeHandlerTest test`
  - Passed: 18 tests.
- `./mvnw -f examples/agent-runtime-middleware-memory-inmemory/pom.xml test`
  - Passed: 1 test.
- `./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml test`
  - Passed with 1 skipped because `SAA_SAMPLE_MEM0_BASE_URL` was not configured.
- `./mvnw -pl agent-runtime -DskipTests install; ./mvnw -f examples/agent-runtime-a2a-openjiuwen-e2e/pom.xml test`
  - Passed: 7 tests, 1 skipped.
