### PR TITLE
feat(e2e): add Versatile mock service for offline testing

### DIFF
--- a/examples/agent-runtime-a2a-versatile-parent-e2e/README.md
+++ b/examples/agent-runtime-a2a-versatile-parent-e2e/README.md
@@ -106,7 +106,9 @@ export SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY=false
 
 ### 步骤 4：手工启动双进程验证（核心验证）
 
-两个 profile 已预设固定端口。
+默认配置（`versatile.url=http://localhost:18083`）已指向本地 mock 服务。子 Agent 启动时会通过 `VersatileMockConfiguration` 自动在端口 18083 启动内嵌 WireMock，无需额外终端。
+
+如需使用外部 Versatile 服务，添加 `--versatile.mock.enabled=false --versatile.url=<外部URL>`。
 
 #### 终端 1 — 启动 Versatile 子 Agent（端口 18082）
 
@@ -114,6 +116,8 @@ export SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY=false
 cd examples/agent-runtime-a2a-versatile-parent-e2e
 mvn spring-boot:run -Dspring-boot.run.profiles=versatile
 ```
+
+日志出现 `Versatile mock server started on port 18083` 表示 mock 已就绪。
 
 #### 终端 2 — 启动主 Agent（OpenJiuwen LLM，端口 18080）
 
@@ -305,6 +309,42 @@ remote tool invocation start taskId=... toolName=a2a_remote_versatile_child
 | 5 | **预订结果提取** | `versatile extracted result match='hotel_book_success' get='ticket'` |
 | 6 | **LLM 最终总结** | COMPLETED 消息包含酒店名、订单号、日期、价格 |
 | 7 | **Remote Agent 配置** | `output.default-target=USER` + `completion-target=LLM` 生效 |
+
+---
+
+## Mock 测试（离线，无需外部 Versatile 服务）
+
+本示例包含一个基于 WireMock 的 Versatile API 模拟服务 `VersatileMockService`，可以完全不依赖外部 Versatile REST API 运行 E2E 测试。
+
+**Mock 行为：**
+
+| 轮次 | Mock 响应 | child 结果 |
+|------|----------|-----------|
+| 第一轮 | `hotels_info` 事件 + End | COMPLETED（酒店列表） |
+| 第一轮（interrupt 模式） | `hotels_info` 事件（无 End） | INPUT_REQUIRED |
+| 第二轮 | `hotel_book_success` 事件 + End | COMPLETED（含 ticket 提取） |
+
+**运行测试：**
+
+```bash
+cd examples/agent-runtime-a2a-versatile-parent-e2e
+
+# 需要 LLM（API Key 已配置）
+SAA_SAMPLE_LLM_API_KEY=sk-x00550472 SAA_SAMPLE_LLM_MODEL=gpt-5.4-mini mvn test
+
+# 无 LLM — card discovery 测试仍可运行，LLM 测试自动跳过
+mvn test
+```
+
+**Mock 架构：**
+```
+JUnit @BeforeEach → VersatileMockService.start()   (随机端口)
+                 → --versatile.url=http://localhost:{mockPort}/...
+                 → child 连接 mock 而非真实 API
+JUnit @AfterEach  → VersatileMockService.stop()
+```
+
+测试不依赖外部 `http://7.213.200.213:3001`，可以在任何网络环境运行。
 
 ---
 

--- a/examples/agent-runtime-a2a-versatile-parent-e2e/README.md
+++ b/examples/agent-runtime-a2a-versatile-parent-e2e/README.md
@@ -316,13 +316,14 @@ remote tool invocation start taskId=... toolName=a2a_remote_versatile_child
 
 本示例包含一个基于 WireMock 的 Versatile API 模拟服务 `VersatileMockService`，可以完全不依赖外部 Versatile REST API 运行 E2E 测试。
 
-**Mock 行为：**
+**Mock 行为（默认中断流程）：**
 
 | 轮次 | Mock 响应 | child 结果 |
 |------|----------|-----------|
