### PR TITLE
End northbound `SendStreamingMessage` SSE responses when a task reaches `TASK_STATE_INPUT_REQUIRED`.

### DIFF
--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/boot/A2aJsonRpcController.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/boot/A2aJsonRpcController.java
@@ -35,6 +35,8 @@ import org.a2aproject.sdk.server.requesthandlers.RequestHandler;
 import org.a2aproject.sdk.spec.A2AError;
 import org.a2aproject.sdk.spec.A2AErrorCodes;
 import org.a2aproject.sdk.spec.StreamingEventKind;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.reactivestreams.FlowAdapters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -122,7 +124,11 @@ public class A2aJsonRpcController {
         } else {
             throw error(A2AErrorCodes.METHOD_NOT_FOUND, "Unknown streaming request: " + request.getMethod());
         }
-        return Flux.from(FlowAdapters.toPublisher(publisher))
+        Flux<StreamingEventKind> events = Flux.from(FlowAdapters.toPublisher(publisher));
+        if (request instanceof SendStreamingMessageRequest) {
+            events = events.takeUntil(A2aJsonRpcController::isInputRequired);
+        }
+        return events
                 .map(evt -> ServerSentEvent.<String>builder().event("jsonrpc")
                         .data(streamingResponseJson(id, evt)).build())
                 // A mid-stream failure must end with a JSON-RPC error frame, not a bare
@@ -174,6 +180,12 @@ public class A2aJsonRpcController {
         } catch (JsonProcessingException e) {
             throw new IllegalStateException("Failed to serialize A2A stream event", e);
         }
+    }
+
+    private static boolean isInputRequired(StreamingEventKind event) {
+        return event instanceof TaskStatusUpdateEvent statusUpdate
+                && statusUpdate.status() != null
+                && statusUpdate.status().state() == TaskState.TASK_STATE_INPUT_REQUIRED;
     }
 
     private static ResponseEntity<String> errorResponse(Object id, A2AError error) {

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/boot/A2aJsonRpcControllerTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/boot/A2aJsonRpcControllerTest.java
@@ -44,6 +44,9 @@ import org.a2aproject.sdk.spec.Task;
 import org.a2aproject.sdk.spec.TaskIdParams;
 import org.a2aproject.sdk.spec.TaskPushNotificationConfig;
 import org.a2aproject.sdk.spec.TaskQueryParams;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatus;
+import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
 import org.a2aproject.sdk.spec.TextPart;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
@@ -215,6 +218,35 @@ class A2aJsonRpcControllerTest {
     }
 
     @Test
+    void sendStreamingMessageCompletesCurrentResponseOnInputRequired() throws Exception {
+        A2aJsonRpcController controller =
+                new A2aJsonRpcController(new InputRequiredThenCompletedRequestHandler(), new RuntimeAccessProperties());
+        A2ARequest<?> request = JSONRPCUtils.parseRequestBody("""
+                {"jsonrpc":"2.0","id":"stream-input","method":"SendStreamingMessage","params":{"message":{"role":"ROLE_USER","parts":[{"text":"ping"}],"messageId":"message-1"}}}
+                """, null);
+
+        StepVerifier.create(controller.handleStream(request, null))
+                .assertNext(event -> assertThat(statusState(event)).isEqualTo("TASK_STATE_WORKING"))
+                .assertNext(event -> assertThat(statusState(event)).isEqualTo("TASK_STATE_INPUT_REQUIRED"))
+                .verifyComplete();
+    }
+
+    @Test
+    void subscribeToTaskKeepsStreamingAfterInputRequired() throws Exception {
+        A2aJsonRpcController controller =
+                new A2aJsonRpcController(new InputRequiredThenCompletedRequestHandler(), new RuntimeAccessProperties());
+        A2ARequest<?> request = JSONRPCUtils.parseRequestBody("""
+                {"jsonrpc":"2.0","id":"sub-input","method":"SubscribeToTask","params":{"id":"task-1"}}
+                """, null);
+
+        StepVerifier.create(controller.handleStream(request, null))
+                .assertNext(event -> assertThat(statusState(event)).isEqualTo("TASK_STATE_WORKING"))
+                .assertNext(event -> assertThat(statusState(event)).isEqualTo("TASK_STATE_INPUT_REQUIRED"))
+                .assertNext(event -> assertThat(statusState(event)).isEqualTo("TASK_STATE_COMPLETED"))
+                .verifyComplete();
+    }
+
+    @Test
     void sseParseFailureAnswersSingleErrorFrame() {
         A2aJsonRpcController controller = new A2aJsonRpcController(new SingleEventRequestHandler(), new RuntimeAccessProperties());
 
@@ -269,6 +301,10 @@ class A2aJsonRpcControllerTest {
         }
     }
 
+    private static String statusState(ServerSentEvent<String> event) {
+        return dataJson(event).path("result").path("statusUpdate").path("status").path("state").asText();
+    }
+
     private static final class FailingRequestHandler extends SingleEventRequestHandler {
         @Override
         public Task onGetTask(TaskQueryParams params, ServerCallContext context) throws A2AError {
@@ -316,6 +352,47 @@ class A2aJsonRpcControllerTest {
                 subscriber.onNext(message);
                 subscriber.onError(new RuntimeException("boom"));
             };
+        }
+    }
+
+    private static final class InputRequiredThenCompletedRequestHandler extends SingleEventRequestHandler {
+        @Override
+        public Flow.Publisher<StreamingEventKind> onMessageSendStream(
+                MessageSendParams params, ServerCallContext context) {
+            return statusPublisher();
+        }
+
+        @Override
+        public Flow.Publisher<StreamingEventKind> onSubscribeToTask(TaskIdParams params, ServerCallContext context) {
+            return statusPublisher();
+        }
+
+        private static Flow.Publisher<StreamingEventKind> statusPublisher() {
+            List<StreamingEventKind> events = List.of(
+                    status(TaskState.TASK_STATE_WORKING),
+                    status(TaskState.TASK_STATE_INPUT_REQUIRED),
+                    status(TaskState.TASK_STATE_COMPLETED));
+            return subscriber -> {
+                subscriber.onSubscribe(new Flow.Subscription() {
+                    @Override
+                    public void request(long n) {
+                    }
+
+                    @Override
+                    public void cancel() {
+                    }
+                });
+                events.forEach(subscriber::onNext);
+                subscriber.onComplete();
+            };
+        }
+
+        private static TaskStatusUpdateEvent status(TaskState state) {
+            return TaskStatusUpdateEvent.builder()
+                    .taskId("task-1")
+                    .contextId("ctx-1")
+                    .status(new TaskStatus(state))
+                    .build();
         }
     }
 


### PR DESCRIPTION
End northbound `SendStreamingMessage` SSE responses when a task reaches `TASK_STATE_INPUT_REQUIRED`.