-| 第一轮 | `hotels_info` 事件 + End | COMPLETED（酒店列表） |
-| 第一轮（interrupt 模式） | `hotels_info` 事件（无 End） | INPUT_REQUIRED |
-| 第二轮 | `hotel_book_success` 事件 + End | COMPLETED（含 ticket 提取） |
+| 第一轮 | `hotels_info` 事件（无 End） | INPUT_REQUIRED（等待用户选择酒店） |
+| 第二轮 | `hotel_book_success` 事件 + End | COMPLETED（含 ticket 提取，返回 LLM） |
+
+JUnit 测试可按需切换：`stubBookingFlow()`（第一轮也带 End → COMPLETED）或 `stubInterruptFlow()`（默认）。
 
 **运行测试：**
 

--- a/examples/agent-runtime-a2a-versatile-parent-e2e/pom.xml
+++ b/examples/agent-runtime-a2a-versatile-parent-e2e/pom.xml
@@ -44,6 +44,11 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/examples/agent-runtime-a2a-versatile-parent-e2e/src/main/java/com/huawei/ascend/examples/a2a/versatileparent/VersatileMockConfiguration.java
+++ b/examples/agent-runtime-a2a-versatile-parent-e2e/src/main/java/com/huawei/ascend/examples/a2a/versatileparent/VersatileMockConfiguration.java
@@ -1,0 +1,65 @@
+package com.huawei.ascend.examples.a2a.versatileparent;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * Auto-starts the Versatile mock WireMock server for the {@code versatile}
+ * profile (the child agent). The mock listens on port 18083 — the same port
+ * configured as the default {@code versatile.url} in
+ * {@code application-versatile.yaml}.
+ *
+ * <p>With this configuration the child agent can run completely standalone
+ * without an external Versatile REST API.
+ */
+@Configuration(proxyBeanMethods = false)
+@Profile("versatile")
+@ConditionalOnProperty(name = "versatile.mock.embedded", havingValue = "true", matchIfMissing = true)
+public class VersatileMockConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VersatileMockConfiguration.class);
+    static final int PORT = 18083;
+    private static final String SCENARIO = "hotel-booking";
+    private static final String STATE_FIRST_DONE = "first-done";
+
+    @Bean
+    WireMockServer versatileMockServer() {
+        WireMockServer server = new WireMockServer(PORT);
+        server.start();
+        WireMock.configureFor(PORT);
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathMatching("/v1/.*/agents/.*/conversations/.*"))
+                .inScenario(SCENARIO).whenScenarioStateIs(Scenario.STARTED)
+                .withQueryParam("type", WireMock.equalTo("controller"))
+                .willReturn(WireMock.aResponse().withStatus(200)
+                        .withHeader("Content-Type", "text/event-stream; charset=utf-8")
+                        .withBody(VersatileMockSse.hotelsInfo()))
+                .willSetStateTo(STATE_FIRST_DONE));
+
+        WireMock.stubFor(WireMock.post(WireMock.urlPathMatching("/v1/.*/agents/.*/conversations/.*"))
+                .inScenario(SCENARIO).whenScenarioStateIs(STATE_FIRST_DONE)
+                .withQueryParam("type", WireMock.equalTo("controller"))
+                .willReturn(WireMock.aResponse().withStatus(200)
+                        .withHeader("Content-Type", "text/event-stream; charset=utf-8")
+                        .withBody(VersatileMockSse.hotelBookSuccess())));
+
+        LOG.info("Versatile mock server started on port {} (versatile.mock.enabled=true)", PORT);
+        return server;
+    }
+
+    @Bean
+    DisposableBean versatileMockShutdown(WireMockServer server) {
+        return () -> {
+            server.stop();
+            LOG.info("Versatile mock server stopped.");
+        };
+    }
+}

--- a/examples/agent-runtime-a2a-versatile-parent-e2e/src/main/java/com/huawei/ascend/examples/a2a/versatileparent/VersatileMockConfiguration.java
+++ b/examples/agent-runtime-a2a-versatile-parent-e2e/src/main/java/com/huawei/ascend/examples/a2a/versatileparent/VersatileMockConfiguration.java
@@ -36,12 +36,13 @@ public class VersatileMockConfiguration {
         server.start();
         WireMock.configureFor(PORT);
 
+        // First request → hotels_info WITHOUT End → child emits INTERRUPTED
         WireMock.stubFor(WireMock.post(WireMock.urlPathMatching("/v1/.*/agents/.*/conversations/.*"))
                 .inScenario(SCENARIO).whenScenarioStateIs(Scenario.STARTED)
                 .withQueryParam("type", WireMock.equalTo("controller"))
                 .willReturn(WireMock.aResponse().withStatus(200)
                         .withHeader("Content-Type", "text/event-stream; charset=utf-8")
-                        .withBody(VersatileMockSse.hotelsInfo()))
+                        .withBody(VersatileMockSse.hotelsInfoNoEnd()))
                 .willSetStateTo(STATE_FIRST_DONE));
 
         WireMock.stubFor(WireMock.post(WireMock.urlPathMatching("/v1/.*/agents/.*/conversations/.*"))

--- a/examples/agent-runtime-a2a-versatile-parent-e2e/src/main/java/com/huawei/ascend/examples/a2a/versatileparent/VersatileMockSse.java
+++ b/examples/agent-runtime-a2a-versatile-parent-e2e/src/main/java/com/huawei/ascend/examples/a2a/versatileparent/VersatileMockSse.java
@@ -1,0 +1,68 @@
+package com.huawei.ascend.examples.a2a.versatileparent;
+
+/**
+ * Shared SSE response bodies for the Versatile mock, used by both the
+ * standalone {@link VersatileMockServer} and the JUnit
+ * {@link VersatileMockService}.
+ */
+final class VersatileMockSse {
+
+    private VersatileMockSse() {}
+
+    /** Hotels_info event + End message + end event. */
+    static String hotelsInfo() {
+        return sse("hotels_info", """
+                {"hotels":[\
+                {"city":"北京","hotel_name":"洲际国际酒店","star":"3","rating":"4.7","location_info":"近北京游乐园 · 休闲区","most_comment":"停车方便，安保到位","comment_num":"1.3万","favorite_num":"3.6万","price":"257"},\
+                {"city":"北京","hotel_name":"铂尔曼中心酒店","star":"5","rating":"3.7","location_info":"近北京游乐园 · 休闲区","most_comment":"环境优美，安静舒适","comment_num":"4.5万","favorite_num":"7.9万","price":"1318"},\
+                {"city":"北京","hotel_name":"皇冠假日广场酒店","star":"4","rating":"4.1","location_info":"北京风景区 · 湖景房","most_comment":"床品舒适，睡眠质量好","comment_num":"2.3万","favorite_num":"6.1万","price":"892"},\
+                {"city":"北京","hotel_name":"希尔顿花园酒店","star":"5","rating":"4.5","location_info":"北京市中心 · 地铁直达","most_comment":"服务热情周到，设施完善","comment_num":"4.2万","favorite_num":"9.3万","price":"1498"},\
+                {"city":"北京","hotel_name":"万豪度假村","star":"4","rating":"4.3","location_info":"近北京机场 · 商业区","most_comment":"亲子友好，设施齐全","comment_num":"3.1万","favorite_num":"5.8万","price":"756"}],\
+                "index":"0","node_id":"node_123","node_type":"QA","node_name":"查询酒店列表",\
+                "workflow_id":"1883913d-2330-492b-9ddd-8687b422fae2"}\
+                """)
+                + sseEndMessage("123") + sseEnd();
+    }
+
+    /** Hotel_book_success event with ticket + End message + end event. */
+    static String hotelBookSuccess() {
+        return sse("hotel_book_success", """
+                {"ticket":{\
+                "person_name":"李四","order_no":"H9876543210","hotel_name":"希尔顿花园酒店",\
+                "star":"5","rating":"4.5","location_info":"北京市中心 · 地铁直达",\
+                "price":"1498","checkin_date":"2026-03-30","checkout_date":"2026-04-03"},\
+                "index":"0","node_id":"node_456","node_type":"QA","node_name":"确认酒店预订",\
+                "workflow_id":"1883913d-2330-492b-9ddd-8687b422fae2"}\
+                """)
+                + sseEndMessage("456") + sseEnd();
+    }
+
+    /** Hotels_info WITHOUT End (for interrupt scenario). */
+    static String hotelsInfoNoEnd() {
+        return sse("hotels_info", """
+                {"hotels":[\
+                {"city":"北京","hotel_name":"洲际国际酒店","star":"3","rating":"4.7","location_info":"近北京游乐园 · 休闲区","most_comment":"停车方便，安保到位","comment_num":"1.3万","favorite_num":"3.6万","price":"257"},\
+                {"city":"北京","hotel_name":"希尔顿花园酒店","star":"5","rating":"4.5","location_info":"北京市中心 · 地铁直达","most_comment":"服务热情周到，设施完善","comment_num":"4.2万","favorite_num":"9.3万","price":"1498"}],\
+                "index":"0","node_id":"node_123","node_type":"QA","node_name":"查询酒店列表",\
+                "workflow_id":"1883913d-2330-492b-9ddd-8687b422fae2"}\
+                """);
+    }
+
+    // ── helpers ──
+
+    private static String sse(String event, String dataJson) {
+        return "data:{\"event\":\"" + event + "\",\"data\":" + dataJson + "}\n\n";
+    }
+
+    private static String sseEnd() {
+        return "data:{\"event\":\"end\",\"data\":{}}\n\n";
+    }
+
+    private static String sseEndMessage(String sourceNodeId) {
+        return sse("message", """
+                {"text":"","summary":"","node_id":"node_end","node_type":"End",\
+                "node_name":"结束","is_finished":true,\
+                "workflow_id":"1883913d-2330-492b-9ddd-8687b422fae2",\
+                "index":"1","source_node_id":"node_""" + sourceNodeId + "\"}");
+    }
+}

--- a/examples/agent-runtime-a2a-versatile-parent-e2e/src/main/resources/application-versatile.yaml
+++ b/examples/agent-runtime-a2a-versatile-parent-e2e/src/main/resources/application-versatile.yaml
@@ -15,7 +15,7 @@ agent-runtime:
       default-agent-id: versatile-child
 
 versatile:
-  url: ${VERSATILE_URL:http://7.213.200.213:3001/v1/{project_id}/agents/{agent_id}/conversations/{conversation_id}}
+  url: ${VERSATILE_URL:http://localhost:18083/v1/{project_id}/agents/{agent_id}/conversations/{conversation_id}}
   timeout: 30s
 
   url-variables:

--- a/examples/agent-runtime-a2a-versatile-parent-e2e/src/test/java/com/huawei/ascend/examples/a2a/versatileparent/VersatileMockService.java
+++ b/examples/agent-runtime-a2a-versatile-parent-e2e/src/test/java/com/huawei/ascend/examples/a2a/versatileparent/VersatileMockService.java
@@ -1,0 +1,75 @@
+package com.huawei.ascend.examples.a2a.versatileparent;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+
+/**
+ * Test-only WireMock versatile API for JUnit E2E tests.
+ * Uses a random port so multiple test runs never collide.
+ *
+ * <p>SSE bodies are shared with {@link VersatileMockServer} via
+ * {@link VersatileMockSse}.
+ */
+public final class VersatileMockService {
+
+    private static final String SCENARIO = "hotel-booking";
+    private static final String STATE_FIRST_DONE = "first-done";
+
+    private final WireMockServer server;
+    private boolean started;
+
+    public VersatileMockService() {
+        this.server = new WireMockServer(0);
+    }
+
+    public void start() {
+        if (started) return;
+        server.start();
+        WireMock.configureFor(server.port());
+        started = true;
+    }
+
+    public int port() { return server.port(); }
+
+    public String baseUrl() { return "http://localhost:" + port(); }
+
+    public void stop() {
+        if (!started) return;
+        server.stop();
+        started = false;
+    }
+
+    // ── Flows ──
+
+    public void stubBookingFlow() {
+        WireMock.reset();
+        firstResponse(VersatileMockSse.hotelsInfo());
+        secondResponse(VersatileMockSse.hotelBookSuccess());
+    }
+
+    public void stubInterruptFlow() {
+        WireMock.reset();
+        firstResponse(VersatileMockSse.hotelsInfoNoEnd());
+        secondResponse(VersatileMockSse.hotelBookSuccess());
+    }
+
+    private static void firstResponse(String body) {
+        WireMock.stubFor(WireMock.post(WireMock.urlPathMatching("/v1/.*/agents/.*/conversations/.*"))
+                .inScenario(SCENARIO).whenScenarioStateIs(Scenario.STARTED)
+                .withQueryParam("type", WireMock.equalTo("controller"))
+                .willReturn(WireMock.aResponse().withStatus(200)
+                        .withHeader("Content-Type", "text/event-stream; charset=utf-8")
+                        .withBody(body))
+                .willSetStateTo(STATE_FIRST_DONE));
+    }
+
+    private static void secondResponse(String body) {
+        WireMock.stubFor(WireMock.post(WireMock.urlPathMatching("/v1/.*/agents/.*/conversations/.*"))
+                .inScenario(SCENARIO).whenScenarioStateIs(STATE_FIRST_DONE)
+                .withQueryParam("type", WireMock.equalTo("controller"))
+                .willReturn(WireMock.aResponse().withStatus(200)
+                        .withHeader("Content-Type", "text/event-stream; charset=utf-8")
+                        .withBody(body)));
+    }
+}

--- a/examples/agent-runtime-a2a-versatile-parent-e2e/src/test/java/com/huawei/ascend/examples/a2a/versatileparent/VersatileParentA2eE2eTest.java
+++ b/examples/agent-runtime-a2a-versatile-parent-e2e/src/test/java/com/huawei/ascend/examples/a2a/versatileparent/VersatileParentA2eE2eTest.java
@@ -10,6 +10,8 @@ import org.a2aproject.sdk.spec.AgentCard;
 import org.a2aproject.sdk.spec.AgentInterface;
 import org.a2aproject.sdk.spec.StreamingEventKind;
 import org.a2aproject.sdk.spec.TransportProtocol;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.ResourceLock;
@@ -20,34 +22,34 @@ import org.springframework.context.ConfigurableApplicationContext;
  * End-to-end test: Main parent (OpenJiuwen LLM) calls versatile child agent
  * via A2A remote tool, with interruption detection and resume.
  *
- * <p>The versatile child starts first on a random port. The main parent starts
- * second with the child's URL configured as a remote agent. The runtime discovers
- * the child's A2A card, injects it as a tool into the parent's OpenJiuwen
- * ReActAgent, and the LLM chooses to invoke it.
+ * <p>Uses a {@link VersatileMockService} (WireMock) to simulate the Versatile
+ * REST API, so tests run offline without an external service dependency.
  *
- * <p>The real-LLM test requires {@code SAA_SAMPLE_LLM_API_KEY} and is skipped
+ * <p>The real-LLM tests require {@code SAA_SAMPLE_LLM_API_KEY} and are skipped
  * otherwise.
- *
- * <h3>Test scenarios</h3>
- * <ol>
- *   <li><b>Agent card discovery:</b> Both agents' cards are discoverable
- *       via {@code /.well-known/agent-card.json}.</li>
- *   <li><b>Parent calls child:</b> Parent LLM invokes the versatile child
- *       tool; child streams intermediate output to user (target=USER);
- *       child caches output; child detects End node and returns final
- *       assembled result (target=LLM); parent LLM receives tool result
- *       and summarizes.</li>
- *   <li><b>Interruption on connection loss:</b> When the versatile HTTP
- *       connection closes without an End node, the child emits INTERRUPTED;
- *       the parent task enters INPUT_REQUIRED; client resumes with same
- *       taskId; request is routed directly to child (skipping LLM).</li>
- * </ol>
  */
 @Tag("e2e")
 @ResourceLock("real-llm")
 class VersatileParentA2eE2eTest {
 
     private static final Duration CLIENT_TIMEOUT = Duration.ofSeconds(90);
+
+    private VersatileMockService versatileMock;
+
+    @BeforeEach
+    void setUp() {
+        versatileMock = new VersatileMockService();
+        versatileMock.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (versatileMock != null) {
+            versatileMock.stop();
+        }
+    }
+
+    // ── Card discovery (no LLM needed) ──
 
     @Test
     void agentCardIsDiscoverable() throws Exception {
@@ -78,26 +80,26 @@ class VersatileParentA2eE2eTest {
         }
     }
 
+    // ── LLM-driven tests (use mock versatile API) ──
+
     @Test
     void llmParentInvokesVersatileChildViaA2aTool() throws Exception {
         assumeTrue(hasText(System.getenv("SAA_SAMPLE_LLM_API_KEY")),
-                "SAA_SAMPLE_LLM_API_KEY not set; skipping real-LLM remote A2A e2e test");
+                "SAA_SAMPLE_LLM_API_KEY not set; skipping real-LLM test");
 
-        // Start versatile child
+        versatileMock.stubBookingFlow();
+
         try (ConfigurableApplicationContext child = startRuntime("versatile")) {
             int childPort = port(child);
 
-            // Start main parent, pointing to child
             try (ConfigurableApplicationContext main = startRuntime("main",
                     "agent-runtime.remote-agents[0].url=http://localhost:" + childPort)) {
 
-                // Verify parent card
                 VersatileParentA2aClient client = new VersatileParentA2aClient(
                         URI.create("http://localhost:" + port(main)), CLIENT_TIMEOUT);
                 AgentCard card = client.agentCard();
                 assertThat(card.name()).isEqualTo(MainAgentConfiguration.AGENT_ID);
 
-                // Ask parent to call versatile child
                 List<StreamingEventKind> events = client.streamMessage(
                         "sample-user",
                         MainAgentConfiguration.AGENT_ID,
@@ -115,24 +117,16 @@ class VersatileParentA2eE2eTest {
         }
     }
 
-    /**
-     * Tests the interruption scenario: the versatile child responds to a
-     * request, the HTTP connection closes before End, the task enters
-     * INPUT_REQUIRED, and the client resumes with the same taskId.
-     *
-     * <p>This test requires a real versatile endpoint that can be interrupted.
-     * When the versatile endpoint is not available, this test is skipped.
-     */
     @Test
     void versatileInterruptionAndResume() throws Exception {
         assumeTrue(hasText(System.getenv("SAA_SAMPLE_LLM_API_KEY")),
                 "SAA_SAMPLE_LLM_API_KEY not set; skipping real-LLM test");
 
-        // Start versatile child
+        versatileMock.stubInterruptFlow();
+
         try (ConfigurableApplicationContext child = startRuntime("versatile")) {
             int childPort = port(child);
 
-            // Start main parent
             try (ConfigurableApplicationContext main = startRuntime("main",
                     "agent-runtime.remote-agents[0].url=http://localhost:" + childPort)) {
 
@@ -141,7 +135,6 @@ class VersatileParentA2eE2eTest {
 
                 String sessionId = "ctx-interrupt-e2e-" + System.currentTimeMillis();
 
-                // First request — may result in INPUT_REQUIRED if versatile interrupts
                 List<StreamingEventKind> firstEvents = client.streamMessage(
                         "sample-user",
                         MainAgentConfiguration.AGENT_ID,
@@ -152,7 +145,6 @@ class VersatileParentA2eE2eTest {
                 assertThat(firstEvents).isNotEmpty();
 
                 if (VersatileParentA2aClient.isInputRequired(firstEvents)) {
-                    // Interruption occurred — resume with same taskId
                     String taskId = VersatileParentA2aClient.firstTaskId(firstEvents);
                     assertThat(taskId).isNotBlank();
 
@@ -171,10 +163,17 @@ class VersatileParentA2eE2eTest {
         }
     }
 
-    private static ConfigurableApplicationContext startRuntime(String profile, String... extraProperties) {
+    // ── Helpers ──
+
+    private ConfigurableApplicationContext startRuntime(String profile, String... extraProperties) {
         java.util.List<String> args = new java.util.ArrayList<>();
         args.add("--server.port=0");
         args.add("--spring.profiles.active=" + profile);
+        // Point the versatile child to the per-test WireMock server (random port)
+        // and disable the embedded mock that would clash with it.
+        args.add("--versatile.mock.embedded=false");
+        args.add("--versatile.url=http://localhost:" + versatileMock.port()
+                + "/v1/mock_project_id/agents/mock_agent/conversations/{conversation_id}");
         for (String property : extraProperties) {
             args.add(property.startsWith("--") ? property : "--" + property);
         }


### PR DESCRIPTION
## Summary

Adds WireMock-based Versatile API mock so E2E tests run offline without external service dependency.

## Changes

**VersatileMockService** (JUnit) — WireMock on random port, @BeforeEach/@AfterEach lifecycle
**VersatileMockConfiguration** (manual testing) — embedded mock auto-starts with versatile profile on port 18083
**VersatileMockSse** — shared SSE response bodies (hotels_info, hotel_book_success)
**Config** — default URL → localhost:18083, wiremock-standalone compile dependency
**README** — simplified from 3 terminals to 2

## Testing
- 4/4 pass with LLM key, 1/4 pass (3 skipped) without LLM key
- No external service dependency