### PR TITLE
[codex] Add daemon middleware examples

### DIFF
--- a/examples/agent-runtime-middleware-memory-inmemory/README.md
+++ b/examples/agent-runtime-middleware-memory-inmemory/README.md
@@ -1,65 +1,56 @@
-# agent-runtime middleware memory InMemory example
+# Agent Runtime Memory InMemory Example
 
-这个样例验证 `MemoryProvider` 的 InMemory 接入形态。Provider 放在 example
-目录中，说明 Memory 后端可以由业务样例或客户工程自行选择，`agent-runtime`
-公共层只依赖窄 SPI。
+本样例验证“长期记忆 MemoryProvider 解耦”的最小接入方式。用户启动一个常驻 Spring Boot 进程，通过 curl 写入记忆、发起一次用户输入，并从响应中观察记忆是否进入 OpenJiuwen ReActAgent 的真实模型输入。
 
-## 配置方式
+该样例不依赖外部服务，适合测试团队先验证 MemoryProvider 的基本链路。
 
-适用场景：
+## 启动服务
 
-- 本地开发、客户二次开发验证、测试团队构造确定性记忆命中。
-- 不需要真实向量库或外部 Memory 服务。
-- 希望看清楚 `MemoryProvider` 如何接入 OpenJiuwen handler。
-
-核心配置点：
-
-```java
-InMemoryMemoryProvider provider = new InMemoryMemoryProvider();
-
-class MemoryEnabledHandler extends OpenJiuwenAgentRuntimeHandler {
-    @Override
-    protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
-        return List.of(memoryRuntimeRail(context, provider));
-    }
-}
-```
-
-`InMemoryMemoryProvider` 是 example-only 实现，按
-`AgentExecutionContext#getAgentStateKey()` 做最小隔离。客户项目可以替换为
-自己的数据库、向量库、RAG 记忆服务或企业内存储。
-
-测试团队检查点：
-
-- 测试先写入一条长期记忆，例如 `the user prefers green tea`。
-- 用户输入进入 `OpenJiuwenAgentRuntimeHandler#execute(...)`。
-- handler 注册 memory rail。
-- rail 在执行前调用 `MemoryProvider.search(...)`。
-- rail 在执行后调用 `MemoryProvider.save(...)` 写回本轮 user/assistant 记录。
-- 不同 `agentStateKey` 的记忆不会互相命中。
-
-## Run
+在仓库根目录执行：
 
 ```bash
-./mvnw -f examples/agent-runtime-middleware-memory-inmemory/pom.xml test
+./mvnw -f examples/agent-runtime-middleware-memory-inmemory/pom.xml spring-boot:run
 ```
 
-## 端到端链路
+服务默认监听：
 
 ```text
-AgentExecutionContext(user input + agentStateKey)
-  -> OpenJiuwenAgentRuntimeHandler.execute(...)
-  -> openJiuwenRails(context)
-  -> memoryRuntimeRail(context, InMemoryMemoryProvider)
-  -> MemoryProvider.search(...)
-  -> OpenJiuwen ModelContext receives memory note
-  -> simulated OpenJiuwen agent response
-  -> MemoryProvider.save(...)
+http://localhost:18081
 ```
 
-## Scope
+## curl 验证
 
-- 无外部依赖。
-- 验证用户接入 `MemoryProvider` 后，执行 `OpenJiuwenAgentRuntimeHandler`
-  会安装 memory rail，并触发 `search` / `save`。
-- 不引入脚本；所有运行方式写在 README 中。
+1. 写入一条长期记忆：
+
+```bash
+curl -s -X POST http://localhost:18081/sample/memory/remember \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-user","text":"the user prefers green tea"}'
+```
+
+2. 模拟用户发起一次请求：
+
+```bash
+curl -s -X POST http://localhost:18081/sample/memory/ask \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-user","text":"green tea"}'
+```
+
+期望响应：
+
+- `modelMessages` 包含 `the user prefers green tea`，说明 memory rail 在调用模型前完成检索和注入。
+- `records` 包含本轮用户输入和 assistant 输出，说明执行后触发了 `MemoryProvider.save(...)`。
+
+说明：本样例的 InMemory provider 使用简单字符串匹配，不做向量语义检索；因此 curl 示例使用 `green tea` 作为 query，确保测试团队能稳定观察到记忆注入。
+
+3. 查询当前 `stateKey` 下的记忆：
+
+```bash
+curl -s 'http://localhost:18081/sample/memory/records?stateKey=demo-user'
+```
+
+## 设计要点
+
+- 样例通过 `SampleMemoryOpenJiuwenHandler#setOpenJiuwenRailFactories(...)` 预设 OpenJiuwen rail。
+- 业务方可以按同样方式把 `memoryRuntimeRail(context, provider)` 设置到自己的 OpenJiuwen handler。
+- `InMemoryMemoryProvider` 只放在 example 中，用于端到端验证；生产环境应替换成企业自己的长期记忆服务。

--- a/examples/agent-runtime-middleware-memory-inmemory/README.md
+++ b/examples/agent-runtime-middleware-memory-inmemory/README.md
@@ -1,53 +1,28 @@
 # Agent Runtime Memory InMemory Example
 
-本样例验证“长期记忆 MemoryProvider 解耦”的最小接入方式。用户启动一个常驻 Spring Boot 进程，通过 curl 写入记忆、发起一次用户输入，并从响应中观察记忆是否进入 OpenJiuwen ReActAgent 的真实模型输入。
+本样例验证“长期记忆 `MemoryProvider` 解耦”的最小接入方式。它启动一个常驻 Spring Boot 进程，用户通过 curl 写入记忆、发起一次用户输入，并从响应中观察记忆是否进入 OpenJiuwen ReActAgent 的真实模型输入。
 
-该样例不依赖外部服务，适合测试团队先验证 MemoryProvider 的基本链路。
+完整 step by step 教程见：[TUTORIAL.cn.md](TUTORIAL.cn.md)。
 
-## 启动服务
-
-在仓库根目录执行：
+## 快速启动
 
 ```bash
 ./mvnw -f examples/agent-runtime-middleware-memory-inmemory/pom.xml spring-boot:run
 ```
 
-服务默认监听：
+默认监听：
 
 ```text
 http://localhost:18081
 ```
 
-## curl 验证
+## 主要接口
 
-1. 写入一条长期记忆：
-
-```bash
-curl -s -X POST http://localhost:18081/sample/memory/remember \
-  -H 'Content-Type: application/json' \
-  -d '{"stateKey":"demo-user","text":"the user prefers green tea"}'
-```
-
-2. 模拟用户发起一次请求：
-
-```bash
-curl -s -X POST http://localhost:18081/sample/memory/ask \
-  -H 'Content-Type: application/json' \
-  -d '{"stateKey":"demo-user","text":"green tea"}'
-```
-
-期望响应：
-
-- `modelMessages` 包含 `the user prefers green tea`，说明 memory rail 在调用模型前完成检索和注入。
-- `records` 包含本轮用户输入和 assistant 输出，说明执行后触发了 `MemoryProvider.save(...)`。
-
-说明：本样例的 InMemory provider 使用简单字符串匹配，不做向量语义检索；因此 curl 示例使用 `green tea` 作为 query，确保测试团队能稳定观察到记忆注入。
-
-3. 查询当前 `stateKey` 下的记忆：
-
-```bash
-curl -s 'http://localhost:18081/sample/memory/records?stateKey=demo-user'
-```
+| 接口 | 用途 |
+|---|---|
+| `POST /sample/memory/remember` | 写入一条长期记忆 |
+| `POST /sample/memory/ask` | 模拟一次用户请求，并触发 memory rail 检索和注入 |
+| `GET /sample/memory/records?stateKey=demo-user` | 查看当前 `stateKey` 下保存的记忆 |
 
 ## 设计要点
 

--- a/examples/agent-runtime-middleware-memory-inmemory/README.md
+++ b/examples/agent-runtime-middleware-memory-inmemory/README.md
@@ -7,6 +7,11 @@
 ## 快速启动
 
 ```bash
+export SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER=openai
+export SAA_SAMPLE_OPENJIUWEN_API_BASE=https://api.deepseek.com
+export SAA_SAMPLE_LLM_MODEL=deepseek-chat
+export SAA_SAMPLE_LLM_API_KEY=sk-your-key
+
 ./mvnw -f examples/agent-runtime-middleware-memory-inmemory/pom.xml spring-boot:run
 ```
 
@@ -27,5 +32,5 @@ http://localhost:18081
 ## 设计要点
 
 - 样例通过 `SampleMemoryOpenJiuwenHandler#setOpenJiuwenRailFactories(...)` 预设 OpenJiuwen rail。
-- 业务方可以按同样方式把 `memoryRuntimeRail(context, provider)` 设置到自己的 OpenJiuwen handler。
+- `buildMemoryRailFactories(...)` 负责构建 rails，`setOpenJiuwenRailFactories(...)` 负责把 rails 设置到 handler；执行时不 override `runOpenJiuwenAgent(...)`，仍走 OpenJiuwen 默认 Runner。
 - `InMemoryMemoryProvider` 只放在 example 中，用于端到端验证；生产环境应替换成企业自己的长期记忆服务。

--- a/examples/agent-runtime-middleware-memory-inmemory/README.md
+++ b/examples/agent-runtime-middleware-memory-inmemory/README.md
@@ -31,6 +31,10 @@ http://localhost:18081
 
 ## 设计要点
 
+- `/sample/memory/ask` 请求体里的 `text` 是本轮用户输入；样例会把它包装成 `RuntimeMessage.user(text)`，
+  最终由 `OpenJiuwenMessageAdapter` 转成 OpenJiuwen Runner 的 `query`。
+- `createOpenJiuwenAgent(...)` 中的 promptTemplate 只是 system prompt，用来约束样例 Agent 的回答方式，
+  不是用户输入。
 - 样例 handler 直接持有 `MemoryProvider`，并在 `openJiuwenRails(context)` 中注册唯一的 memory rail。
 - 执行时不 override `runOpenJiuwenAgent(...)`，仍走 OpenJiuwen 默认 Runner。
 - `InMemoryMemoryProvider` 只放在 example 中，用于端到端验证；生产环境应替换成企业自己的长期记忆服务。

--- a/examples/agent-runtime-middleware-memory-inmemory/README.md
+++ b/examples/agent-runtime-middleware-memory-inmemory/README.md
@@ -31,6 +31,6 @@ http://localhost:18081
 
 ## 设计要点
 
-- 样例通过 `SampleMemoryOpenJiuwenHandler#setOpenJiuwenRailFactories(...)` 预设 OpenJiuwen rail。
-- `buildMemoryRailFactories(...)` 负责构建 rails，`setOpenJiuwenRailFactories(...)` 负责把 rails 设置到 handler；执行时不 override `runOpenJiuwenAgent(...)`，仍走 OpenJiuwen 默认 Runner。
+- 样例 handler 直接持有 `MemoryProvider`，并在 `openJiuwenRails(context)` 中注册唯一的 memory rail。
+- 执行时不 override `runOpenJiuwenAgent(...)`，仍走 OpenJiuwen 默认 Runner。
 - `InMemoryMemoryProvider` 只放在 example 中，用于端到端验证；生产环境应替换成企业自己的长期记忆服务。

--- a/examples/agent-runtime-middleware-memory-inmemory/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-memory-inmemory/TUTORIAL.cn.md
@@ -1,0 +1,132 @@
+# InMemory MemoryProvider 样例教程
+
+跟着做完，你会启动一个常驻样例服务，通过 curl 写入一条长期记忆，再模拟一次用户输入，确认 OpenJiuwen ReActAgent 的真实模型输入里包含该记忆。
+
+---
+
+## 0. 你将验证什么
+
+本样例验证长期记忆链路：
+
+```text
+curl 写入记忆
+        ↓
+InMemoryMemoryProvider 保存
+        ↓
+curl 发起用户输入
+        ↓
+OpenJiuwen memory rail 检索记忆
+        ↓
+ReActAgent 模型输入包含 Relevant memory
+        ↓
+MemoryProvider.save(...) 保存本轮用户输入和 assistant 输出
+```
+
+本样例不依赖外部服务，适合测试团队先验证 `MemoryProvider` 的基本接入形态。
+
+---
+
+## 1. 环境准备
+
+在仓库根目录执行命令。需要：
+
+- JDK 21
+- curl
+- 本地 18081 端口未被占用
+
+Windows PowerShell 可以把下面的 `./mvnw` 换成 `./mvnw.cmd`。
+
+---
+
+## 2. Step 1 — 启动守护进程
+
+```bash
+./mvnw -f examples/agent-runtime-middleware-memory-inmemory/pom.xml spring-boot:run
+```
+
+看到 Spring Boot 启动完成后，不要关闭终端。服务地址：
+
+```text
+http://localhost:18081
+```
+
+---
+
+## 3. Step 2 — 写入一条长期记忆
+
+另开一个终端执行：
+
+```bash
+curl -s -X POST http://localhost:18081/sample/memory/remember \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-user","text":"the user prefers green tea"}'
+```
+
+期望响应里能看到：
+
+```json
+{
+  "stateKey": "demo-user",
+  "records": [
+    {
+      "content": "the user prefers green tea"
+    }
+  ]
+}
+```
+
+---
+
+## 4. Step 3 — 发起一次用户请求
+
+```bash
+curl -s -X POST http://localhost:18081/sample/memory/ask \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-user","text":"green tea"}'
+```
+
+期望响应：
+
+- `rawResults` 中包含 `output=pong`。
+- `modelMessages` 中包含 `the user prefers green tea`。
+- `modelMessages` 中包含 `Relevant memory:`，说明 memory rail 在调用模型前完成了检索和注入。
+- `records` 中包含本轮用户输入和 assistant 输出，说明执行后触发了 `MemoryProvider.save(...)`。
+
+说明：本样例的 InMemory provider 使用简单字符串匹配，不做向量语义检索；因此 curl 示例使用 `green tea` 作为 query，确保测试团队能稳定观察到记忆注入。
+
+---
+
+## 5. Step 4 — 查看保存结果
+
+```bash
+curl -s 'http://localhost:18081/sample/memory/records?stateKey=demo-user'
+```
+
+你应该能看到三类记录：
+
+1. 第 3 步手工写入的长期记忆。
+2. 第 4 步的用户输入。
+3. 第 4 步的 assistant 输出。
+
+---
+
+## 6. Step 5 — 看代码入口
+
+关键代码在：
+
+- `MemoryInMemoryApplication.java`
+- `SampleMemoryOpenJiuwenHandler#setOpenJiuwenRailFactories(...)`
+- `SampleMemoryOpenJiuwenHandler#memoryRail(...)`
+- `InMemoryMemoryProvider`
+
+用户侧要复用这个模式时，核心动作是：
+
+```java
+handler.setOpenJiuwenRailFactories(List.of(context -> handler.memoryRail(context, memoryProvider)));
+```
+
+---
+
+## 7. 清理
+
+在启动服务的终端按 `Ctrl+C` 停止进程。

--- a/examples/agent-runtime-middleware-memory-inmemory/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-memory-inmemory/TUTORIAL.cn.md
@@ -32,6 +32,7 @@ MemoryProvider.save(...) 保存本轮用户输入和 assistant 输出
 
 - JDK 21
 - curl
+- 可用的 OpenAI-compatible LLM API
 - 本地 18081 端口未被占用
 
 Windows PowerShell 可以把下面的 `./mvnw` 换成 `./mvnw.cmd`。
@@ -41,6 +42,11 @@ Windows PowerShell 可以把下面的 `./mvnw` 换成 `./mvnw.cmd`。
 ## 2. Step 1 — 启动守护进程
 
 ```bash
+export SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER=openai
+export SAA_SAMPLE_OPENJIUWEN_API_BASE=https://api.deepseek.com
+export SAA_SAMPLE_LLM_MODEL=deepseek-chat
+export SAA_SAMPLE_LLM_API_KEY=sk-your-key
+
 ./mvnw -f examples/agent-runtime-middleware-memory-inmemory/pom.xml spring-boot:run
 ```
 
@@ -82,17 +88,16 @@ curl -s -X POST http://localhost:18081/sample/memory/remember \
 ```bash
 curl -s -X POST http://localhost:18081/sample/memory/ask \
   -H 'Content-Type: application/json' \
-  -d '{"stateKey":"demo-user","text":"green tea"}'
+  -d '{"stateKey":"demo-user","text":"What drink does the user prefer?"}'
 ```
 
 期望响应：
 
-- `rawResults` 中包含 `output=pong`。
-- `modelMessages` 中包含 `the user prefers green tea`。
-- `modelMessages` 中包含 `Relevant memory:`，说明 memory rail 在调用模型前完成了检索和注入。
+- `memoryHits` 中包含 `the user prefers green tea`，说明 memory rail 使用同一个 `stateKey` 检索到了长期记忆。
+- `rawResults` 中是模型真实返回结果，正常情况下应能回答用户偏好是 `green tea`。
 - `records` 中包含本轮用户输入和 assistant 输出，说明执行后触发了 `MemoryProvider.save(...)`。
 
-说明：本样例的 InMemory provider 使用简单字符串匹配，不做向量语义检索；因此 curl 示例使用 `green tea` 作为 query，确保测试团队能稳定观察到记忆注入。
+说明：本样例的 InMemory provider 使用简单字符串匹配和词重叠打分，不做向量语义检索；因此 curl 示例的用户输入和记忆内容都包含 `user/prefer` 这类关键词，确保测试团队能稳定观察到记忆命中。
 
 ---
 
@@ -116,14 +121,17 @@ curl -s 'http://localhost:18081/sample/memory/records?stateKey=demo-user'
 
 - `MemoryInMemoryApplication.java`
 - `SampleMemoryOpenJiuwenHandler#setOpenJiuwenRailFactories(...)`
+- `SampleMemoryOpenJiuwenHandler#buildMemoryRailFactories(...)`
 - `SampleMemoryOpenJiuwenHandler#memoryRail(...)`
 - `InMemoryMemoryProvider`
 
 用户侧要复用这个模式时，核心动作是：
 
 ```java
-handler.setOpenJiuwenRailFactories(List.of(context -> handler.memoryRail(context, memoryProvider)));
+handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(memoryProvider));
 ```
+
+样例不 override `runOpenJiuwenAgent(...)`；handler 执行仍走 `OpenJiuwenAgentRuntimeHandler` 默认 Runner。业务侧只负责拿到自己的 handler，并在执行前把 rails 设置进去。
 
 ---
 

--- a/examples/agent-runtime-middleware-memory-inmemory/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-memory-inmemory/TUTORIAL.cn.md
@@ -94,7 +94,7 @@ curl -s -X POST http://localhost:18081/sample/memory/ask \
 期望响应：
 
 - `memoryHits` 中包含 `the user prefers green tea`，说明 memory rail 使用同一个 `stateKey` 检索到了长期记忆。
-- `rawResults` 中是模型真实返回结果，正常情况下应能回答用户偏好是 `green tea`。
+- `agentOutputs` 中是模型真实返回结果，正常情况下应能回答用户偏好是 `green tea`。
 - `records` 中包含本轮用户输入和 assistant 输出，说明执行后触发了 `MemoryProvider.save(...)`。
 
 说明：本样例的 InMemory provider 使用简单字符串匹配和词重叠打分，不做向量语义检索；因此 curl 示例的用户输入和记忆内容都包含 `user/prefer` 这类关键词，确保测试团队能稳定观察到记忆命中。

--- a/examples/agent-runtime-middleware-memory-inmemory/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-memory-inmemory/TUTORIAL.cn.md
@@ -120,18 +120,18 @@ curl -s 'http://localhost:18081/sample/memory/records?stateKey=demo-user'
 关键代码在：
 
 - `MemoryInMemoryApplication.java`
-- `SampleMemoryOpenJiuwenHandler#setOpenJiuwenRailFactories(...)`
-- `SampleMemoryOpenJiuwenHandler#buildMemoryRailFactories(...)`
-- `SampleMemoryOpenJiuwenHandler#memoryRail(...)`
+- `SampleMemoryOpenJiuwenHandler#openJiuwenRails(...)`
 - `InMemoryMemoryProvider`
 
-用户侧要复用这个模式时，核心动作是：
+用户侧要复用这个模式时，核心动作是让 handler 持有 `MemoryProvider`，并在每次执行时基于当前 `AgentExecutionContext` 创建 memory rail：
 
 ```java
-handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(memoryProvider));
+protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
+    return List.of(memoryRuntimeRail(context, memoryProvider));
+}
 ```
 
-样例不 override `runOpenJiuwenAgent(...)`；handler 执行仍走 `OpenJiuwenAgentRuntimeHandler` 默认 Runner。业务侧只负责拿到自己的 handler，并在执行前把 rails 设置进去。
+样例不 override `runOpenJiuwenAgent(...)`；handler 执行仍走 `OpenJiuwenAgentRuntimeHandler` 默认 Runner。业务侧只负责把自己的 `MemoryProvider` 接到 handler 上。
 
 ---
 

--- a/examples/agent-runtime-middleware-memory-inmemory/pom.xml
+++ b/examples/agent-runtime-middleware-memory-inmemory/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.huawei.ascend</groupId>
     <artifactId>spring-ai-ascend-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -31,9 +31,30 @@
       <version>0.1.12-jdk17</version>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.33.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <mainClass>com.huawei.ascend.examples.runtime.middleware.memory.inmemory.MemoryInMemoryApplication</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/examples/agent-runtime-middleware-memory-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryApplication.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryApplication.java
@@ -68,34 +68,34 @@ class MemoryInMemoryController {
 
     @PostMapping("/sample/memory/remember")
     Map<String, Object> remember(@RequestBody MemoryRequest request) {
-        AgentExecutionContext context = context(request.stateKey(), request.text());
-        memoryProvider.init(context);
-        memoryProvider.save(context, List.of(new MemoryProvider.MemoryRecord(
+        AgentExecutionContext executionContext = buildExecutionContext(request.stateKey(), request.text());
+        memoryProvider.init(executionContext);
+        memoryProvider.save(executionContext, List.of(new MemoryProvider.MemoryRecord(
                 null, "assistant", request.text(), Map.of("source", "curl"))));
         return Map.of(
-                "stateKey", context.getAgentStateKey(),
-                "records", memoryProvider.records(context));
+                "stateKey", executionContext.getAgentStateKey(),
+                "records", memoryProvider.records(executionContext));
     }
 
     @PostMapping("/sample/memory/ask")
     Map<String, Object> ask(@RequestBody MemoryRequest request) {
-        AgentExecutionContext context = context(request.stateKey(), request.text());
-        List<?> rawResults = handler.execute(context).toList();
+        AgentExecutionContext executionContext = buildExecutionContext(request.stateKey(), request.text());
+        List<?> agentOutputs = handler.execute(executionContext).toList();
         return Map.of(
-                "stateKey", context.getAgentStateKey(),
+                "stateKey", executionContext.getAgentStateKey(),
                 "query", request.text(),
-                "rawResults", rawResults,
-                "memoryHits", memoryProvider.search(context, request.text(), 5),
-                "records", memoryProvider.records(context));
+                "agentOutputs", agentOutputs,
+                "memoryHits", memoryProvider.search(executionContext, request.text(), 5),
+                "records", memoryProvider.records(executionContext));
     }
 
     @GetMapping("/sample/memory/records")
     Map<String, Object> records(@RequestParam(defaultValue = "demo-user") String stateKey) {
-        AgentExecutionContext context = context(stateKey, "");
-        return Map.of("stateKey", stateKey, "records", memoryProvider.records(context));
+        AgentExecutionContext executionContext = buildExecutionContext(stateKey, "");
+        return Map.of("stateKey", stateKey, "records", memoryProvider.records(executionContext));
     }
 
-    private static AgentExecutionContext context(String stateKey, String text) {
+    private static AgentExecutionContext buildExecutionContext(String stateKey, String text) {
         RuntimeIdentity identity =
                 new RuntimeIdentity("sample-tenant", "sample-user", "sample-session", "sample-task",
                         "middleware-memory-inmemory-agent");

--- a/examples/agent-runtime-middleware-memory-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryApplication.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryApplication.java
@@ -1,0 +1,246 @@
+package com.huawei.ascend.examples.runtime.middleware.memory.inmemory;
+
+import com.huawei.ascend.runtime.common.RuntimeIdentity;
+import com.huawei.ascend.runtime.common.RuntimeMessage;
+import com.huawei.ascend.runtime.engine.AgentExecutionContext;
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenAgentRuntimeHandler;
+import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
+import com.openjiuwen.core.foundation.llm.Model;
+import com.openjiuwen.core.foundation.llm.model_clients.BaseModelClient;
+import com.openjiuwen.core.foundation.llm.output_parsers.BaseOutputParser;
+import com.openjiuwen.core.foundation.llm.schema.AssistantMessage;
+import com.openjiuwen.core.foundation.llm.schema.AssistantMessageChunk;
+import com.openjiuwen.core.foundation.llm.schema.AudioGenerationResponse;
+import com.openjiuwen.core.foundation.llm.schema.BaseMessage;
+import com.openjiuwen.core.foundation.llm.schema.ImageGenerationResponse;
+import com.openjiuwen.core.foundation.llm.schema.ModelClientConfig;
+import com.openjiuwen.core.foundation.llm.schema.ModelRequestConfig;
+import com.openjiuwen.core.foundation.llm.schema.UserMessage;
+import com.openjiuwen.core.foundation.llm.schema.VideoGenerationResponse;
+import com.openjiuwen.core.session.AgentSessionApi;
+import com.openjiuwen.core.session.stream.StreamMode;
+import com.openjiuwen.core.singleagent.BaseAgent;
+import com.openjiuwen.core.singleagent.agents.ReActAgent;
+import com.openjiuwen.core.singleagent.agents.ReActAgentConfig;
+import com.openjiuwen.core.singleagent.rail.AgentRail;
+import com.openjiuwen.core.singleagent.schema.AgentCard;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+public class MemoryInMemoryApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MemoryInMemoryApplication.class, args);
+    }
+}
+
+@Configuration(proxyBeanMethods = false)
+class MemoryInMemoryConfiguration {
+    private static final String AGENT_ID = "middleware-memory-inmemory-agent";
+
+    @Bean
+    InMemoryMemoryProvider memoryProvider() {
+        return new InMemoryMemoryProvider();
+    }
+
+    @Bean
+    SampleMemoryOpenJiuwenHandler sampleHandler(InMemoryMemoryProvider memoryProvider) {
+        SampleMemoryOpenJiuwenHandler handler = new SampleMemoryOpenJiuwenHandler(AGENT_ID);
+        handler.setOpenJiuwenRailFactories(List.of(context -> handler.memoryRail(context, memoryProvider)));
+        return handler;
+    }
+
+    @Bean
+    Object sampleModelFactoryRegistration() {
+        SampleModelClient.ensureRegistered();
+        return new Object();
+    }
+}
+
+@RestController
+class MemoryInMemoryController {
+    private final InMemoryMemoryProvider memoryProvider;
+    private final SampleMemoryOpenJiuwenHandler handler;
+
+    MemoryInMemoryController(InMemoryMemoryProvider memoryProvider, SampleMemoryOpenJiuwenHandler handler) {
+        this.memoryProvider = memoryProvider;
+        this.handler = handler;
+    }
+
+    @PostMapping("/sample/memory/remember")
+    Map<String, Object> remember(@RequestBody MemoryRequest request) {
+        AgentExecutionContext context = context(request.stateKey(), request.text());
+        memoryProvider.init(context);
+        memoryProvider.save(context, List.of(new MemoryProvider.MemoryRecord(
+                null, "assistant", request.text(), Map.of("source", "curl"))));
+        return Map.of(
+                "stateKey", context.getAgentStateKey(),
+                "records", memoryProvider.records(context));
+    }
+
+    @PostMapping("/sample/memory/ask")
+    Map<String, Object> ask(@RequestBody MemoryRequest request) {
+        AgentExecutionContext context = context(request.stateKey(), request.text());
+        List<?> rawResults = handler.execute(context).toList();
+        return Map.of(
+                "stateKey", context.getAgentStateKey(),
+                "query", request.text(),
+                "rawResults", rawResults,
+                "modelMessages", SampleModelClient.capturedMessages(),
+                "records", memoryProvider.records(context));
+    }
+
+    @GetMapping("/sample/memory/records")
+    Map<String, Object> records(@RequestParam(defaultValue = "demo-user") String stateKey) {
+        AgentExecutionContext context = context(stateKey, "");
+        return Map.of("stateKey", stateKey, "records", memoryProvider.records(context));
+    }
+
+    private static AgentExecutionContext context(String stateKey, String text) {
+        RuntimeIdentity identity =
+                new RuntimeIdentity("sample-tenant", "sample-user", "sample-session", "sample-task",
+                        "middleware-memory-inmemory-agent");
+        return new AgentExecutionContext(identity, "USER_MESSAGE",
+                List.of(RuntimeMessage.user(text == null ? "" : text)), Map.of(), normalizeStateKey(stateKey), null);
+    }
+
+    private static String normalizeStateKey(String stateKey) {
+        return stateKey == null || stateKey.isBlank() ? "demo-user" : stateKey;
+    }
+
+    record MemoryRequest(String stateKey, String text) {
+    }
+}
+
+final class SampleMemoryOpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler {
+    private static final String MODEL_PROVIDER = "sample-memory-inmemory-model";
+    private final String agentId;
+    private List<Function<AgentExecutionContext, AgentRail>> railFactories = List.of();
+
+    SampleMemoryOpenJiuwenHandler(String agentId) {
+        super(agentId);
+        this.agentId = agentId;
+    }
+
+    void setOpenJiuwenRailFactories(List<Function<AgentExecutionContext, AgentRail>> railFactories) {
+        this.railFactories = List.copyOf(Objects.requireNonNull(railFactories, "railFactories"));
+    }
+
+    AgentRail memoryRail(AgentExecutionContext context, MemoryProvider provider) {
+        return memoryRuntimeRail(context, provider);
+    }
+
+    @Override
+    protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
+        return railFactories.stream().map(factory -> factory.apply(context)).toList();
+    }
+
+    @Override
+    protected BaseAgent createOpenJiuwenAgent(AgentExecutionContext context) {
+        ReActAgent agent = new ReActAgent(AgentCard.builder()
+                .id(agentId)
+                .name(agentId)
+                .description("InMemory MemoryProvider curl example")
+                .build());
+        ReActAgentConfig config = ReActAgentConfig.builder()
+                .promptTemplate(List.of(Map.of("role", "system", "content",
+                        "You are a deterministic middleware memory example. Reply exactly pong.")))
+                .maxIterations(1)
+                .build()
+                .configureModelClient(MODEL_PROVIDER, "sample-key", "http://localhost", "sample-model", false);
+        agent.configure(config);
+        return agent;
+    }
+
+    @Override
+    protected Object runOpenJiuwenAgent(BaseAgent agent, Object input, String conversationId) {
+        Iterator<Object> output = agent.stream(input, AgentSessionApi.create(conversationId, null, agent.getCard()),
+                List.of(StreamMode.OUTPUT));
+        output.forEachRemaining(ignored -> { });
+        return Map.of("result_type", "answer", "output", "pong");
+    }
+}
+
+final class SampleModelClient extends BaseModelClient {
+    private static final AtomicBoolean REGISTERED = new AtomicBoolean(false);
+    private static final CopyOnWriteArrayList<String> CAPTURED_MESSAGES = new CopyOnWriteArrayList<>();
+
+    private SampleModelClient(ModelRequestConfig modelConfig, ModelClientConfig clientConfig) {
+        super(modelConfig, clientConfig);
+    }
+
+    static void ensureRegistered() {
+        if (REGISTERED.compareAndSet(false, true)) {
+            Model.registerFactory(new Model.ModelClientFactory() {
+                @Override
+                public String providerName() {
+                    return "sample-memory-inmemory-model";
+                }
+
+                @Override
+                public BaseModelClient create(ModelRequestConfig modelConfig, ModelClientConfig clientConfig) {
+                    return new SampleModelClient(modelConfig, clientConfig);
+                }
+            });
+        }
+    }
+
+    static List<String> capturedMessages() {
+        return List.copyOf(CAPTURED_MESSAGES);
+    }
+
+    @Override
+    public AssistantMessage invoke(Object messages, Object tools, Float temperature, Float topP, String model,
+            Integer maxTokens, String stop, BaseOutputParser outputParser, Float timeout, Map<String, Object> kwargs) {
+        CAPTURED_MESSAGES.clear();
+        if (messages instanceof List<?> list) {
+            list.stream()
+                    .filter(BaseMessage.class::isInstance)
+                    .map(BaseMessage.class::cast)
+                    .map(BaseMessage::getContentAsString)
+                    .forEach(CAPTURED_MESSAGES::add);
+        }
+        return new AssistantMessage("pong");
+    }
+
+    @Override
+    public Iterator<AssistantMessageChunk> stream(Object messages, Object tools, Float temperature, Float topP,
+            String model, Integer maxTokens, String stop, BaseOutputParser outputParser, Float timeout,
+            Map<String, Object> kwargs) {
+        return List.<AssistantMessageChunk>of().iterator();
+    }
+
+    @Override
+    public ImageGenerationResponse generateImage(List<UserMessage> messages, String model, String size,
+            String negativePrompt, int n, boolean promptExtend, boolean watermark, int seed,
+            Map<String, Object> kwargs) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AudioGenerationResponse generateSpeech(List<UserMessage> messages, String model, String voice,
+            String languageType, Map<String, Object> kwargs) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VideoGenerationResponse generateVideo(List<UserMessage> messages, String imgUrl, String audioUrl,
+            String model, String size, String resolution, int duration, boolean promptExtend, boolean watermark,
+            String negativePrompt, Integer seed, Map<String, Object> kwargs) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/examples/agent-runtime-middleware-memory-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryApplication.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryApplication.java
@@ -5,32 +5,17 @@ import com.huawei.ascend.runtime.common.RuntimeMessage;
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
 import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenAgentRuntimeHandler;
 import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
-import com.openjiuwen.core.foundation.llm.Model;
-import com.openjiuwen.core.foundation.llm.model_clients.BaseModelClient;
-import com.openjiuwen.core.foundation.llm.output_parsers.BaseOutputParser;
-import com.openjiuwen.core.foundation.llm.schema.AssistantMessage;
-import com.openjiuwen.core.foundation.llm.schema.AssistantMessageChunk;
-import com.openjiuwen.core.foundation.llm.schema.AudioGenerationResponse;
-import com.openjiuwen.core.foundation.llm.schema.BaseMessage;
-import com.openjiuwen.core.foundation.llm.schema.ImageGenerationResponse;
-import com.openjiuwen.core.foundation.llm.schema.ModelClientConfig;
 import com.openjiuwen.core.foundation.llm.schema.ModelRequestConfig;
-import com.openjiuwen.core.foundation.llm.schema.UserMessage;
-import com.openjiuwen.core.foundation.llm.schema.VideoGenerationResponse;
-import com.openjiuwen.core.session.AgentSessionApi;
-import com.openjiuwen.core.session.stream.StreamMode;
 import com.openjiuwen.core.singleagent.BaseAgent;
 import com.openjiuwen.core.singleagent.agents.ReActAgent;
 import com.openjiuwen.core.singleagent.agents.ReActAgentConfig;
 import com.openjiuwen.core.singleagent.rail.AgentRail;
 import com.openjiuwen.core.singleagent.schema.AgentCard;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
@@ -58,16 +43,20 @@ class MemoryInMemoryConfiguration {
     }
 
     @Bean
-    SampleMemoryOpenJiuwenHandler sampleHandler(InMemoryMemoryProvider memoryProvider) {
-        SampleMemoryOpenJiuwenHandler handler = new SampleMemoryOpenJiuwenHandler(AGENT_ID);
-        handler.setOpenJiuwenRailFactories(List.of(context -> handler.memoryRail(context, memoryProvider)));
+    SampleMemoryOpenJiuwenHandler sampleHandler(
+            @Value("${sample.openjiuwen.model-provider:${SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER:openai}}")
+            String modelProvider,
+            @Value("${sample.openjiuwen.api-key:${SAA_SAMPLE_LLM_API_KEY:}}") String apiKey,
+            @Value("${sample.openjiuwen.api-base:${SAA_SAMPLE_OPENJIUWEN_API_BASE:https://api.deepseek.com}}")
+            String apiBase,
+            @Value("${sample.openjiuwen.model-name:${SAA_SAMPLE_LLM_MODEL:deepseek-chat}}") String modelName,
+            @Value("${sample.openjiuwen.ssl-verify:${SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY:false}}")
+            boolean sslVerify,
+            InMemoryMemoryProvider memoryProvider) {
+        SampleMemoryOpenJiuwenHandler handler =
+                new SampleMemoryOpenJiuwenHandler(AGENT_ID, modelProvider, apiKey, apiBase, modelName, sslVerify);
+        handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(memoryProvider));
         return handler;
-    }
-
-    @Bean
-    Object sampleModelFactoryRegistration() {
-        SampleModelClient.ensureRegistered();
-        return new Object();
     }
 }
 
@@ -100,7 +89,7 @@ class MemoryInMemoryController {
                 "stateKey", context.getAgentStateKey(),
                 "query", request.text(),
                 "rawResults", rawResults,
-                "modelMessages", SampleModelClient.capturedMessages(),
+                "memoryHits", memoryProvider.search(context, request.text(), 5),
                 "records", memoryProvider.records(context));
     }
 
@@ -127,17 +116,36 @@ class MemoryInMemoryController {
 }
 
 final class SampleMemoryOpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler {
-    private static final String MODEL_PROVIDER = "sample-memory-inmemory-model";
     private final String agentId;
+    private final String modelProvider;
+    private final String apiKey;
+    private final String apiBase;
+    private final String modelName;
+    private final boolean sslVerify;
     private List<Function<AgentExecutionContext, AgentRail>> railFactories = List.of();
 
-    SampleMemoryOpenJiuwenHandler(String agentId) {
+    SampleMemoryOpenJiuwenHandler(
+            String agentId,
+            String modelProvider,
+            String apiKey,
+            String apiBase,
+            String modelName,
+            boolean sslVerify) {
         super(agentId);
         this.agentId = agentId;
+        this.modelProvider = modelProvider;
+        this.apiKey = apiKey;
+        this.apiBase = apiBase;
+        this.modelName = modelName;
+        this.sslVerify = sslVerify;
     }
 
     void setOpenJiuwenRailFactories(List<Function<AgentExecutionContext, AgentRail>> railFactories) {
         this.railFactories = List.copyOf(Objects.requireNonNull(railFactories, "railFactories"));
+    }
+
+    List<Function<AgentExecutionContext, AgentRail>> buildMemoryRailFactories(MemoryProvider provider) {
+        return List.of(context -> memoryRail(context, provider));
     }
 
     AgentRail memoryRail(AgentExecutionContext context, MemoryProvider provider) {
@@ -158,89 +166,18 @@ final class SampleMemoryOpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler 
                 .build());
         ReActAgentConfig config = ReActAgentConfig.builder()
                 .promptTemplate(List.of(Map.of("role", "system", "content",
-                        "You are a deterministic middleware memory example. Reply exactly pong.")))
-                .maxIterations(1)
+                        """
+                        You are a middleware memory example assistant.
+                        Answer the user's question using relevant memory when it is provided.
+                        If the user asks for a preference, answer with the remembered preference directly.
+                        """)))
+                .maxIterations(3)
                 .build()
-                .configureModelClient(MODEL_PROVIDER, "sample-key", "http://localhost", "sample-model", false);
+                .configureModelClient(modelProvider, apiKey, apiBase, modelName, sslVerify);
+        ModelRequestConfig modelConfig = config.getModelConfigObj();
+        modelConfig.setTemperature(0.0);
+        modelConfig.setMaxTokens(128);
         agent.configure(config);
         return agent;
-    }
-
-    @Override
-    protected Object runOpenJiuwenAgent(BaseAgent agent, Object input, String conversationId) {
-        Iterator<Object> output = agent.stream(input, AgentSessionApi.create(conversationId, null, agent.getCard()),
-                List.of(StreamMode.OUTPUT));
-        output.forEachRemaining(ignored -> { });
-        return Map.of("result_type", "answer", "output", "pong");
-    }
-}
-
-final class SampleModelClient extends BaseModelClient {
-    private static final AtomicBoolean REGISTERED = new AtomicBoolean(false);
-    private static final CopyOnWriteArrayList<String> CAPTURED_MESSAGES = new CopyOnWriteArrayList<>();
-
-    private SampleModelClient(ModelRequestConfig modelConfig, ModelClientConfig clientConfig) {
-        super(modelConfig, clientConfig);
-    }
-
-    static void ensureRegistered() {
-        if (REGISTERED.compareAndSet(false, true)) {
-            Model.registerFactory(new Model.ModelClientFactory() {
-                @Override
-                public String providerName() {
-                    return "sample-memory-inmemory-model";
-                }
-
-                @Override
-                public BaseModelClient create(ModelRequestConfig modelConfig, ModelClientConfig clientConfig) {
-                    return new SampleModelClient(modelConfig, clientConfig);
-                }
-            });
-        }
-    }
-
-    static List<String> capturedMessages() {
-        return List.copyOf(CAPTURED_MESSAGES);
-    }
-
-    @Override
-    public AssistantMessage invoke(Object messages, Object tools, Float temperature, Float topP, String model,
-            Integer maxTokens, String stop, BaseOutputParser outputParser, Float timeout, Map<String, Object> kwargs) {
-        CAPTURED_MESSAGES.clear();
-        if (messages instanceof List<?> list) {
-            list.stream()
-                    .filter(BaseMessage.class::isInstance)
-                    .map(BaseMessage.class::cast)
-                    .map(BaseMessage::getContentAsString)
-                    .forEach(CAPTURED_MESSAGES::add);
-        }
-        return new AssistantMessage("pong");
-    }
-
-    @Override
-    public Iterator<AssistantMessageChunk> stream(Object messages, Object tools, Float temperature, Float topP,
-            String model, Integer maxTokens, String stop, BaseOutputParser outputParser, Float timeout,
-            Map<String, Object> kwargs) {
-        return List.<AssistantMessageChunk>of().iterator();
-    }
-
-    @Override
-    public ImageGenerationResponse generateImage(List<UserMessage> messages, String model, String size,
-            String negativePrompt, int n, boolean promptExtend, boolean watermark, int seed,
-            Map<String, Object> kwargs) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public AudioGenerationResponse generateSpeech(List<UserMessage> messages, String model, String voice,
-            String languageType, Map<String, Object> kwargs) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public VideoGenerationResponse generateVideo(List<UserMessage> messages, String imgUrl, String audioUrl,
-            String model, String size, String resolution, int duration, boolean promptExtend, boolean watermark,
-            String negativePrompt, Integer seed, Map<String, Object> kwargs) {
-        throw new UnsupportedOperationException();
     }
 }

--- a/examples/agent-runtime-middleware-memory-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryApplication.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryApplication.java
@@ -13,8 +13,6 @@ import com.openjiuwen.core.singleagent.rail.AgentRail;
 import com.openjiuwen.core.singleagent.schema.AgentCard;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -53,10 +51,8 @@ class MemoryInMemoryConfiguration {
             @Value("${sample.openjiuwen.ssl-verify:${SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY:false}}")
             boolean sslVerify,
             InMemoryMemoryProvider memoryProvider) {
-        SampleMemoryOpenJiuwenHandler handler =
-                new SampleMemoryOpenJiuwenHandler(AGENT_ID, modelProvider, apiKey, apiBase, modelName, sslVerify);
-        handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(memoryProvider));
-        return handler;
+        return new SampleMemoryOpenJiuwenHandler(
+                AGENT_ID, modelProvider, apiKey, apiBase, modelName, sslVerify, memoryProvider);
     }
 }
 
@@ -122,7 +118,7 @@ final class SampleMemoryOpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler 
     private final String apiBase;
     private final String modelName;
     private final boolean sslVerify;
-    private List<Function<AgentExecutionContext, AgentRail>> railFactories = List.of();
+    private final MemoryProvider memoryProvider;
 
     SampleMemoryOpenJiuwenHandler(
             String agentId,
@@ -130,7 +126,8 @@ final class SampleMemoryOpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler 
             String apiKey,
             String apiBase,
             String modelName,
-            boolean sslVerify) {
+            boolean sslVerify,
+            MemoryProvider memoryProvider) {
         super(agentId);
         this.agentId = agentId;
         this.modelProvider = modelProvider;
@@ -138,23 +135,12 @@ final class SampleMemoryOpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler 
         this.apiBase = apiBase;
         this.modelName = modelName;
         this.sslVerify = sslVerify;
-    }
-
-    void setOpenJiuwenRailFactories(List<Function<AgentExecutionContext, AgentRail>> railFactories) {
-        this.railFactories = List.copyOf(Objects.requireNonNull(railFactories, "railFactories"));
-    }
-
-    List<Function<AgentExecutionContext, AgentRail>> buildMemoryRailFactories(MemoryProvider provider) {
-        return List.of(context -> memoryRail(context, provider));
-    }
-
-    AgentRail memoryRail(AgentExecutionContext context, MemoryProvider provider) {
-        return memoryRuntimeRail(context, provider);
+        this.memoryProvider = memoryProvider;
     }
 
     @Override
     protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
-        return railFactories.stream().map(factory -> factory.apply(context)).toList();
+        return List.of(memoryRuntimeRail(context, memoryProvider));
     }
 
     @Override

--- a/examples/agent-runtime-middleware-memory-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryApplication.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryApplication.java
@@ -140,7 +140,13 @@ final class SampleMemoryOpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler 
 
     @Override
     protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
-        return List.of(memoryRuntimeRail(context, memoryProvider));
+        // OpenJiuwenAgentRuntimeHandler#doExecute calls installRails(...),
+        // which registers each returned rail on the concrete OpenJiuwen agent.
+        return List.of(createMemoryRail(context));
+    }
+
+    private AgentRail createMemoryRail(AgentExecutionContext context) {
+        return memoryRuntimeRail(context, memoryProvider);
     }
 
     @Override

--- a/examples/agent-runtime-middleware-memory-inmemory/src/main/resources/application.yaml
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/main/resources/application.yaml
@@ -1,0 +1,2 @@
+server:
+  port: 18081

--- a/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
@@ -1,41 +1,58 @@
 package com.huawei.ascend.examples.runtime.middleware.memory.inmemory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
 import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("manual")
 class MemoryInMemoryExampleTest {
 
     @Test
     void inMemoryMemoryProviderWorksThroughOpenJiuwenHandlerExecution() {
+        assumeTrue(hasText(System.getenv("SAA_SAMPLE_LLM_API_KEY")),
+                "Set SAA_SAMPLE_LLM_API_KEY to run the real LLM example");
         InMemoryMemoryProvider provider = new InMemoryMemoryProvider();
         AgentExecutionContext first = MiddlewareTestFixtures.context("memory-state-a");
         AgentExecutionContext second = MiddlewareTestFixtures.context("memory-state-b");
         provider.save(first, List.of(record("the user prefers green tea")));
         provider.save(second, List.of(record("the user prefers black coffee")));
-        SampleModelClient.ensureRegistered();
-        SampleMemoryOpenJiuwenHandler handler = new SampleMemoryOpenJiuwenHandler("openjiuwen-simple-agent");
-        handler.setOpenJiuwenRailFactories(List.of(context -> handler.memoryRail(context, provider)));
+        SampleMemoryOpenJiuwenHandler handler = new SampleMemoryOpenJiuwenHandler(
+                "openjiuwen-simple-agent",
+                envOrDefault("SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER", "openai"),
+                System.getenv("SAA_SAMPLE_LLM_API_KEY"),
+                envOrDefault("SAA_SAMPLE_OPENJIUWEN_API_BASE", "https://api.deepseek.com"),
+                envOrDefault("SAA_SAMPLE_LLM_MODEL", "deepseek-chat"),
+                Boolean.parseBoolean(envOrDefault("SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY", "false")));
+        handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(provider));
 
         List<?> rawResults = handler.execute(first).toList();
 
-        assertThat(rawResults).singleElement().isEqualTo(Map.of("result_type", "answer", "output", "pong"));
+        assertThat(rawResults).isNotEmpty();
         assertThat(provider.search(first, "black coffee", 3)).isEmpty();
         assertThat(provider.search(first, "green tea", 3))
                 .first()
                 .satisfies(hit -> assertThat(hit.content()).contains("green tea"));
         assertThat(provider.records(first))
                 .extracting(MemoryProvider.MemoryRecord::content)
-                .contains("the user prefers green tea", "green tea", "pong");
-        assertThat(SampleModelClient.capturedMessages())
-                .anySatisfy(message -> assertThat(message).contains("the user prefers green tea"));
+                .contains("the user prefers green tea", "green tea");
     }
 
     private static MemoryProvider.MemoryRecord record(String content) {
         return new MemoryProvider.MemoryRecord(null, "assistant", content, Map.of("source", "test"));
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static String envOrDefault(String key, String fallback) {
+        String value = System.getenv(key);
+        return hasText(value) ? value : fallback;
     }
 }

--- a/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
@@ -39,9 +39,9 @@ class MemoryInMemoryExampleTest {
                 Boolean.parseBoolean(envOrDefault("SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY", "false")),
                 provider);
 
-        List<?> rawResults = handler.execute(greenTeaUserContext).toList();
+        List<?> agentOutputs = handler.execute(greenTeaUserContext).toList();
 
-        assertThat(rawResults).isNotEmpty();
+        assertThat(agentOutputs).isNotEmpty();
         assertThat(provider.search(greenTeaUserContext, "black coffee", 3)).isEmpty();
         assertThat(provider.search(greenTeaUserContext, "green tea", 3))
                 .first()
@@ -49,7 +49,7 @@ class MemoryInMemoryExampleTest {
         assertThat(provider.records(greenTeaUserContext))
                 .extracting(MemoryProvider.MemoryRecord::content)
                 .contains("the user prefers green tea", "green tea");
-        assertThat(judgeAnswer(rawResults)).contains("PASS");
+        assertThat(judgeAnswer(agentOutputs)).contains("PASS");
     }
 
     private static MemoryProvider.MemoryRecord record(String content) {
@@ -65,9 +65,9 @@ class MemoryInMemoryExampleTest {
         return hasText(value) ? value : fallback;
     }
 
-    private static String judgeAnswer(List<?> rawResults) throws Exception {
-        String answer = rawResults.toString();
-        Map<String, Object> request = Map.of(
+    private static String judgeAnswer(List<?> agentOutputs) throws Exception {
+        String agentAnswer = agentOutputs.toString();
+        Map<String, Object> judgeRequest = Map.of(
                 "model", envOrDefault("SAA_SAMPLE_LLM_MODEL", "deepseek-chat"),
                 "temperature", 0,
                 "max_tokens", 16,
@@ -81,22 +81,22 @@ class MemoryInMemoryExampleTest {
 
                                 Answer:
                                 %s
-                                """.formatted(answer))));
-        HttpRequest httpRequest = HttpRequest.newBuilder()
+                                """.formatted(agentAnswer))));
+        HttpRequest judgeHttpRequest = HttpRequest.newBuilder()
                 .uri(URI.create(chatCompletionsUrl(envOrDefault(
                         "SAA_SAMPLE_OPENJIUWEN_API_BASE", "https://api.deepseek.com"))))
                 .header("Authorization", "Bearer " + System.getenv("SAA_SAMPLE_LLM_API_KEY"))
                 .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString(JSON.writeValueAsString(request)))
+                .POST(HttpRequest.BodyPublishers.ofString(JSON.writeValueAsString(judgeRequest)))
                 .build();
-        HttpResponse<String> response = HTTP.send(httpRequest, HttpResponse.BodyHandlers.ofString());
-        assertThat(response.statusCode()).isBetween(200, 299);
-        JsonNode content = JSON.readTree(response.body())
+        HttpResponse<String> judgeResponse = HTTP.send(judgeHttpRequest, HttpResponse.BodyHandlers.ofString());
+        assertThat(judgeResponse.statusCode()).isBetween(200, 299);
+        JsonNode judgeContent = JSON.readTree(judgeResponse.body())
                 .path("choices")
                 .path(0)
                 .path("message")
                 .path("content");
-        return content.asText();
+        return judgeContent.asText();
     }
 
     private static String chatCompletionsUrl(String apiBase) {

--- a/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
@@ -48,7 +48,7 @@ class MemoryInMemoryExampleTest {
                 .satisfies(hit -> assertThat(hit.content()).contains("green tea"));
         assertThat(provider.records(greenTeaUserContext))
                 .extracting(MemoryProvider.MemoryRecord::content)
-                .contains("the user prefers green tea", "green tea");
+                .contains("the user prefers green tea", "What drink does the user prefer?");
         assertThat(judgeAnswer(agentOutputs)).contains("PASS");
     }
 

--- a/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
@@ -3,25 +3,6 @@ package com.huawei.ascend.examples.runtime.middleware.memory.inmemory;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
-import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenAgentRuntimeHandler;
-import com.openjiuwen.core.context.ContextStats;
-import com.openjiuwen.core.context.ContextWindow;
-import com.openjiuwen.core.context.ModelContext;
-import com.openjiuwen.core.context.token.TokenCounter;
-import com.openjiuwen.core.foundation.llm.schema.AssistantMessage;
-import com.openjiuwen.core.foundation.llm.schema.BaseMessage;
-import com.openjiuwen.core.foundation.llm.schema.SystemMessage;
-import com.openjiuwen.core.foundation.llm.schema.UserMessage;
-import com.openjiuwen.core.foundation.tool.Tool;
-import com.openjiuwen.core.foundation.tool.schema.ToolInfo;
-import com.openjiuwen.core.session.Session;
-import com.openjiuwen.core.session.stream.StreamMode;
-import com.openjiuwen.core.singleagent.BaseAgent;
-import com.openjiuwen.core.singleagent.rail.AgentCallbackContext;
-import com.openjiuwen.core.singleagent.rail.AgentRail;
-import com.openjiuwen.core.singleagent.schema.AgentCard;
-import java.util.ArrayList;
-import java.util.Iterator;
 import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
 import java.util.List;
 import java.util.Map;
@@ -34,168 +15,27 @@ class MemoryInMemoryExampleTest {
         InMemoryMemoryProvider provider = new InMemoryMemoryProvider();
         AgentExecutionContext first = MiddlewareTestFixtures.context("memory-state-a");
         AgentExecutionContext second = MiddlewareTestFixtures.context("memory-state-b");
-
-        provider.init(first);
-        provider.init(second);
-        provider.save(first, List.of(new MemoryProvider.MemoryRecord(null, "assistant",
-                "the user prefers green tea", Map.of("source", "test"))));
-        provider.save(second, List.of(new MemoryProvider.MemoryRecord(null, "assistant",
-                "the user prefers black coffee", Map.of("source", "test"))));
-
-        MemoryEnabledHandler handler = new MemoryEnabledHandler(provider);
+        provider.save(first, List.of(record("the user prefers green tea")));
+        provider.save(second, List.of(record("the user prefers black coffee")));
+        SampleModelClient.ensureRegistered();
+        SampleMemoryOpenJiuwenHandler handler = new SampleMemoryOpenJiuwenHandler("openjiuwen-simple-agent");
+        handler.setOpenJiuwenRailFactories(List.of(context -> handler.memoryRail(context, provider)));
 
         List<?> rawResults = handler.execute(first).toList();
 
         assertThat(rawResults).singleElement().isEqualTo(Map.of("result_type", "answer", "output", "pong"));
-        assertThat(handler.agent.registeredRails).hasSize(1);
         assertThat(provider.search(first, "black coffee", 3)).isEmpty();
-        assertThat(provider.records(first))
-                .extracting(MemoryProvider.MemoryRecord::content)
-                .contains("the user prefers green tea", "green tea", "pong");
         assertThat(provider.search(first, "green tea", 3))
                 .first()
                 .satisfies(hit -> assertThat(hit.content()).contains("green tea"));
+        assertThat(provider.records(first))
+                .extracting(MemoryProvider.MemoryRecord::content)
+                .contains("the user prefers green tea", "green tea", "pong");
+        assertThat(SampleModelClient.capturedMessages())
+                .anySatisfy(message -> assertThat(message).contains("the user prefers green tea"));
     }
 
-    private static final class MemoryEnabledHandler extends OpenJiuwenAgentRuntimeHandler {
-        private final InMemoryMemoryProvider provider;
-        private final RecordingAgent agent = new RecordingAgent();
-
-        private MemoryEnabledHandler(InMemoryMemoryProvider provider) {
-            super("openjiuwen-simple-agent");
-            this.provider = provider;
-        }
-
-        @Override
-        protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
-            return List.of(memoryRuntimeRail(context, provider));
-        }
-
-        @Override
-        protected BaseAgent createOpenJiuwenAgent(AgentExecutionContext context) {
-            return agent;
-        }
-
-        @Override
-        protected Object runOpenJiuwenAgent(BaseAgent agent, Object input, String conversationId) {
-            RecordingModelContext modelContext = new RecordingModelContext();
-            modelContext.setMessages(List.of(
-                    new SystemMessage("business policy: keep original system prompt"),
-                    new UserMessage("green tea"),
-                    new AssistantMessage("pong")), true);
-            AgentCallbackContext callbackContext = AgentCallbackContext.builder()
-                    .context(modelContext)
-                    .build();
-            for (AgentRail rail : ((RecordingAgent) agent).registeredRails) {
-                rail.beforeInvoke(callbackContext);
-                rail.afterInvoke(callbackContext);
-            }
-            return Map.of("result_type", "answer", "output", "pong");
-        }
-    }
-
-    private static final class RecordingAgent extends BaseAgent {
-        private final List<AgentRail> registeredRails = new ArrayList<>();
-
-        private RecordingAgent() {
-            super(AgentCard.builder().id("agent").name("agent").description("test").build());
-        }
-
-        @Override
-        public BaseAgent configure(Object config) {
-            return this;
-        }
-
-        @Override
-        public Object getConfig() {
-            return null;
-        }
-
-        @Override
-        public BaseAgent registerRail(AgentRail rail) {
-            registeredRails.add(rail);
-            return this;
-        }
-
-        @Override
-        public Object invoke(Object input, Session session) {
-            return null;
-        }
-
-        @Override
-        public Iterator<Object> stream(Object input, Session session, List<StreamMode> streamModes) {
-            return List.of().iterator();
-        }
-    }
-
-    private static final class RecordingModelContext extends ModelContext {
-        private final List<BaseMessage> messages = new ArrayList<>();
-
-        @Override
-        public int size() {
-            return messages.size();
-        }
-
-        @Override
-        public List<BaseMessage> getMessages(Integer size, boolean withHistory) {
-            return List.copyOf(messages);
-        }
-
-        @Override
-        public void setMessages(List<BaseMessage> messages, boolean withHistory) {
-            this.messages.clear();
-            this.messages.addAll(messages);
-        }
-
-        @Override
-        public List<BaseMessage> popMessages(int size, boolean withHistory) {
-            return List.of();
-        }
-
-        @Override
-        public void clearMessages(boolean withHistory) {
-            messages.clear();
-        }
-
-        @Override
-        public List<BaseMessage> addMessages(List<BaseMessage> messages) {
-            this.messages.addAll(messages);
-            return List.copyOf(this.messages);
-        }
-
-        @Override
-        public ContextWindow getContextWindow(
-                List<BaseMessage> systemMessages,
-                List<ToolInfo> tools,
-                Integer windowSize,
-                Integer dialogueRound,
-                Map<String, Object> kwargs) {
-            return null;
-        }
-
-        @Override
-        public ContextStats statistic() {
-            return null;
-        }
-
-        @Override
-        public String sessionId() {
-            return "test-session";
-        }
-
-        @Override
-        public String contextId() {
-            return "test-context";
-        }
-
-        @Override
-        public TokenCounter tokenCounter() {
-            return null;
-        }
-
-        @Override
-        public Tool reloaderTool() {
-            return null;
-        }
+    private static MemoryProvider.MemoryRecord record(String content) {
+        return new MemoryProvider.MemoryRecord(null, "assistant", content, Map.of("source", "test"));
     }
 }

--- a/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
@@ -26,10 +26,10 @@ class MemoryInMemoryExampleTest {
         assumeTrue(hasText(System.getenv("SAA_SAMPLE_LLM_API_KEY")),
                 "Set SAA_SAMPLE_LLM_API_KEY to run the real LLM example");
         InMemoryMemoryProvider provider = new InMemoryMemoryProvider();
-        AgentExecutionContext first = MiddlewareTestFixtures.context("memory-state-a");
-        AgentExecutionContext second = MiddlewareTestFixtures.context("memory-state-b");
-        provider.save(first, List.of(record("the user prefers green tea")));
-        provider.save(second, List.of(record("the user prefers black coffee")));
+        AgentExecutionContext greenTeaUserContext = MiddlewareTestFixtures.context("memory-state-a");
+        AgentExecutionContext coffeeUserContext = MiddlewareTestFixtures.context("memory-state-b");
+        provider.save(greenTeaUserContext, List.of(record("the user prefers green tea")));
+        provider.save(coffeeUserContext, List.of(record("the user prefers black coffee")));
         SampleMemoryOpenJiuwenHandler handler = new SampleMemoryOpenJiuwenHandler(
                 "openjiuwen-simple-agent",
                 envOrDefault("SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER", "openai"),
@@ -39,14 +39,14 @@ class MemoryInMemoryExampleTest {
                 Boolean.parseBoolean(envOrDefault("SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY", "false")),
                 provider);
 
-        List<?> rawResults = handler.execute(first).toList();
+        List<?> rawResults = handler.execute(greenTeaUserContext).toList();
 
         assertThat(rawResults).isNotEmpty();
-        assertThat(provider.search(first, "black coffee", 3)).isEmpty();
-        assertThat(provider.search(first, "green tea", 3))
+        assertThat(provider.search(greenTeaUserContext, "black coffee", 3)).isEmpty();
+        assertThat(provider.search(greenTeaUserContext, "green tea", 3))
                 .first()
                 .satisfies(hit -> assertThat(hit.content()).contains("green tea"));
-        assertThat(provider.records(first))
+        assertThat(provider.records(greenTeaUserContext))
                 .extracting(MemoryProvider.MemoryRecord::content)
                 .contains("the user prefers green tea", "green tea");
         assertThat(judgeAnswer(rawResults)).contains("PASS");

--- a/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
@@ -36,8 +36,8 @@ class MemoryInMemoryExampleTest {
                 System.getenv("SAA_SAMPLE_LLM_API_KEY"),
                 envOrDefault("SAA_SAMPLE_OPENJIUWEN_API_BASE", "https://api.deepseek.com"),
                 envOrDefault("SAA_SAMPLE_LLM_MODEL", "deepseek-chat"),
-                Boolean.parseBoolean(envOrDefault("SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY", "false")));
-        handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(provider));
+                Boolean.parseBoolean(envOrDefault("SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY", "false")),
+                provider);
 
         List<?> rawResults = handler.execute(first).toList();
 

--- a/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MemoryInMemoryExampleTest.java
@@ -3,8 +3,14 @@ package com.huawei.ascend.examples.runtime.middleware.memory.inmemory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
 import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Tag;
@@ -12,9 +18,11 @@ import org.junit.jupiter.api.Test;
 
 @Tag("manual")
 class MemoryInMemoryExampleTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final HttpClient HTTP = HttpClient.newHttpClient();
 
     @Test
-    void inMemoryMemoryProviderWorksThroughOpenJiuwenHandlerExecution() {
+    void inMemoryMemoryProviderWorksThroughOpenJiuwenHandlerExecution() throws Exception {
         assumeTrue(hasText(System.getenv("SAA_SAMPLE_LLM_API_KEY")),
                 "Set SAA_SAMPLE_LLM_API_KEY to run the real LLM example");
         InMemoryMemoryProvider provider = new InMemoryMemoryProvider();
@@ -41,6 +49,7 @@ class MemoryInMemoryExampleTest {
         assertThat(provider.records(first))
                 .extracting(MemoryProvider.MemoryRecord::content)
                 .contains("the user prefers green tea", "green tea");
+        assertThat(judgeAnswer(rawResults)).contains("PASS");
     }
 
     private static MemoryProvider.MemoryRecord record(String content) {
@@ -54,5 +63,47 @@ class MemoryInMemoryExampleTest {
     private static String envOrDefault(String key, String fallback) {
         String value = System.getenv(key);
         return hasText(value) ? value : fallback;
+    }
+
+    private static String judgeAnswer(List<?> rawResults) throws Exception {
+        String answer = rawResults.toString();
+        Map<String, Object> request = Map.of(
+                "model", envOrDefault("SAA_SAMPLE_LLM_MODEL", "deepseek-chat"),
+                "temperature", 0,
+                "max_tokens", 16,
+                "messages", List.of(
+                        Map.of("role", "system", "content",
+                                "You are a strict test judge. Reply exactly PASS or FAIL."),
+                        Map.of("role", "user", "content", """
+                                The memory says: the user prefers green tea.
+                                The user asked about their preference.
+                                Does the answer correctly use the memory and identify green tea as the preference?
+
+                                Answer:
+                                %s
+                                """.formatted(answer))));
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+                .uri(URI.create(chatCompletionsUrl(envOrDefault(
+                        "SAA_SAMPLE_OPENJIUWEN_API_BASE", "https://api.deepseek.com"))))
+                .header("Authorization", "Bearer " + System.getenv("SAA_SAMPLE_LLM_API_KEY"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(JSON.writeValueAsString(request)))
+                .build();
+        HttpResponse<String> response = HTTP.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isBetween(200, 299);
+        JsonNode content = JSON.readTree(response.body())
+                .path("choices")
+                .path(0)
+                .path("message")
+                .path("content");
+        return content.asText();
+    }
+
+    private static String chatCompletionsUrl(String apiBase) {
+        String normalized = String.valueOf(apiBase).replaceAll("/+$", "");
+        if (normalized.endsWith("/chat/completions")) {
+            return normalized;
+        }
+        return normalized + "/chat/completions";
     }
 }

--- a/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MiddlewareTestFixtures.java
+++ b/examples/agent-runtime-middleware-memory-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/inmemory/MiddlewareTestFixtures.java
@@ -13,6 +13,6 @@ final class MiddlewareTestFixtures {
         RuntimeIdentity identity =
                 new RuntimeIdentity("tenant", "user", "session", "task", "openjiuwen-simple-agent");
         return new AgentExecutionContext(identity, "USER_MESSAGE",
-                java.util.List.of(RuntimeMessage.user("green tea")), Map.of(), stateKey, null);
+                java.util.List.of(RuntimeMessage.user("What drink does the user prefer?")), Map.of(), stateKey, null);
     }
 }

--- a/examples/agent-runtime-middleware-memory-mem0/README.md
+++ b/examples/agent-runtime-middleware-memory-mem0/README.md
@@ -9,6 +9,11 @@
 先准备一个兼容 Mem0 REST API 的服务，然后启动样例：
 
 ```bash
+export SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER=openai
+export SAA_SAMPLE_OPENJIUWEN_API_BASE=https://api.deepseek.com
+export SAA_SAMPLE_LLM_MODEL=deepseek-chat
+export SAA_SAMPLE_LLM_API_KEY=sk-your-key
+
 ./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml spring-boot:run \
   -Dspring-boot.run.arguments="--sample.mem0.base-url=http://localhost:8000 --sample.mem0.api-mode=oss --sample.mem0.infer-on-save=false"
 ```
@@ -30,6 +35,7 @@ http://localhost:18082
 ## 设计要点
 
 - 样例通过 `SampleMem0OpenJiuwenHandler#setOpenJiuwenRailFactories(...)` 预设 OpenJiuwen rail。
+- `buildMemoryRailFactories(...)` 负责构建 rails，`setOpenJiuwenRailFactories(...)` 负责把 rails 设置到 handler；执行时不 override `runOpenJiuwenAgent(...)`，仍走 OpenJiuwen 默认 Runner。
 - `Mem0RestMemoryProvider` 是 example 级适配器，用于演示 `MemoryProvider` 如何对接外部长期记忆服务。
 - `sample.mem0.api-mode=oss` 使用 `/memories` 和 `/search`；`sample.mem0.api-mode=platform` 使用 `/v1/memories/` 和 `/v2/memories/search/`。
 - 本样例是面向用户视角的 daemon + curl 验证，不是单元测试替代品。

--- a/examples/agent-runtime-middleware-memory-mem0/README.md
+++ b/examples/agent-runtime-middleware-memory-mem0/README.md
@@ -6,7 +6,8 @@
 
 ## 快速启动
 
-先准备一个兼容 Mem0 REST API 的服务，然后启动样例：
+先准备一个兼容 Mem0 REST API 的服务，然后启动样例。Mem0 服务启动方式、`oss` / `platform`
+两种 API 模式差异，以及后续 curl 验证步骤见 [TUTORIAL.cn.md](TUTORIAL.cn.md)。
 
 ```bash
 export SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER=openai

--- a/examples/agent-runtime-middleware-memory-mem0/README.md
+++ b/examples/agent-runtime-middleware-memory-mem0/README.md
@@ -1,76 +1,35 @@
 # Agent Runtime Memory Mem0 Example
 
-本样例验证 `MemoryProvider` 对接 Mem0-compatible REST 服务的方式。用户启动一个常驻 Spring Boot 进程，通过 curl 触发写入、检索和 OpenJiuwen ReActAgent 执行链路。
+本样例验证 `MemoryProvider` 对接 Mem0-compatible REST 服务的方式。它启动一个常驻 Spring Boot 进程，用户通过 curl 触发写入、检索和 OpenJiuwen ReActAgent 执行链路。
 
-该样例不内置 Mem0 服务；测试团队需要先准备一个兼容 Mem0 OSS REST API 的服务。
+完整 step by step 教程见：[TUTORIAL.cn.md](TUTORIAL.cn.md)。
 
-## 外部环境
+## 快速启动
 
-默认配置：
-
-```text
-mem0.base-url=http://localhost:8000
-mem0.api-key=
-mem0.infer-on-save=false
-```
-
-如果你的 Mem0 服务地址不同，可以在启动时覆盖：
+先准备一个兼容 Mem0 REST API 的服务，然后启动样例：
 
 ```bash
 ./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml spring-boot:run \
-  -Dspring-boot.run.arguments="--mem0.base-url=http://localhost:8000 --mem0.api-key= --mem0.infer-on-save=false"
+  -Dspring-boot.run.arguments="--sample.mem0.base-url=http://localhost:8000 --sample.mem0.api-mode=oss --sample.mem0.infer-on-save=false"
 ```
 
-说明：
-
-- `infer-on-save=false` 表示样例按测试输入直接写入，便于稳定验证。
-- 如果接入真实 Mem0 推理写入能力，可改成 `true`，但验证结果会依赖 Mem0 的抽取策略。
-
-## 启动服务
-
-在仓库根目录执行：
-
-```bash
-./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml spring-boot:run
-```
-
-服务默认监听：
+默认监听：
 
 ```text
 http://localhost:18082
 ```
 
-## curl 验证
+## 主要接口
 
-1. 写入一条长期记忆：
-
-```bash
-curl -s -X POST http://localhost:18082/sample/memory/remember \
-  -H 'Content-Type: application/json' \
-  -d '{"stateKey":"demo-user","text":"the user prefers green tea"}'
-```
-
-2. 查询 Mem0 返回的记忆：
-
-```bash
-curl -s 'http://localhost:18082/sample/memory/search?stateKey=demo-user&query=green%20tea'
-```
-
-3. 模拟用户发起一次请求：
-
-```bash
-curl -s -X POST http://localhost:18082/sample/memory/ask \
-  -H 'Content-Type: application/json' \
-  -d '{"stateKey":"demo-user","text":"green tea"}'
-```
-
-期望响应：
-
-- `modelMessages` 包含 Mem0 检索出的记忆内容。
-- `records` 或 Mem0 后台数据中能看到本轮用户输入和 assistant 输出。
+| 接口 | 用途 |
+|---|---|
+| `POST /sample/memory/remember` | 通过 Mem0 REST 写入一条长期记忆 |
+| `GET /sample/memory/search?stateKey=demo-user&query=green%20tea` | 通过 Mem0 REST 检索记忆 |
+| `POST /sample/memory/ask` | 模拟一次用户请求，并触发 memory rail 检索和注入 |
 
 ## 设计要点
 
 - 样例通过 `SampleMem0OpenJiuwenHandler#setOpenJiuwenRailFactories(...)` 预设 OpenJiuwen rail。
 - `Mem0RestMemoryProvider` 是 example 级适配器，用于演示 `MemoryProvider` 如何对接外部长期记忆服务。
+- `sample.mem0.api-mode=oss` 使用 `/memories` 和 `/search`；`sample.mem0.api-mode=platform` 使用 `/v1/memories/` 和 `/v2/memories/search/`。
 - 本样例是面向用户视角的 daemon + curl 验证，不是单元测试替代品。

--- a/examples/agent-runtime-middleware-memory-mem0/README.md
+++ b/examples/agent-runtime-middleware-memory-mem0/README.md
@@ -1,152 +1,76 @@
-# agent-runtime middleware memory Mem0 example
+# Agent Runtime Memory Mem0 Example
 
-这个样例验证 `MemoryProvider` 对接 Mem0-compatible REST 服务的方式。
-Provider 放在 example 目录中，避免 `agent-runtime` 公共 SPI 直接绑定 Mem0 包名。
+本样例验证 `MemoryProvider` 对接 Mem0-compatible REST 服务的方式。用户启动一个常驻 Spring Boot 进程，通过 curl 触发写入、检索和 OpenJiuwen ReActAgent 执行链路。
 
-## 配置方式
+该样例不内置 Mem0 服务；测试团队需要先准备一个兼容 Mem0 OSS REST API 的服务。
 
-适用场景：
+## 外部环境
 
-- 客户已有 Mem0-compatible REST 服务。
-- 需要把 runtime 的 `MemoryProvider` 窄 SPI 接到外部长期记忆服务。
-- 希望验证 `search` / `save` 的 request/response 映射，而不是把 Mem0 SDK
-  绑定进 runtime 公共层。
-
-核心配置点：
-
-```java
-Mem0RestMemoryProvider provider = new Mem0RestMemoryProvider(
-        "http://localhost:8000",
-        apiKey,
-        false,
-        "oss");
-
-class MemoryEnabledHandler extends OpenJiuwenAgentRuntimeHandler {
-    @Override
-    protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
-        return List.of(memoryRuntimeRail(context, provider));
-    }
-}
-```
-
-参数说明：
-
-| 参数 | 含义 |
-|---|---|
-| `baseUrl` | Mem0-compatible REST 服务地址 |
-| `apiKey` | 鉴权密钥；OSS 本地测试可为空 |
-| `inferOnSave` | 写入时是否让 Mem0 自己推断/抽取长期记忆 |
-| `apiMode` | `oss` 或 `platform`，用于选择不同 REST path 和鉴权 header |
-
-测试团队检查点：
-
-- handler 执行前，provider 向 Mem0 search endpoint 发送检索请求。
-- handler 执行后，provider 向 Mem0 add/memories endpoint 写入本轮记录。
-- 请求里包含 user/session/task/agentStateKey 这类隔离 metadata。
-- `agent-runtime` 公共层只依赖 `MemoryProvider`，不依赖 Mem0 SDK 或包名。
-
-## Environment
-
-该样例必须连接真实 Mem0-compatible REST 服务。自动化测试不会启动内嵌假服务；
-没有设置 `SAA_SAMPLE_MEM0_BASE_URL` 时，测试会通过 JUnit assumption 跳过。
-
-最小配置：
-
-```bash
-export SAA_SAMPLE_MEM0_BASE_URL=http://localhost:8000
-export SAA_SAMPLE_MEM0_API_MODE=oss
-```
-
-如果服务开启鉴权，再设置：
-
-```bash
-export SAA_SAMPLE_MEM0_API_KEY=<your-api-key>
-```
-
-环境变量说明：
-
-| 变量 | 必填 | 默认值 | 说明 |
-|---|---|---|---|
-| `SAA_SAMPLE_MEM0_BASE_URL` | 是 | 无 | Mem0-compatible REST 服务地址；未设置时测试跳过 |
-| `SAA_SAMPLE_MEM0_API_MODE` | 否 | `oss` | REST endpoint 与鉴权 header 形态，支持 `oss` / `platform` |
-| `SAA_SAMPLE_MEM0_API_KEY` | 否 | 空 | 鉴权密钥；本地 OSS 服务未开启鉴权时可为空 |
-
-API mode 对应关系：
-
-| `SAA_SAMPLE_MEM0_API_MODE` | 写入 endpoint | 检索 endpoint | 鉴权 header |
-|---|---|---|---|
-| `oss` | `POST /memories` | `POST /search` | `X-API-Key: <key>` |
-| `platform` | `POST /v1/memories/` | `POST /v2/memories/search/` | `Authorization: Token <key>` |
-
-注意：该样例验证的是 Mem0 OSS/Platform memory REST API，不是 OpenMemory UI
-的 `/api/v1/memories` 管理 API。
-
-## Mem0 service contract
-
-测试团队可以使用官方 Mem0 OSS REST server，也可以使用基于 `mem0ai`
-Python 包封装的本地 REST 服务。无论哪种方式，服务必须真实调用 Mem0 memory
-引擎，不能用固定 JSON response 伪装。
-
-`oss` 模式需要支持：
+默认配置：
 
 ```text
-POST /memories
-  request:  { "messages": [...], "user_id": "...", "agent_id": "...", "run_id": "...", "metadata": {...}, "infer": false }
-  response: Mem0 Memory.add(...) compatible JSON
-
-POST /search
-  request:  { "query": "...", "top_k": 5, "user_id": "...", "agent_id": "...", "run_id": "...", "metadata": {...} }
-  response: Mem0 Memory.search(...) compatible JSON, usually { "results": [...] }
+mem0.base-url=http://localhost:8000
+mem0.api-key=
+mem0.infer-on-save=false
 ```
 
-本地验证过的真实后端形态：
-
-- Qdrant container 提供向量存储。
-- `mem0ai` Python package 提供 `Memory.add(...)` / `Memory.search(...)`。
-- `fastembed` 提供本地 embedding。
-- 一个很薄的 FastAPI/uvicorn wrapper 只负责把 `/memories` 和 `/search`
-  转给 Mem0 `Memory` 对象；wrapper 不生成固定响应。
-
-## Run
-
-无真实 Mem0 服务时，命令应当构建成功并显示测试被跳过：
+如果你的 Mem0 服务地址不同，可以在启动时覆盖：
 
 ```bash
-./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml test
+./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml spring-boot:run \
+  -Dspring-boot.run.arguments="--mem0.base-url=http://localhost:8000 --mem0.api-key= --mem0.infer-on-save=false"
 ```
 
-连接真实 Mem0 OSS-compatible REST 服务时：
+说明：
+
+- `infer-on-save=false` 表示样例按测试输入直接写入，便于稳定验证。
+- 如果接入真实 Mem0 推理写入能力，可改成 `true`，但验证结果会依赖 Mem0 的抽取策略。
+
+## 启动服务
+
+在仓库根目录执行：
 
 ```bash
-export SAA_SAMPLE_MEM0_BASE_URL=http://localhost:8000
-export SAA_SAMPLE_MEM0_API_MODE=oss
-export SAA_SAMPLE_MEM0_API_KEY=
-./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml test
+./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml spring-boot:run
 ```
 
-连接 Mem0 Platform-compatible REST 服务时：
-
-```bash
-export SAA_SAMPLE_MEM0_BASE_URL=https://api.mem0.ai
-export SAA_SAMPLE_MEM0_API_MODE=platform
-export SAA_SAMPLE_MEM0_API_KEY=<your-api-key>
-./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml test
-```
-
-## 端到端链路
+服务默认监听：
 
 ```text
-AgentExecutionContext(user input + agentStateKey)
-  -> OpenJiuwenAgentRuntimeHandler.execute(...)
-  -> openJiuwenRails(context)
-  -> memoryRuntimeRail(context, Mem0RestMemoryProvider)
-  -> POST /search
-  -> OpenJiuwen ModelContext receives memory note
-  -> simulated OpenJiuwen agent response
-  -> POST /memories
-  -> POST /search verifies the saved user-facing memory is queryable
+http://localhost:18082
 ```
 
-这个测试从用户输入进入 handler 开始，经过 OpenJiuwen memory rail，再打到真实
-Mem0-compatible REST 服务。它不是 provider 的孤立单元测试，也不是内嵌 HTTP
-server 的伪装测试。
+## curl 验证
+
+1. 写入一条长期记忆：
+
+```bash
+curl -s -X POST http://localhost:18082/sample/memory/remember \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-user","text":"the user prefers green tea"}'
+```
+
+2. 查询 Mem0 返回的记忆：
+
+```bash
+curl -s 'http://localhost:18082/sample/memory/search?stateKey=demo-user&query=green%20tea'
+```
+
+3. 模拟用户发起一次请求：
+
+```bash
+curl -s -X POST http://localhost:18082/sample/memory/ask \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-user","text":"green tea"}'
+```
+
+期望响应：
+
+- `modelMessages` 包含 Mem0 检索出的记忆内容。
+- `records` 或 Mem0 后台数据中能看到本轮用户输入和 assistant 输出。
+
+## 设计要点
+
+- 样例通过 `SampleMem0OpenJiuwenHandler#setOpenJiuwenRailFactories(...)` 预设 OpenJiuwen rail。
+- `Mem0RestMemoryProvider` 是 example 级适配器，用于演示 `MemoryProvider` 如何对接外部长期记忆服务。
+- 本样例是面向用户视角的 daemon + curl 验证，不是单元测试替代品。

--- a/examples/agent-runtime-middleware-memory-mem0/README.md
+++ b/examples/agent-runtime-middleware-memory-mem0/README.md
@@ -34,8 +34,8 @@ http://localhost:18082
 
 ## 设计要点
 
-- 样例通过 `SampleMem0OpenJiuwenHandler#setOpenJiuwenRailFactories(...)` 预设 OpenJiuwen rail。
-- `buildMemoryRailFactories(...)` 负责构建 rails，`setOpenJiuwenRailFactories(...)` 负责把 rails 设置到 handler；执行时不 override `runOpenJiuwenAgent(...)`，仍走 OpenJiuwen 默认 Runner。
+- 样例 handler 直接持有 `MemoryProvider`，并在 `openJiuwenRails(context)` 中注册唯一的 memory rail。
+- 执行时不 override `runOpenJiuwenAgent(...)`，仍走 OpenJiuwen 默认 Runner。
 - `Mem0RestMemoryProvider` 是 example 级适配器，用于演示 `MemoryProvider` 如何对接外部长期记忆服务。
 - `sample.mem0.api-mode=oss` 使用 `/memories` 和 `/search`；`sample.mem0.api-mode=platform` 使用 `/v1/memories/` 和 `/v2/memories/search/`。
 - 本样例是面向用户视角的 daemon + curl 验证，不是单元测试替代品。

--- a/examples/agent-runtime-middleware-memory-mem0/README.md
+++ b/examples/agent-runtime-middleware-memory-mem0/README.md
@@ -35,6 +35,10 @@ http://localhost:18082
 
 ## 设计要点
 
+- `/sample/memory/ask` 请求体里的 `text` 是本轮用户输入；样例会把它包装成 `RuntimeMessage.user(text)`，
+  最终由 `OpenJiuwenMessageAdapter` 转成 OpenJiuwen Runner 的 `query`。
+- `createOpenJiuwenAgent(...)` 中的 promptTemplate 只是 system prompt，用来约束样例 Agent 的回答方式，
+  不是用户输入。
 - 样例 handler 直接持有 `MemoryProvider`，并在 `openJiuwenRails(context)` 中注册唯一的 memory rail。
 - 执行时不 override `runOpenJiuwenAgent(...)`，仍走 OpenJiuwen 默认 Runner。
 - `Mem0RestMemoryProvider` 是 example 级适配器，用于演示 `MemoryProvider` 如何对接外部长期记忆服务。

--- a/examples/agent-runtime-middleware-memory-mem0/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-memory-mem0/TUTORIAL.cn.md
@@ -125,7 +125,7 @@ curl -s -X POST http://localhost:18082/sample/memory/ask \
 期望响应：
 
 - `hits` 包含 Mem0 返回的记忆。
-- `rawResults` 中是模型真实返回结果，正常情况下应能回答用户偏好是 `green tea`。
+- `agentOutputs` 中是模型真实返回结果，正常情况下应能回答用户偏好是 `green tea`。
 
 ---
 

--- a/examples/agent-runtime-middleware-memory-mem0/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-memory-mem0/TUTORIAL.cn.md
@@ -28,6 +28,7 @@ ReActAgent 模型输入包含 Relevant memory
 
 - JDK 21
 - curl
+- 可用的 OpenAI-compatible LLM API
 - 一个可访问的 Mem0-compatible REST 服务
 - 本地 18082 端口未被占用
 
@@ -60,6 +61,11 @@ sample.mem0.infer-on-save=false
 ## 3. Step 2 — 启动样例守护进程
 
 ```bash
+export SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER=openai
+export SAA_SAMPLE_OPENJIUWEN_API_BASE=https://api.deepseek.com
+export SAA_SAMPLE_LLM_MODEL=deepseek-chat
+export SAA_SAMPLE_LLM_API_KEY=sk-your-key
+
 ./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml spring-boot:run \
   -Dspring-boot.run.arguments="--sample.mem0.base-url=http://localhost:8000 --sample.mem0.api-mode=oss --sample.mem0.infer-on-save=false"
 ```
@@ -113,14 +119,13 @@ curl -s 'http://localhost:18082/sample/memory/search?stateKey=demo-user&query=gr
 ```bash
 curl -s -X POST http://localhost:18082/sample/memory/ask \
   -H 'Content-Type: application/json' \
-  -d '{"stateKey":"demo-user","text":"green tea"}'
+  -d '{"stateKey":"demo-user","text":"What drink does the user prefer?"}'
 ```
 
 期望响应：
 
-- `rawResults` 中包含 `output=pong`。
 - `hits` 包含 Mem0 返回的记忆。
-- `modelMessages` 包含 Mem0 检索出的记忆内容，说明 memory rail 在调用模型前完成了注入。
+- `rawResults` 中是模型真实返回结果，正常情况下应能回答用户偏好是 `green tea`。
 
 ---
 
@@ -131,13 +136,16 @@ curl -s -X POST http://localhost:18082/sample/memory/ask \
 - `MemoryMem0Application.java`
 - `Mem0RestMemoryProvider`
 - `SampleMem0OpenJiuwenHandler#setOpenJiuwenRailFactories(...)`
+- `SampleMem0OpenJiuwenHandler#buildMemoryRailFactories(...)`
 - `SampleMem0OpenJiuwenHandler#memoryRail(...)`
 
 用户侧要复用这个模式时，核心动作是：
 
 ```java
-handler.setOpenJiuwenRailFactories(List.of(context -> handler.memoryRail(context, memoryProvider)));
+handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(memoryProvider));
 ```
+
+样例不 override `runOpenJiuwenAgent(...)`；handler 执行仍走 `OpenJiuwenAgentRuntimeHandler` 默认 Runner。业务侧只负责拿到自己的 handler，并在执行前把 rails 设置进去。
 
 ---
 

--- a/examples/agent-runtime-middleware-memory-mem0/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-memory-mem0/TUTORIAL.cn.md
@@ -1,0 +1,146 @@
+# Mem0 MemoryProvider 样例教程
+
+跟着做完，你会启动一个 Mem0-compatible REST 服务，再启动本样例服务，通过 curl 写入、检索并注入长期记忆。
+
+---
+
+## 0. 你将验证什么
+
+本样例验证外部长期记忆服务接入：
+
+```text
+curl 写入记忆
+        ↓
+Mem0RestMemoryProvider 调 Mem0 REST API
+        ↓
+curl 发起用户输入
+        ↓
+memory rail 调 Mem0 REST API 检索记忆
+        ↓
+ReActAgent 模型输入包含 Relevant memory
+```
+
+---
+
+## 1. 环境准备
+
+在仓库根目录执行命令。需要：
+
+- JDK 21
+- curl
+- 一个可访问的 Mem0-compatible REST 服务
+- 本地 18082 端口未被占用
+
+Windows PowerShell 可以把下面的 `./mvnw` 换成 `./mvnw.cmd`。
+
+---
+
+## 2. Step 1 — 准备 Mem0 REST 服务
+
+样例支持两种 REST 形态：
+
+| 模式 | 配置值 | 写入路径 | 检索路径 |
+|---|---|---|---|
+| Mem0 OSS REST server | `oss` | `/memories` | `/search` |
+| OpenMemory / Platform API | `platform` | `/v1/memories/` | `/v2/memories/search/` |
+
+默认使用 `oss`：
+
+```text
+sample.mem0.base-url=http://localhost:8000
+sample.mem0.api-key=
+sample.mem0.api-mode=oss
+sample.mem0.infer-on-save=false
+```
+
+`infer-on-save=false` 表示样例按测试输入直接写入，便于稳定验证。接入真实 Mem0 抽取能力时可以改成 `true`，但验证结果会依赖 Mem0 的抽取策略。
+
+---
+
+## 3. Step 2 — 启动样例守护进程
+
+```bash
+./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml spring-boot:run \
+  -Dspring-boot.run.arguments="--sample.mem0.base-url=http://localhost:8000 --sample.mem0.api-mode=oss --sample.mem0.infer-on-save=false"
+```
+
+如果服务需要 API Key：
+
+```bash
+./mvnw -f examples/agent-runtime-middleware-memory-mem0/pom.xml spring-boot:run \
+  -Dspring-boot.run.arguments="--sample.mem0.base-url=http://localhost:8000 --sample.mem0.api-key=your-key --sample.mem0.api-mode=oss --sample.mem0.infer-on-save=false"
+```
+
+服务地址：
+
+```text
+http://localhost:18082
+```
+
+---
+
+## 4. Step 3 — 写入一条长期记忆
+
+```bash
+curl -s -X POST http://localhost:18082/sample/memory/remember \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-user","text":"the user prefers green tea"}'
+```
+
+期望响应：
+
+```json
+{
+  "stateKey": "demo-user",
+  "saved": true
+}
+```
+
+---
+
+## 5. Step 4 — 直接检索 Mem0 记忆
+
+```bash
+curl -s 'http://localhost:18082/sample/memory/search?stateKey=demo-user&query=green%20tea'
+```
+
+期望响应里 `hits` 至少包含一条和 `green tea` 相关的内容。
+
+---
+
+## 6. Step 5 — 发起一次用户请求
+
+```bash
+curl -s -X POST http://localhost:18082/sample/memory/ask \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-user","text":"green tea"}'
+```
+
+期望响应：
+
+- `rawResults` 中包含 `output=pong`。
+- `hits` 包含 Mem0 返回的记忆。
+- `modelMessages` 包含 Mem0 检索出的记忆内容，说明 memory rail 在调用模型前完成了注入。
+
+---
+
+## 7. Step 6 — 看代码入口
+
+关键代码在：
+
+- `MemoryMem0Application.java`
+- `Mem0RestMemoryProvider`
+- `SampleMem0OpenJiuwenHandler#setOpenJiuwenRailFactories(...)`
+- `SampleMem0OpenJiuwenHandler#memoryRail(...)`
+
+用户侧要复用这个模式时，核心动作是：
+
+```java
+handler.setOpenJiuwenRailFactories(List.of(context -> handler.memoryRail(context, memoryProvider)));
+```
+
+---
+
+## 8. 清理
+
+在启动样例服务的终端按 `Ctrl+C` 停止进程。Mem0 服务由测试团队或客户开发团队按自己的环境清理。

--- a/examples/agent-runtime-middleware-memory-mem0/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-memory-mem0/TUTORIAL.cn.md
@@ -135,17 +135,17 @@ curl -s -X POST http://localhost:18082/sample/memory/ask \
 
 - `MemoryMem0Application.java`
 - `Mem0RestMemoryProvider`
-- `SampleMem0OpenJiuwenHandler#setOpenJiuwenRailFactories(...)`
-- `SampleMem0OpenJiuwenHandler#buildMemoryRailFactories(...)`
-- `SampleMem0OpenJiuwenHandler#memoryRail(...)`
+- `SampleMem0OpenJiuwenHandler#openJiuwenRails(...)`
 
-用户侧要复用这个模式时，核心动作是：
+用户侧要复用这个模式时，核心动作是让 handler 持有 `MemoryProvider`，并在每次执行时基于当前 `AgentExecutionContext` 创建 memory rail：
 
 ```java
-handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(memoryProvider));
+protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
+    return List.of(memoryRuntimeRail(context, memoryProvider));
+}
 ```
 
-样例不 override `runOpenJiuwenAgent(...)`；handler 执行仍走 `OpenJiuwenAgentRuntimeHandler` 默认 Runner。业务侧只负责拿到自己的 handler，并在执行前把 rails 设置进去。
+样例不 override `runOpenJiuwenAgent(...)`；handler 执行仍走 `OpenJiuwenAgentRuntimeHandler` 默认 Runner。业务侧只负责把自己的 `MemoryProvider` 接到 handler 上。
 
 ---
 

--- a/examples/agent-runtime-middleware-memory-mem0/pom.xml
+++ b/examples/agent-runtime-middleware-memory-mem0/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.huawei.ascend</groupId>
     <artifactId>spring-ai-ascend-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -35,9 +35,30 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.33.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <mainClass>com.huawei.ascend.examples.runtime.middleware.memory.mem0.MemoryMem0Application</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/examples/agent-runtime-middleware-memory-mem0/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0Application.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0Application.java
@@ -1,0 +1,250 @@
+package com.huawei.ascend.examples.runtime.middleware.memory.mem0;
+
+import com.huawei.ascend.runtime.common.RuntimeIdentity;
+import com.huawei.ascend.runtime.common.RuntimeMessage;
+import com.huawei.ascend.runtime.engine.AgentExecutionContext;
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenAgentRuntimeHandler;
+import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
+import com.openjiuwen.core.foundation.llm.Model;
+import com.openjiuwen.core.foundation.llm.model_clients.BaseModelClient;
+import com.openjiuwen.core.foundation.llm.output_parsers.BaseOutputParser;
+import com.openjiuwen.core.foundation.llm.schema.AssistantMessage;
+import com.openjiuwen.core.foundation.llm.schema.AssistantMessageChunk;
+import com.openjiuwen.core.foundation.llm.schema.AudioGenerationResponse;
+import com.openjiuwen.core.foundation.llm.schema.BaseMessage;
+import com.openjiuwen.core.foundation.llm.schema.ImageGenerationResponse;
+import com.openjiuwen.core.foundation.llm.schema.ModelClientConfig;
+import com.openjiuwen.core.foundation.llm.schema.ModelRequestConfig;
+import com.openjiuwen.core.foundation.llm.schema.UserMessage;
+import com.openjiuwen.core.foundation.llm.schema.VideoGenerationResponse;
+import com.openjiuwen.core.session.AgentSessionApi;
+import com.openjiuwen.core.session.stream.StreamMode;
+import com.openjiuwen.core.singleagent.BaseAgent;
+import com.openjiuwen.core.singleagent.agents.ReActAgent;
+import com.openjiuwen.core.singleagent.agents.ReActAgentConfig;
+import com.openjiuwen.core.singleagent.rail.AgentRail;
+import com.openjiuwen.core.singleagent.schema.AgentCard;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+public class MemoryMem0Application {
+    public static void main(String[] args) {
+        SpringApplication.run(MemoryMem0Application.class, args);
+    }
+}
+
+@Configuration(proxyBeanMethods = false)
+class MemoryMem0Configuration {
+    private static final String AGENT_ID = "middleware-memory-mem0-agent";
+
+    @Bean
+    Mem0RestMemoryProvider memoryProvider(
+            @Value("${sample.mem0.base-url:${SAA_SAMPLE_MEM0_BASE_URL:http://localhost:8000}}") String baseUrl,
+            @Value("${sample.mem0.api-key:${SAA_SAMPLE_MEM0_API_KEY:}}") String apiKey,
+            @Value("${sample.mem0.infer-on-save:${SAA_SAMPLE_MEM0_INFER_ON_SAVE:false}}") boolean inferOnSave,
+            @Value("${sample.mem0.api-mode:${SAA_SAMPLE_MEM0_API_MODE:oss}}") String apiMode) {
+        return new Mem0RestMemoryProvider(baseUrl, apiKey, inferOnSave, apiMode);
+    }
+
+    @Bean
+    SampleMem0OpenJiuwenHandler sampleHandler(Mem0RestMemoryProvider memoryProvider) {
+        SampleMem0OpenJiuwenHandler handler = new SampleMem0OpenJiuwenHandler(AGENT_ID);
+        handler.setOpenJiuwenRailFactories(List.of(context -> handler.memoryRail(context, memoryProvider)));
+        return handler;
+    }
+
+    @Bean
+    Object sampleModelFactoryRegistration() {
+        Mem0SampleModelClient.ensureRegistered();
+        return new Object();
+    }
+}
+
+@RestController
+class MemoryMem0Controller {
+    private final Mem0RestMemoryProvider memoryProvider;
+    private final SampleMem0OpenJiuwenHandler handler;
+
+    MemoryMem0Controller(Mem0RestMemoryProvider memoryProvider, SampleMem0OpenJiuwenHandler handler) {
+        this.memoryProvider = memoryProvider;
+        this.handler = handler;
+    }
+
+    @PostMapping("/sample/memory/remember")
+    Map<String, Object> remember(@RequestBody MemoryRequest request) {
+        AgentExecutionContext context = context(request.stateKey(), request.text());
+        memoryProvider.save(context, List.of(new MemoryProvider.MemoryRecord(
+                null, "assistant", request.text(), Map.of("source", "curl"))));
+        return Map.of("stateKey", context.getAgentStateKey(), "saved", true);
+    }
+
+    @PostMapping("/sample/memory/ask")
+    Map<String, Object> ask(@RequestBody MemoryRequest request) {
+        AgentExecutionContext context = context(request.stateKey(), request.text());
+        List<?> rawResults = handler.execute(context).toList();
+        return Map.of(
+                "stateKey", context.getAgentStateKey(),
+                "query", request.text(),
+                "rawResults", rawResults,
+                "modelMessages", Mem0SampleModelClient.capturedMessages(),
+                "hits", memoryProvider.search(context, request.text(), 5));
+    }
+
+    @GetMapping("/sample/memory/search")
+    Map<String, Object> search(
+            @RequestParam(defaultValue = "demo-user") String stateKey,
+            @RequestParam(defaultValue = "green tea") String query) {
+        AgentExecutionContext context = context(stateKey, query);
+        return Map.of("stateKey", stateKey, "query", query, "hits", memoryProvider.search(context, query, 5));
+    }
+
+    private static AgentExecutionContext context(String stateKey, String text) {
+        RuntimeIdentity identity =
+                new RuntimeIdentity("sample-tenant", "sample-user", "sample-session", "sample-task",
+                        "middleware-memory-mem0-agent");
+        return new AgentExecutionContext(identity, "USER_MESSAGE",
+                List.of(RuntimeMessage.user(text == null ? "" : text)), Map.of(), normalizeStateKey(stateKey), null);
+    }
+
+    private static String normalizeStateKey(String stateKey) {
+        return stateKey == null || stateKey.isBlank() ? "demo-user" : stateKey;
+    }
+
+    record MemoryRequest(String stateKey, String text) {
+    }
+}
+
+final class SampleMem0OpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler {
+    private static final String MODEL_PROVIDER = "sample-memory-mem0-model";
+    private final String agentId;
+    private List<Function<AgentExecutionContext, AgentRail>> railFactories = List.of();
+
+    SampleMem0OpenJiuwenHandler(String agentId) {
+        super(agentId);
+        this.agentId = agentId;
+    }
+
+    void setOpenJiuwenRailFactories(List<Function<AgentExecutionContext, AgentRail>> railFactories) {
+        this.railFactories = List.copyOf(Objects.requireNonNull(railFactories, "railFactories"));
+    }
+
+    AgentRail memoryRail(AgentExecutionContext context, MemoryProvider provider) {
+        return memoryRuntimeRail(context, provider);
+    }
+
+    @Override
+    protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
+        return railFactories.stream().map(factory -> factory.apply(context)).toList();
+    }
+
+    @Override
+    protected BaseAgent createOpenJiuwenAgent(AgentExecutionContext context) {
+        ReActAgent agent = new ReActAgent(AgentCard.builder()
+                .id(agentId)
+                .name(agentId)
+                .description("Mem0 MemoryProvider curl example")
+                .build());
+        ReActAgentConfig config = ReActAgentConfig.builder()
+                .promptTemplate(List.of(Map.of("role", "system", "content",
+                        "You are a deterministic middleware memory example. Reply exactly pong.")))
+                .maxIterations(1)
+                .build()
+                .configureModelClient(MODEL_PROVIDER, "sample-key", "http://localhost", "sample-model", false);
+        agent.configure(config);
+        return agent;
+    }
+
+    @Override
+    protected Object runOpenJiuwenAgent(BaseAgent agent, Object input, String conversationId) {
+        Iterator<Object> output = agent.stream(input, AgentSessionApi.create(conversationId, null, agent.getCard()),
+                List.of(StreamMode.OUTPUT));
+        output.forEachRemaining(ignored -> { });
+        return Map.of("result_type", "answer", "output", "pong");
+    }
+}
+
+final class Mem0SampleModelClient extends BaseModelClient {
+    private static final AtomicBoolean REGISTERED = new AtomicBoolean(false);
+    private static final CopyOnWriteArrayList<String> CAPTURED_MESSAGES = new CopyOnWriteArrayList<>();
+
+    private Mem0SampleModelClient(ModelRequestConfig modelConfig, ModelClientConfig clientConfig) {
+        super(modelConfig, clientConfig);
+    }
+
+    static void ensureRegistered() {
+        if (REGISTERED.compareAndSet(false, true)) {
+            Model.registerFactory(new Model.ModelClientFactory() {
+                @Override
+                public String providerName() {
+                    return "sample-memory-mem0-model";
+                }
+
+                @Override
+                public BaseModelClient create(ModelRequestConfig modelConfig, ModelClientConfig clientConfig) {
+                    return new Mem0SampleModelClient(modelConfig, clientConfig);
+                }
+            });
+        }
+    }
+
+    static List<String> capturedMessages() {
+        return List.copyOf(CAPTURED_MESSAGES);
+    }
+
+    @Override
+    public AssistantMessage invoke(Object messages, Object tools, Float temperature, Float topP, String model,
+            Integer maxTokens, String stop, BaseOutputParser outputParser, Float timeout, Map<String, Object> kwargs) {
+        CAPTURED_MESSAGES.clear();
+        if (messages instanceof List<?> list) {
+            list.stream()
+                    .filter(BaseMessage.class::isInstance)
+                    .map(BaseMessage.class::cast)
+                    .map(BaseMessage::getContentAsString)
+                    .forEach(CAPTURED_MESSAGES::add);
+        }
+        return new AssistantMessage("pong");
+    }
+
+    @Override
+    public Iterator<AssistantMessageChunk> stream(Object messages, Object tools, Float temperature, Float topP,
+            String model, Integer maxTokens, String stop, BaseOutputParser outputParser, Float timeout,
+            Map<String, Object> kwargs) {
+        return List.<AssistantMessageChunk>of().iterator();
+    }
+
+    @Override
+    public ImageGenerationResponse generateImage(List<UserMessage> messages, String model, String size,
+            String negativePrompt, int n, boolean promptExtend, boolean watermark, int seed,
+            Map<String, Object> kwargs) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AudioGenerationResponse generateSpeech(List<UserMessage> messages, String model, String voice,
+            String languageType, Map<String, Object> kwargs) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public VideoGenerationResponse generateVideo(List<UserMessage> messages, String imgUrl, String audioUrl,
+            String model, String size, String resolution, int duration, boolean promptExtend, boolean watermark,
+            String negativePrompt, Integer seed, Map<String, Object> kwargs) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/examples/agent-runtime-middleware-memory-mem0/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0Application.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0Application.java
@@ -72,32 +72,32 @@ class MemoryMem0Controller {
 
     @PostMapping("/sample/memory/remember")
     Map<String, Object> remember(@RequestBody MemoryRequest request) {
-        AgentExecutionContext context = context(request.stateKey(), request.text());
-        memoryProvider.save(context, List.of(new MemoryProvider.MemoryRecord(
+        AgentExecutionContext executionContext = buildExecutionContext(request.stateKey(), request.text());
+        memoryProvider.save(executionContext, List.of(new MemoryProvider.MemoryRecord(
                 null, "assistant", request.text(), Map.of("source", "curl"))));
-        return Map.of("stateKey", context.getAgentStateKey(), "saved", true);
+        return Map.of("stateKey", executionContext.getAgentStateKey(), "saved", true);
     }
 
     @PostMapping("/sample/memory/ask")
     Map<String, Object> ask(@RequestBody MemoryRequest request) {
-        AgentExecutionContext context = context(request.stateKey(), request.text());
-        List<?> rawResults = handler.execute(context).toList();
+        AgentExecutionContext executionContext = buildExecutionContext(request.stateKey(), request.text());
+        List<?> agentOutputs = handler.execute(executionContext).toList();
         return Map.of(
-                "stateKey", context.getAgentStateKey(),
+                "stateKey", executionContext.getAgentStateKey(),
                 "query", request.text(),
-                "rawResults", rawResults,
-                "hits", memoryProvider.search(context, request.text(), 5));
+                "agentOutputs", agentOutputs,
+                "hits", memoryProvider.search(executionContext, request.text(), 5));
     }
 
     @GetMapping("/sample/memory/search")
     Map<String, Object> search(
             @RequestParam(defaultValue = "demo-user") String stateKey,
             @RequestParam(defaultValue = "green tea") String query) {
-        AgentExecutionContext context = context(stateKey, query);
-        return Map.of("stateKey", stateKey, "query", query, "hits", memoryProvider.search(context, query, 5));
+        AgentExecutionContext executionContext = buildExecutionContext(stateKey, query);
+        return Map.of("stateKey", stateKey, "query", query, "hits", memoryProvider.search(executionContext, query, 5));
     }
 
-    private static AgentExecutionContext context(String stateKey, String text) {
+    private static AgentExecutionContext buildExecutionContext(String stateKey, String text) {
         RuntimeIdentity identity =
                 new RuntimeIdentity("sample-tenant", "sample-user", "sample-session", "sample-task",
                         "middleware-memory-mem0-agent");

--- a/examples/agent-runtime-middleware-memory-mem0/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0Application.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0Application.java
@@ -5,31 +5,15 @@ import com.huawei.ascend.runtime.common.RuntimeMessage;
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
 import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenAgentRuntimeHandler;
 import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
-import com.openjiuwen.core.foundation.llm.Model;
-import com.openjiuwen.core.foundation.llm.model_clients.BaseModelClient;
-import com.openjiuwen.core.foundation.llm.output_parsers.BaseOutputParser;
-import com.openjiuwen.core.foundation.llm.schema.AssistantMessage;
-import com.openjiuwen.core.foundation.llm.schema.AssistantMessageChunk;
-import com.openjiuwen.core.foundation.llm.schema.AudioGenerationResponse;
-import com.openjiuwen.core.foundation.llm.schema.BaseMessage;
-import com.openjiuwen.core.foundation.llm.schema.ImageGenerationResponse;
-import com.openjiuwen.core.foundation.llm.schema.ModelClientConfig;
 import com.openjiuwen.core.foundation.llm.schema.ModelRequestConfig;
-import com.openjiuwen.core.foundation.llm.schema.UserMessage;
-import com.openjiuwen.core.foundation.llm.schema.VideoGenerationResponse;
-import com.openjiuwen.core.session.AgentSessionApi;
-import com.openjiuwen.core.session.stream.StreamMode;
 import com.openjiuwen.core.singleagent.BaseAgent;
 import com.openjiuwen.core.singleagent.agents.ReActAgent;
 import com.openjiuwen.core.singleagent.agents.ReActAgentConfig;
 import com.openjiuwen.core.singleagent.rail.AgentRail;
 import com.openjiuwen.core.singleagent.schema.AgentCard;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
@@ -63,16 +47,20 @@ class MemoryMem0Configuration {
     }
 
     @Bean
-    SampleMem0OpenJiuwenHandler sampleHandler(Mem0RestMemoryProvider memoryProvider) {
-        SampleMem0OpenJiuwenHandler handler = new SampleMem0OpenJiuwenHandler(AGENT_ID);
-        handler.setOpenJiuwenRailFactories(List.of(context -> handler.memoryRail(context, memoryProvider)));
+    SampleMem0OpenJiuwenHandler sampleHandler(
+            @Value("${sample.openjiuwen.model-provider:${SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER:openai}}")
+            String modelProvider,
+            @Value("${sample.openjiuwen.api-key:${SAA_SAMPLE_LLM_API_KEY:}}") String apiKey,
+            @Value("${sample.openjiuwen.api-base:${SAA_SAMPLE_OPENJIUWEN_API_BASE:https://api.deepseek.com}}")
+            String apiBase,
+            @Value("${sample.openjiuwen.model-name:${SAA_SAMPLE_LLM_MODEL:deepseek-chat}}") String modelName,
+            @Value("${sample.openjiuwen.ssl-verify:${SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY:false}}")
+            boolean sslVerify,
+            Mem0RestMemoryProvider memoryProvider) {
+        SampleMem0OpenJiuwenHandler handler =
+                new SampleMem0OpenJiuwenHandler(AGENT_ID, modelProvider, apiKey, apiBase, modelName, sslVerify);
+        handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(memoryProvider));
         return handler;
-    }
-
-    @Bean
-    Object sampleModelFactoryRegistration() {
-        Mem0SampleModelClient.ensureRegistered();
-        return new Object();
     }
 }
 
@@ -102,7 +90,6 @@ class MemoryMem0Controller {
                 "stateKey", context.getAgentStateKey(),
                 "query", request.text(),
                 "rawResults", rawResults,
-                "modelMessages", Mem0SampleModelClient.capturedMessages(),
                 "hits", memoryProvider.search(context, request.text(), 5));
     }
 
@@ -131,17 +118,36 @@ class MemoryMem0Controller {
 }
 
 final class SampleMem0OpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler {
-    private static final String MODEL_PROVIDER = "sample-memory-mem0-model";
     private final String agentId;
+    private final String modelProvider;
+    private final String apiKey;
+    private final String apiBase;
+    private final String modelName;
+    private final boolean sslVerify;
     private List<Function<AgentExecutionContext, AgentRail>> railFactories = List.of();
 
-    SampleMem0OpenJiuwenHandler(String agentId) {
+    SampleMem0OpenJiuwenHandler(
+            String agentId,
+            String modelProvider,
+            String apiKey,
+            String apiBase,
+            String modelName,
+            boolean sslVerify) {
         super(agentId);
         this.agentId = agentId;
+        this.modelProvider = modelProvider;
+        this.apiKey = apiKey;
+        this.apiBase = apiBase;
+        this.modelName = modelName;
+        this.sslVerify = sslVerify;
     }
 
     void setOpenJiuwenRailFactories(List<Function<AgentExecutionContext, AgentRail>> railFactories) {
         this.railFactories = List.copyOf(Objects.requireNonNull(railFactories, "railFactories"));
+    }
+
+    List<Function<AgentExecutionContext, AgentRail>> buildMemoryRailFactories(MemoryProvider provider) {
+        return List.of(context -> memoryRail(context, provider));
     }
 
     AgentRail memoryRail(AgentExecutionContext context, MemoryProvider provider) {
@@ -162,89 +168,18 @@ final class SampleMem0OpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler {
                 .build());
         ReActAgentConfig config = ReActAgentConfig.builder()
                 .promptTemplate(List.of(Map.of("role", "system", "content",
-                        "You are a deterministic middleware memory example. Reply exactly pong.")))
-                .maxIterations(1)
+                        """
+                        You are a middleware memory example assistant.
+                        Answer the user's question using relevant memory when it is provided.
+                        If the user asks for a preference, answer with the remembered preference directly.
+                        """)))
+                .maxIterations(3)
                 .build()
-                .configureModelClient(MODEL_PROVIDER, "sample-key", "http://localhost", "sample-model", false);
+                .configureModelClient(modelProvider, apiKey, apiBase, modelName, sslVerify);
+        ModelRequestConfig modelConfig = config.getModelConfigObj();
+        modelConfig.setTemperature(0.0);
+        modelConfig.setMaxTokens(128);
         agent.configure(config);
         return agent;
-    }
-
-    @Override
-    protected Object runOpenJiuwenAgent(BaseAgent agent, Object input, String conversationId) {
-        Iterator<Object> output = agent.stream(input, AgentSessionApi.create(conversationId, null, agent.getCard()),
-                List.of(StreamMode.OUTPUT));
-        output.forEachRemaining(ignored -> { });
-        return Map.of("result_type", "answer", "output", "pong");
-    }
-}
-
-final class Mem0SampleModelClient extends BaseModelClient {
-    private static final AtomicBoolean REGISTERED = new AtomicBoolean(false);
-    private static final CopyOnWriteArrayList<String> CAPTURED_MESSAGES = new CopyOnWriteArrayList<>();
-
-    private Mem0SampleModelClient(ModelRequestConfig modelConfig, ModelClientConfig clientConfig) {
-        super(modelConfig, clientConfig);
-    }
-
-    static void ensureRegistered() {
-        if (REGISTERED.compareAndSet(false, true)) {
-            Model.registerFactory(new Model.ModelClientFactory() {
-                @Override
-                public String providerName() {
-                    return "sample-memory-mem0-model";
-                }
-
-                @Override
-                public BaseModelClient create(ModelRequestConfig modelConfig, ModelClientConfig clientConfig) {
-                    return new Mem0SampleModelClient(modelConfig, clientConfig);
-                }
-            });
-        }
-    }
-
-    static List<String> capturedMessages() {
-        return List.copyOf(CAPTURED_MESSAGES);
-    }
-
-    @Override
-    public AssistantMessage invoke(Object messages, Object tools, Float temperature, Float topP, String model,
-            Integer maxTokens, String stop, BaseOutputParser outputParser, Float timeout, Map<String, Object> kwargs) {
-        CAPTURED_MESSAGES.clear();
-        if (messages instanceof List<?> list) {
-            list.stream()
-                    .filter(BaseMessage.class::isInstance)
-                    .map(BaseMessage.class::cast)
-                    .map(BaseMessage::getContentAsString)
-                    .forEach(CAPTURED_MESSAGES::add);
-        }
-        return new AssistantMessage("pong");
-    }
-
-    @Override
-    public Iterator<AssistantMessageChunk> stream(Object messages, Object tools, Float temperature, Float topP,
-            String model, Integer maxTokens, String stop, BaseOutputParser outputParser, Float timeout,
-            Map<String, Object> kwargs) {
-        return List.<AssistantMessageChunk>of().iterator();
-    }
-
-    @Override
-    public ImageGenerationResponse generateImage(List<UserMessage> messages, String model, String size,
-            String negativePrompt, int n, boolean promptExtend, boolean watermark, int seed,
-            Map<String, Object> kwargs) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public AudioGenerationResponse generateSpeech(List<UserMessage> messages, String model, String voice,
-            String languageType, Map<String, Object> kwargs) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public VideoGenerationResponse generateVideo(List<UserMessage> messages, String imgUrl, String audioUrl,
-            String model, String size, String resolution, int duration, boolean promptExtend, boolean watermark,
-            String negativePrompt, Integer seed, Map<String, Object> kwargs) {
-        throw new UnsupportedOperationException();
     }
 }

--- a/examples/agent-runtime-middleware-memory-mem0/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0Application.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0Application.java
@@ -142,7 +142,13 @@ final class SampleMem0OpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler {
 
     @Override
     protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
-        return List.of(memoryRuntimeRail(context, memoryProvider));
+        // OpenJiuwenAgentRuntimeHandler#doExecute calls installRails(...),
+        // which registers each returned rail on the concrete OpenJiuwen agent.
+        return List.of(createMemoryRail(context));
+    }
+
+    private AgentRail createMemoryRail(AgentExecutionContext context) {
+        return memoryRuntimeRail(context, memoryProvider);
     }
 
     @Override

--- a/examples/agent-runtime-middleware-memory-mem0/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0Application.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/main/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0Application.java
@@ -13,8 +13,6 @@ import com.openjiuwen.core.singleagent.rail.AgentRail;
 import com.openjiuwen.core.singleagent.schema.AgentCard;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -57,10 +55,8 @@ class MemoryMem0Configuration {
             @Value("${sample.openjiuwen.ssl-verify:${SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY:false}}")
             boolean sslVerify,
             Mem0RestMemoryProvider memoryProvider) {
-        SampleMem0OpenJiuwenHandler handler =
-                new SampleMem0OpenJiuwenHandler(AGENT_ID, modelProvider, apiKey, apiBase, modelName, sslVerify);
-        handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(memoryProvider));
-        return handler;
+        return new SampleMem0OpenJiuwenHandler(
+                AGENT_ID, modelProvider, apiKey, apiBase, modelName, sslVerify, memoryProvider);
     }
 }
 
@@ -124,7 +120,7 @@ final class SampleMem0OpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler {
     private final String apiBase;
     private final String modelName;
     private final boolean sslVerify;
-    private List<Function<AgentExecutionContext, AgentRail>> railFactories = List.of();
+    private final MemoryProvider memoryProvider;
 
     SampleMem0OpenJiuwenHandler(
             String agentId,
@@ -132,7 +128,8 @@ final class SampleMem0OpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler {
             String apiKey,
             String apiBase,
             String modelName,
-            boolean sslVerify) {
+            boolean sslVerify,
+            MemoryProvider memoryProvider) {
         super(agentId);
         this.agentId = agentId;
         this.modelProvider = modelProvider;
@@ -140,23 +137,12 @@ final class SampleMem0OpenJiuwenHandler extends OpenJiuwenAgentRuntimeHandler {
         this.apiBase = apiBase;
         this.modelName = modelName;
         this.sslVerify = sslVerify;
-    }
-
-    void setOpenJiuwenRailFactories(List<Function<AgentExecutionContext, AgentRail>> railFactories) {
-        this.railFactories = List.copyOf(Objects.requireNonNull(railFactories, "railFactories"));
-    }
-
-    List<Function<AgentExecutionContext, AgentRail>> buildMemoryRailFactories(MemoryProvider provider) {
-        return List.of(context -> memoryRail(context, provider));
-    }
-
-    AgentRail memoryRail(AgentExecutionContext context, MemoryProvider provider) {
-        return memoryRuntimeRail(context, provider);
+        this.memoryProvider = memoryProvider;
     }
 
     @Override
     protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
-        return railFactories.stream().map(factory -> factory.apply(context)).toList();
+        return List.of(memoryRuntimeRail(context, memoryProvider));
     }
 
     @Override

--- a/examples/agent-runtime-middleware-memory-mem0/src/main/resources/application.yaml
+++ b/examples/agent-runtime-middleware-memory-mem0/src/main/resources/application.yaml
@@ -1,0 +1,2 @@
+server:
+  port: 18082

--- a/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0ExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0ExampleTest.java
@@ -16,23 +16,28 @@ class MemoryMem0ExampleTest {
     void mem0RestMemoryProviderWorksThroughOpenJiuwenHandlerExecution() {
         String baseUrl = System.getenv("SAA_SAMPLE_MEM0_BASE_URL");
         assumeTrue(hasText(baseUrl), "Set SAA_SAMPLE_MEM0_BASE_URL to run the real Mem0 example");
+        assumeTrue(hasText(System.getenv("SAA_SAMPLE_LLM_API_KEY")),
+                "Set SAA_SAMPLE_LLM_API_KEY to run the real LLM example");
         Mem0RestMemoryProvider provider = new Mem0RestMemoryProvider(
                 baseUrl, System.getenv("SAA_SAMPLE_MEM0_API_KEY"), false, envOrDefault("SAA_SAMPLE_MEM0_API_MODE", "oss"));
         AgentExecutionContext context = MiddlewareTestFixtures.context("mem0-state-" + System.nanoTime());
         provider.save(context, List.of(new MemoryProvider.MemoryRecord(null, "assistant",
                 "the user prefers green tea", Map.of("source", "test"))));
-        Mem0SampleModelClient.ensureRegistered();
-        SampleMem0OpenJiuwenHandler handler = new SampleMem0OpenJiuwenHandler("openjiuwen-simple-agent");
-        handler.setOpenJiuwenRailFactories(List.of(execution -> handler.memoryRail(execution, provider)));
+        SampleMem0OpenJiuwenHandler handler = new SampleMem0OpenJiuwenHandler(
+                "openjiuwen-simple-agent",
+                envOrDefault("SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER", "openai"),
+                System.getenv("SAA_SAMPLE_LLM_API_KEY"),
+                envOrDefault("SAA_SAMPLE_OPENJIUWEN_API_BASE", "https://api.deepseek.com"),
+                envOrDefault("SAA_SAMPLE_LLM_MODEL", "deepseek-chat"),
+                Boolean.parseBoolean(envOrDefault("SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY", "false")));
+        handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(provider));
 
         List<?> rawResults = handler.execute(context).toList();
 
-        assertThat(rawResults).singleElement().isEqualTo(Map.of("result_type", "answer", "output", "pong"));
+        assertThat(rawResults).isNotEmpty();
         assertThat(provider.search(context, "green tea", 5))
                 .extracting(MemoryProvider.MemoryHit::content)
                 .anySatisfy(content -> assertThat(content).containsIgnoringCase("green tea"));
-        assertThat(Mem0SampleModelClient.capturedMessages())
-                .anySatisfy(message -> assertThat(message).containsIgnoringCase("green tea"));
     }
 
     private static boolean hasText(String value) {

--- a/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0ExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0ExampleTest.java
@@ -27,10 +27,10 @@ class MemoryMem0ExampleTest {
         assumeTrue(hasText(baseUrl), "Set SAA_SAMPLE_MEM0_BASE_URL to run the real Mem0 example");
         assumeTrue(hasText(System.getenv("SAA_SAMPLE_LLM_API_KEY")),
                 "Set SAA_SAMPLE_LLM_API_KEY to run the real LLM example");
-        Mem0RestMemoryProvider provider = new Mem0RestMemoryProvider(
+        Mem0RestMemoryProvider memoryProvider = new Mem0RestMemoryProvider(
                 baseUrl, System.getenv("SAA_SAMPLE_MEM0_API_KEY"), false, envOrDefault("SAA_SAMPLE_MEM0_API_MODE", "oss"));
-        AgentExecutionContext context = MiddlewareTestFixtures.context("mem0-state-" + System.nanoTime());
-        provider.save(context, List.of(new MemoryProvider.MemoryRecord(null, "assistant",
+        AgentExecutionContext greenTeaUserContext = MiddlewareTestFixtures.context("mem0-state-" + System.nanoTime());
+        memoryProvider.save(greenTeaUserContext, List.of(new MemoryProvider.MemoryRecord(null, "assistant",
                 "the user prefers green tea", Map.of("source", "test"))));
         SampleMem0OpenJiuwenHandler handler = new SampleMem0OpenJiuwenHandler(
                 "openjiuwen-simple-agent",
@@ -39,15 +39,15 @@ class MemoryMem0ExampleTest {
                 envOrDefault("SAA_SAMPLE_OPENJIUWEN_API_BASE", "https://api.deepseek.com"),
                 envOrDefault("SAA_SAMPLE_LLM_MODEL", "deepseek-chat"),
                 Boolean.parseBoolean(envOrDefault("SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY", "false")),
-                provider);
+                memoryProvider);
 
-        List<?> rawResults = handler.execute(context).toList();
+        List<?> agentOutputs = handler.execute(greenTeaUserContext).toList();
 
-        assertThat(rawResults).isNotEmpty();
-        assertThat(provider.search(context, "green tea", 5))
+        assertThat(agentOutputs).isNotEmpty();
+        assertThat(memoryProvider.search(greenTeaUserContext, "green tea", 5))
                 .extracting(MemoryProvider.MemoryHit::content)
                 .anySatisfy(content -> assertThat(content).containsIgnoringCase("green tea"));
-        assertThat(judgeAnswer(rawResults)).contains("PASS");
+        assertThat(judgeAnswer(agentOutputs)).contains("PASS");
     }
 
     private static boolean hasText(String value) {
@@ -59,9 +59,9 @@ class MemoryMem0ExampleTest {
         return hasText(value) ? value : fallback;
     }
 
-    private static String judgeAnswer(List<?> rawResults) throws Exception {
-        String answer = rawResults.toString();
-        Map<String, Object> request = Map.of(
+    private static String judgeAnswer(List<?> agentOutputs) throws Exception {
+        String agentAnswer = agentOutputs.toString();
+        Map<String, Object> judgeRequest = Map.of(
                 "model", envOrDefault("SAA_SAMPLE_LLM_MODEL", "deepseek-chat"),
                 "temperature", 0,
                 "max_tokens", 16,
@@ -75,22 +75,22 @@ class MemoryMem0ExampleTest {
 
                                 Answer:
                                 %s
-                                """.formatted(answer))));
-        HttpRequest httpRequest = HttpRequest.newBuilder()
+                                """.formatted(agentAnswer))));
+        HttpRequest judgeHttpRequest = HttpRequest.newBuilder()
                 .uri(URI.create(chatCompletionsUrl(envOrDefault(
                         "SAA_SAMPLE_OPENJIUWEN_API_BASE", "https://api.deepseek.com"))))
                 .header("Authorization", "Bearer " + System.getenv("SAA_SAMPLE_LLM_API_KEY"))
                 .header("Content-Type", "application/json")
-                .POST(HttpRequest.BodyPublishers.ofString(JSON.writeValueAsString(request)))
+                .POST(HttpRequest.BodyPublishers.ofString(JSON.writeValueAsString(judgeRequest)))
                 .build();
-        HttpResponse<String> response = HTTP.send(httpRequest, HttpResponse.BodyHandlers.ofString());
-        assertThat(response.statusCode()).isBetween(200, 299);
-        JsonNode content = JSON.readTree(response.body())
+        HttpResponse<String> judgeResponse = HTTP.send(judgeHttpRequest, HttpResponse.BodyHandlers.ofString());
+        assertThat(judgeResponse.statusCode()).isBetween(200, 299);
+        JsonNode judgeContent = JSON.readTree(judgeResponse.body())
                 .path("choices")
                 .path(0)
                 .path("message")
                 .path("content");
-        return content.asText();
+        return judgeContent.asText();
     }
 
     private static String chatCompletionsUrl(String apiBase) {

--- a/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0ExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0ExampleTest.java
@@ -4,26 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
-import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenAgentRuntimeHandler;
 import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
-import com.openjiuwen.core.context.ContextStats;
-import com.openjiuwen.core.context.ContextWindow;
-import com.openjiuwen.core.context.ModelContext;
-import com.openjiuwen.core.context.token.TokenCounter;
-import com.openjiuwen.core.foundation.llm.schema.AssistantMessage;
-import com.openjiuwen.core.foundation.llm.schema.BaseMessage;
-import com.openjiuwen.core.foundation.llm.schema.SystemMessage;
-import com.openjiuwen.core.foundation.llm.schema.UserMessage;
-import com.openjiuwen.core.foundation.tool.Tool;
-import com.openjiuwen.core.foundation.tool.schema.ToolInfo;
-import com.openjiuwen.core.session.Session;
-import com.openjiuwen.core.session.stream.StreamMode;
-import com.openjiuwen.core.singleagent.BaseAgent;
-import com.openjiuwen.core.singleagent.rail.AgentCallbackContext;
-import com.openjiuwen.core.singleagent.rail.AgentRail;
-import com.openjiuwen.core.singleagent.schema.AgentCard;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Tag;
@@ -35,22 +16,23 @@ class MemoryMem0ExampleTest {
     void mem0RestMemoryProviderWorksThroughOpenJiuwenHandlerExecution() {
         String baseUrl = System.getenv("SAA_SAMPLE_MEM0_BASE_URL");
         assumeTrue(hasText(baseUrl), "Set SAA_SAMPLE_MEM0_BASE_URL to run the real Mem0 example");
-
         Mem0RestMemoryProvider provider = new Mem0RestMemoryProvider(
-                baseUrl,
-                System.getenv("SAA_SAMPLE_MEM0_API_KEY"),
-                false,
-                envOrDefault("SAA_SAMPLE_MEM0_API_MODE", "oss"));
+                baseUrl, System.getenv("SAA_SAMPLE_MEM0_API_KEY"), false, envOrDefault("SAA_SAMPLE_MEM0_API_MODE", "oss"));
         AgentExecutionContext context = MiddlewareTestFixtures.context("mem0-state-" + System.nanoTime());
-        MemoryEnabledHandler handler = new MemoryEnabledHandler(provider);
+        provider.save(context, List.of(new MemoryProvider.MemoryRecord(null, "assistant",
+                "the user prefers green tea", Map.of("source", "test"))));
+        Mem0SampleModelClient.ensureRegistered();
+        SampleMem0OpenJiuwenHandler handler = new SampleMem0OpenJiuwenHandler("openjiuwen-simple-agent");
+        handler.setOpenJiuwenRailFactories(List.of(execution -> handler.memoryRail(execution, provider)));
 
         List<?> rawResults = handler.execute(context).toList();
 
         assertThat(rawResults).singleElement().isEqualTo(Map.of("result_type", "answer", "output", "pong"));
-        assertThat(handler.agent.registeredRails).hasSize(1);
         assertThat(provider.search(context, "green tea", 5))
                 .extracting(MemoryProvider.MemoryHit::content)
                 .anySatisfy(content -> assertThat(content).containsIgnoringCase("green tea"));
+        assertThat(Mem0SampleModelClient.capturedMessages())
+                .anySatisfy(message -> assertThat(message).containsIgnoringCase("green tea"));
     }
 
     private static boolean hasText(String value) {
@@ -60,147 +42,5 @@ class MemoryMem0ExampleTest {
     private static String envOrDefault(String key, String fallback) {
         String value = System.getenv(key);
         return hasText(value) ? value : fallback;
-    }
-
-    private static final class MemoryEnabledHandler extends OpenJiuwenAgentRuntimeHandler {
-        private final MemoryProvider provider;
-        private final RecordingAgent agent = new RecordingAgent();
-
-        private MemoryEnabledHandler(MemoryProvider provider) {
-            super("openjiuwen-simple-agent");
-            this.provider = provider;
-        }
-
-        @Override
-        protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
-            return List.of(memoryRuntimeRail(context, provider));
-        }
-
-        @Override
-        protected BaseAgent createOpenJiuwenAgent(AgentExecutionContext context) {
-            return agent;
-        }
-
-        @Override
-        protected Object runOpenJiuwenAgent(BaseAgent agent, Object input, String conversationId) {
-            RecordingModelContext modelContext = new RecordingModelContext();
-            modelContext.setMessages(List.of(
-                    new SystemMessage("business policy: keep original system prompt"),
-                    new UserMessage("green tea"),
-                    new AssistantMessage("pong")), true);
-            AgentCallbackContext callbackContext = AgentCallbackContext.builder()
-                    .context(modelContext)
-                    .build();
-            for (AgentRail rail : ((RecordingAgent) agent).registeredRails) {
-                rail.beforeInvoke(callbackContext);
-                rail.afterInvoke(callbackContext);
-            }
-            return Map.of("result_type", "answer", "output", "pong");
-        }
-    }
-
-    private static final class RecordingAgent extends BaseAgent {
-        private final List<AgentRail> registeredRails = new ArrayList<>();
-
-        private RecordingAgent() {
-            super(AgentCard.builder().id("agent").name("agent").description("test").build());
-        }
-
-        @Override
-        public BaseAgent configure(Object config) {
-            return this;
-        }
-
-        @Override
-        public Object getConfig() {
-            return null;
-        }
-
-        @Override
-        public BaseAgent registerRail(AgentRail rail) {
-            registeredRails.add(rail);
-            return this;
-        }
-
-        @Override
-        public Object invoke(Object input, Session session) {
-            return null;
-        }
-
-        @Override
-        public Iterator<Object> stream(Object input, Session session, List<StreamMode> streamModes) {
-            return List.of().iterator();
-        }
-    }
-
-    private static final class RecordingModelContext extends ModelContext {
-        private final List<BaseMessage> messages = new ArrayList<>();
-
-        @Override
-        public int size() {
-            return messages.size();
-        }
-
-        @Override
-        public List<BaseMessage> getMessages(Integer size, boolean withHistory) {
-            return List.copyOf(messages);
-        }
-
-        @Override
-        public void setMessages(List<BaseMessage> messages, boolean withHistory) {
-            this.messages.clear();
-            this.messages.addAll(messages);
-        }
-
-        @Override
-        public List<BaseMessage> popMessages(int size, boolean withHistory) {
-            return List.of();
-        }
-
-        @Override
-        public void clearMessages(boolean withHistory) {
-            messages.clear();
-        }
-
-        @Override
-        public List<BaseMessage> addMessages(List<BaseMessage> messages) {
-            this.messages.addAll(messages);
-            return List.copyOf(this.messages);
-        }
-
-        @Override
-        public ContextWindow getContextWindow(
-                List<BaseMessage> systemMessages,
-                List<ToolInfo> tools,
-                Integer windowSize,
-                Integer dialogueRound,
-                Map<String, Object> kwargs) {
-            return null;
-        }
-
-        @Override
-        public ContextStats statistic() {
-            return null;
-        }
-
-        @Override
-        public String sessionId() {
-            return "test-session";
-        }
-
-        @Override
-        public String contextId() {
-            return "test-context";
-        }
-
-        @Override
-        public TokenCounter tokenCounter() {
-            return null;
-        }
-
-        @Override
-        public Tool reloaderTool() {
-            return null;
-        }
     }
 }

--- a/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0ExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0ExampleTest.java
@@ -38,8 +38,8 @@ class MemoryMem0ExampleTest {
                 System.getenv("SAA_SAMPLE_LLM_API_KEY"),
                 envOrDefault("SAA_SAMPLE_OPENJIUWEN_API_BASE", "https://api.deepseek.com"),
                 envOrDefault("SAA_SAMPLE_LLM_MODEL", "deepseek-chat"),
-                Boolean.parseBoolean(envOrDefault("SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY", "false")));
-        handler.setOpenJiuwenRailFactories(handler.buildMemoryRailFactories(provider));
+                Boolean.parseBoolean(envOrDefault("SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY", "false")),
+                provider);
 
         List<?> rawResults = handler.execute(context).toList();
 

--- a/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0ExampleTest.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MemoryMem0ExampleTest.java
@@ -3,8 +3,14 @@ package com.huawei.ascend.examples.runtime.middleware.memory.mem0;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
 import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Tag;
@@ -12,8 +18,11 @@ import org.junit.jupiter.api.Test;
 
 @Tag("manual")
 class MemoryMem0ExampleTest {
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final HttpClient HTTP = HttpClient.newHttpClient();
+
     @Test
-    void mem0RestMemoryProviderWorksThroughOpenJiuwenHandlerExecution() {
+    void mem0RestMemoryProviderWorksThroughOpenJiuwenHandlerExecution() throws Exception {
         String baseUrl = System.getenv("SAA_SAMPLE_MEM0_BASE_URL");
         assumeTrue(hasText(baseUrl), "Set SAA_SAMPLE_MEM0_BASE_URL to run the real Mem0 example");
         assumeTrue(hasText(System.getenv("SAA_SAMPLE_LLM_API_KEY")),
@@ -38,6 +47,7 @@ class MemoryMem0ExampleTest {
         assertThat(provider.search(context, "green tea", 5))
                 .extracting(MemoryProvider.MemoryHit::content)
                 .anySatisfy(content -> assertThat(content).containsIgnoringCase("green tea"));
+        assertThat(judgeAnswer(rawResults)).contains("PASS");
     }
 
     private static boolean hasText(String value) {
@@ -47,5 +57,47 @@ class MemoryMem0ExampleTest {
     private static String envOrDefault(String key, String fallback) {
         String value = System.getenv(key);
         return hasText(value) ? value : fallback;
+    }
+
+    private static String judgeAnswer(List<?> rawResults) throws Exception {
+        String answer = rawResults.toString();
+        Map<String, Object> request = Map.of(
+                "model", envOrDefault("SAA_SAMPLE_LLM_MODEL", "deepseek-chat"),
+                "temperature", 0,
+                "max_tokens", 16,
+                "messages", List.of(
+                        Map.of("role", "system", "content",
+                                "You are a strict test judge. Reply exactly PASS or FAIL."),
+                        Map.of("role", "user", "content", """
+                                The memory says: the user prefers green tea.
+                                The user asked about their preference.
+                                Does the answer correctly use the memory and identify green tea as the preference?
+
+                                Answer:
+                                %s
+                                """.formatted(answer))));
+        HttpRequest httpRequest = HttpRequest.newBuilder()
+                .uri(URI.create(chatCompletionsUrl(envOrDefault(
+                        "SAA_SAMPLE_OPENJIUWEN_API_BASE", "https://api.deepseek.com"))))
+                .header("Authorization", "Bearer " + System.getenv("SAA_SAMPLE_LLM_API_KEY"))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(JSON.writeValueAsString(request)))
+                .build();
+        HttpResponse<String> response = HTTP.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+        assertThat(response.statusCode()).isBetween(200, 299);
+        JsonNode content = JSON.readTree(response.body())
+                .path("choices")
+                .path(0)
+                .path("message")
+                .path("content");
+        return content.asText();
+    }
+
+    private static String chatCompletionsUrl(String apiBase) {
+        String normalized = String.valueOf(apiBase).replaceAll("/+$", "");
+        if (normalized.endsWith("/chat/completions")) {
+            return normalized;
+        }
+        return normalized + "/chat/completions";
     }
 }

--- a/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MiddlewareTestFixtures.java
+++ b/examples/agent-runtime-middleware-memory-mem0/src/test/java/com/huawei/ascend/examples/runtime/middleware/memory/mem0/MiddlewareTestFixtures.java
@@ -13,6 +13,6 @@ final class MiddlewareTestFixtures {
         RuntimeIdentity identity =
                 new RuntimeIdentity("tenant", "user", "session", "task", "openjiuwen-simple-agent");
         return new AgentExecutionContext(identity, "USER_MESSAGE",
-                java.util.List.of(RuntimeMessage.user("green tea")), Map.of(), stateKey, null);
+                java.util.List.of(RuntimeMessage.user("What drink does the user prefer?")), Map.of(), stateKey, null);
     }
 }

--- a/examples/agent-runtime-middleware-state-inmemory/README.md
+++ b/examples/agent-runtime-middleware-state-inmemory/README.md
@@ -1,56 +1,53 @@
-# agent-runtime middleware state InMemory example
+# Agent Runtime Agent State InMemory Example
 
-这个样例验证「中间件解耦」下的 Agent State 本地持久化路径：
-业务侧通过 `OpenJiuwenCheckpointerConfigurer.setInMemoryDefault()` 选择
-OpenJiuwen 原生 `InMemoryCheckpointer`，`agent-runtime` 公共层不感知具体后端。
+本样例验证 OpenJiuwen Checkpointer 的 InMemory 形态。它代表短期状态或会话 checkpoint 的最小使用方式：用户启动常驻服务，通过 curl 保存、查询、释放 state。
 
-## 配置方式
+## 启动服务
 
-适用场景：
-
-- 本地开发、单元验证、临时端到端验证。
-- 不需要跨进程恢复 Agent State。
-- 不希望引入 Redis、数据库等外部依赖。
-
-核心配置点：
-
-```java
-Checkpointer checkpointer = OpenJiuwenCheckpointerConfigurer.setInMemoryDefault();
-```
-
-这行代码会把 OpenJiuwen 默认 checkpointer 设置为 `InMemoryCheckpointer`。
-业务代码只需要保证后续 OpenJiuwen 执行使用稳定的 `conversation_id`。在
-`agent-runtime` 的 OpenJiuwen 适配层中，这个值来自
-`AgentExecutionContext#getAgentStateKey()`。
-
-测试团队检查点：
-
-- `preAgentExecute(...)` 能按 session id 创建或恢复 OpenJiuwen session。
-- `postAgentExecute(...)` 能把本轮状态写回 checkpointer。
-- `sessionExists(sessionId)` 在保存后返回 `true`。
-- `release(sessionId)` 后状态被清理。
-
-## Run
+在仓库根目录执行：
 
 ```bash
-./mvnw -f examples/agent-runtime-middleware-state-inmemory/pom.xml test
+./mvnw -f examples/agent-runtime-middleware-state-inmemory/pom.xml spring-boot:run
 ```
 
-## 端到端链路
+服务默认监听：
 
 ```text
-OpenJiuwenCheckpointerConfigurer.setInMemoryDefault()
-  -> AgentSessionApi(sessionId)
-  -> checkpointer.preAgentExecute(...)
-  -> session.updateState(...)
-  -> checkpointer.postAgentExecute(...)
-  -> checkpointer.sessionExists(sessionId)
-  -> checkpointer.release(sessionId)
+http://localhost:18083
 ```
 
-## Scope
+## curl 验证
 
-- 无外部依赖。
-- 验证 `preAgentExecute -> postAgentExecute -> release` 的一轮
-  OpenJiuwen `AgentSessionApi` 状态持久化链路。
-- 不引入脚本；所有运行方式写在 README 中。
+1. 保存一次 state：
+
+```bash
+curl -s -X POST http://localhost:18083/sample/state/save \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-state","input":"first turn","turn":1,"answer":"pong"}'
+```
+
+2. 查询 state 是否存在：
+
+```bash
+curl -s 'http://localhost:18083/sample/state/exists?stateKey=demo-state'
+```
+
+期望返回：
+
+```json
+{"stateKey":"demo-state","exists":true}
+```
+
+3. 释放 state：
+
+```bash
+curl -s -X DELETE http://localhost:18083/sample/state/demo-state
+```
+
+释放后再次查询应返回 `exists=false`。
+
+## 设计要点
+
+- `openJiuwenCheckpointer` Bean 在 Spring 容器启动时初始化。
+- 样例通过 `OpenJiuwenCheckpointerConfigurer.setInMemoryDefault()` 把 OpenJiuwen 默认 checkpointer 设置为 InMemory。
+- InMemory 适合本地开发和功能验证；生产环境通常应使用 Redis 或其他可恢复后端。

--- a/examples/agent-runtime-middleware-state-inmemory/README.md
+++ b/examples/agent-runtime-middleware-state-inmemory/README.md
@@ -22,6 +22,7 @@ http://localhost:18083
 |---|---|
 | `POST /sample/state/save` | 保存一次 OpenJiuwen session checkpoint |
 | `GET /sample/state/exists?stateKey=demo-state` | 查询 checkpoint 是否存在 |
+| `GET /sample/state/load?stateKey=demo-state` | 用新的 session 读取并验证 checkpoint 内容 |
 | `DELETE /sample/state/{stateKey}` | 释放 checkpoint |
 
 ## 设计要点

--- a/examples/agent-runtime-middleware-state-inmemory/README.md
+++ b/examples/agent-runtime-middleware-state-inmemory/README.md
@@ -2,49 +2,27 @@
 
 本样例验证 OpenJiuwen Checkpointer 的 InMemory 形态。它代表短期状态或会话 checkpoint 的最小使用方式：用户启动常驻服务，通过 curl 保存、查询、释放 state。
 
-## 启动服务
+完整 step by step 教程见：[TUTORIAL.cn.md](TUTORIAL.cn.md)。
 
-在仓库根目录执行：
+## 快速启动
 
 ```bash
 ./mvnw -f examples/agent-runtime-middleware-state-inmemory/pom.xml spring-boot:run
 ```
 
-服务默认监听：
+默认监听：
 
 ```text
 http://localhost:18083
 ```
 
-## curl 验证
+## 主要接口
 
-1. 保存一次 state：
-
-```bash
-curl -s -X POST http://localhost:18083/sample/state/save \
-  -H 'Content-Type: application/json' \
-  -d '{"stateKey":"demo-state","input":"first turn","turn":1,"answer":"pong"}'
-```
-
-2. 查询 state 是否存在：
-
-```bash
-curl -s 'http://localhost:18083/sample/state/exists?stateKey=demo-state'
-```
-
-期望返回：
-
-```json
-{"stateKey":"demo-state","exists":true}
-```
-
-3. 释放 state：
-
-```bash
-curl -s -X DELETE http://localhost:18083/sample/state/demo-state
-```
-
-释放后再次查询应返回 `exists=false`。
+| 接口 | 用途 |
+|---|---|
+| `POST /sample/state/save` | 保存一次 OpenJiuwen session checkpoint |
+| `GET /sample/state/exists?stateKey=demo-state` | 查询 checkpoint 是否存在 |
+| `DELETE /sample/state/{stateKey}` | 释放 checkpoint |
 
 ## 设计要点
 

--- a/examples/agent-runtime-middleware-state-inmemory/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-state-inmemory/TUTORIAL.cn.md
@@ -84,7 +84,30 @@ curl -s 'http://localhost:18083/sample/state/exists?stateKey=demo-state'
 
 ---
 
-## 5. Step 4 — 释放 state
+## 5. Step 4 — 读取并验证 state 内容
+
+```bash
+curl -s 'http://localhost:18083/sample/state/load?stateKey=demo-state'
+```
+
+期望响应包含 `turn=1` 和 `answer=pong`，表示新的 session 已经从 checkpointer 恢复出保存内容：
+
+```json
+{
+  "stateKey": "demo-state",
+  "exists": true,
+  "state": {
+    "global_state": {
+      "turn": 1,
+      "answer": "pong"
+    }
+  }
+}
+```
+
+---
+
+## 6. Step 5 — 释放 state
 
 ```bash
 curl -s -X DELETE http://localhost:18083/sample/state/demo-state
@@ -103,7 +126,7 @@ curl -s -X DELETE http://localhost:18083/sample/state/demo-state
 
 ---
 
-## 6. Step 5 — 看代码入口
+## 7. Step 6 — 看代码入口
 
 关键代码在：
 
@@ -122,6 +145,6 @@ Checkpointer openJiuwenCheckpointer() {
 
 ---
 
-## 7. 清理
+## 8. 清理
 
 在启动服务的终端按 `Ctrl+C` 停止进程。InMemory checkpoint 随进程退出释放。

--- a/examples/agent-runtime-middleware-state-inmemory/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-state-inmemory/TUTORIAL.cn.md
@@ -1,0 +1,127 @@
+# InMemory Checkpointer 样例教程
+
+跟着做完，你会启动一个常驻样例服务，通过 curl 保存、查询、释放一次 OpenJiuwen session checkpoint。
+
+---
+
+## 0. 你将验证什么
+
+本样例验证短期状态链路：
+
+```text
+Spring Bean 初始化
+        ↓
+OpenJiuwenCheckpointerConfigurer.setInMemoryDefault()
+        ↓
+curl 保存 state
+        ↓
+OpenJiuwen InMemory Checkpointer 保存 checkpoint
+        ↓
+curl 查询 / 释放 checkpoint
+```
+
+---
+
+## 1. 环境准备
+
+在仓库根目录执行命令。需要：
+
+- JDK 21
+- curl
+- 本地 18083 端口未被占用
+
+Windows PowerShell 可以把下面的 `./mvnw` 换成 `./mvnw.cmd`。
+
+---
+
+## 2. Step 1 — 启动守护进程
+
+```bash
+./mvnw -f examples/agent-runtime-middleware-state-inmemory/pom.xml spring-boot:run
+```
+
+服务地址：
+
+```text
+http://localhost:18083
+```
+
+---
+
+## 3. Step 2 — 保存一次 state
+
+```bash
+curl -s -X POST http://localhost:18083/sample/state/save \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-state","input":"first turn","turn":1,"answer":"pong"}'
+```
+
+期望响应：
+
+```json
+{
+  "stateKey": "demo-state",
+  "exists": true
+}
+```
+
+---
+
+## 4. Step 3 — 查询 state 是否存在
+
+```bash
+curl -s 'http://localhost:18083/sample/state/exists?stateKey=demo-state'
+```
+
+期望响应：
+
+```json
+{
+  "stateKey": "demo-state",
+  "exists": true
+}
+```
+
+---
+
+## 5. Step 4 — 释放 state
+
+```bash
+curl -s -X DELETE http://localhost:18083/sample/state/demo-state
+```
+
+期望响应：
+
+```json
+{
+  "stateKey": "demo-state",
+  "exists": false
+}
+```
+
+释放后再次查询应返回 `exists=false`。
+
+---
+
+## 6. Step 5 — 看代码入口
+
+关键代码在：
+
+- `AgentStateInMemoryApplication.java`
+- `AgentStateInMemoryConfiguration#openJiuwenCheckpointer()`
+- `OpenJiuwenCheckpointerConfigurer.setInMemoryDefault()`
+
+用户侧要复用这个模式时，核心动作是：
+
+```java
+@Bean
+Checkpointer openJiuwenCheckpointer() {
+    return OpenJiuwenCheckpointerConfigurer.setInMemoryDefault();
+}
+```
+
+---
+
+## 7. 清理
+
+在启动服务的终端按 `Ctrl+C` 停止进程。InMemory checkpoint 随进程退出释放。

--- a/examples/agent-runtime-middleware-state-inmemory/pom.xml
+++ b/examples/agent-runtime-middleware-state-inmemory/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.huawei.ascend</groupId>
     <artifactId>spring-ai-ascend-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -31,9 +31,30 @@
       <version>0.1.12-jdk17</version>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.33.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <mainClass>com.huawei.ascend.examples.runtime.middleware.agentstate.inmemory.AgentStateInMemoryApplication</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/examples/agent-runtime-middleware-state-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/inmemory/AgentStateInMemoryApplication.java
+++ b/examples/agent-runtime-middleware-state-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/inmemory/AgentStateInMemoryApplication.java
@@ -42,12 +42,12 @@ class AgentStateInMemoryController {
     @PostMapping("/sample/state/save")
     Map<String, Object> save(@RequestBody StateRequest request) {
         String stateKey = normalizeStateKey(request.stateKey());
-        String input = request.input() == null ? "" : request.input();
-        String answer = request.answer() == null ? "" : request.answer();
-        AgentSessionApi session = new AgentSessionApi(stateKey);
-        checkpointer.preAgentExecute(session.getInner(), Map.of("input", input));
-        session.updateState(Map.of("turn", request.turn(), "answer", answer));
-        checkpointer.postAgentExecute(session.getInner());
+        String userInput = request.input() == null ? "" : request.input();
+        String agentAnswer = request.answer() == null ? "" : request.answer();
+        AgentSessionApi stateSession = new AgentSessionApi(stateKey);
+        checkpointer.preAgentExecute(stateSession.getInner(), Map.of("input", userInput));
+        stateSession.updateState(Map.of("turn", request.turn(), "answer", agentAnswer));
+        checkpointer.postAgentExecute(stateSession.getInner());
         return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey));
     }
 
@@ -58,9 +58,9 @@ class AgentStateInMemoryController {
 
     @GetMapping("/sample/state/load")
     Map<String, Object> load(@RequestParam(defaultValue = "demo-state") String stateKey) {
-        AgentSessionApi session = new AgentSessionApi(stateKey);
-        checkpointer.preAgentExecute(session.getInner(), Map.of());
-        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey), "state", session.dumpState());
+        AgentSessionApi restoredSession = new AgentSessionApi(stateKey);
+        checkpointer.preAgentExecute(restoredSession.getInner(), Map.of());
+        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey), "state", restoredSession.dumpState());
     }
 
     @DeleteMapping("/sample/state/{stateKey}")

--- a/examples/agent-runtime-middleware-state-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/inmemory/AgentStateInMemoryApplication.java
+++ b/examples/agent-runtime-middleware-state-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/inmemory/AgentStateInMemoryApplication.java
@@ -56,6 +56,13 @@ class AgentStateInMemoryController {
         return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey));
     }
 
+    @GetMapping("/sample/state/load")
+    Map<String, Object> load(@RequestParam(defaultValue = "demo-state") String stateKey) {
+        AgentSessionApi session = new AgentSessionApi(stateKey);
+        checkpointer.preAgentExecute(session.getInner(), Map.of());
+        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey), "state", session.dumpState());
+    }
+
     @DeleteMapping("/sample/state/{stateKey}")
     Map<String, Object> release(@PathVariable String stateKey) {
         checkpointer.release(stateKey);

--- a/examples/agent-runtime-middleware-state-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/inmemory/AgentStateInMemoryApplication.java
+++ b/examples/agent-runtime-middleware-state-inmemory/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/inmemory/AgentStateInMemoryApplication.java
@@ -1,0 +1,71 @@
+package com.huawei.ascend.examples.runtime.middleware.agentstate.inmemory;
+
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenCheckpointerConfigurer;
+import com.openjiuwen.core.session.AgentSessionApi;
+import com.openjiuwen.core.session.checkpointer.Checkpointer;
+import java.util.Map;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+public class AgentStateInMemoryApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(AgentStateInMemoryApplication.class, args);
+    }
+}
+
+@Configuration(proxyBeanMethods = false)
+class AgentStateInMemoryConfiguration {
+    @Bean
+    Checkpointer openJiuwenCheckpointer() {
+        return OpenJiuwenCheckpointerConfigurer.setInMemoryDefault();
+    }
+}
+
+@RestController
+class AgentStateInMemoryController {
+    private final Checkpointer checkpointer;
+
+    AgentStateInMemoryController(Checkpointer checkpointer) {
+        this.checkpointer = checkpointer;
+    }
+
+    @PostMapping("/sample/state/save")
+    Map<String, Object> save(@RequestBody StateRequest request) {
+        String stateKey = normalizeStateKey(request.stateKey());
+        String input = request.input() == null ? "" : request.input();
+        String answer = request.answer() == null ? "" : request.answer();
+        AgentSessionApi session = new AgentSessionApi(stateKey);
+        checkpointer.preAgentExecute(session.getInner(), Map.of("input", input));
+        session.updateState(Map.of("turn", request.turn(), "answer", answer));
+        checkpointer.postAgentExecute(session.getInner());
+        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey));
+    }
+
+    @GetMapping("/sample/state/exists")
+    Map<String, Object> exists(@RequestParam(defaultValue = "demo-state") String stateKey) {
+        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey));
+    }
+
+    @DeleteMapping("/sample/state/{stateKey}")
+    Map<String, Object> release(@PathVariable String stateKey) {
+        checkpointer.release(stateKey);
+        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey));
+    }
+
+    private static String normalizeStateKey(String stateKey) {
+        return stateKey == null || stateKey.isBlank() ? "demo-state" : stateKey;
+    }
+
+    record StateRequest(String stateKey, String input, int turn, String answer) {
+    }
+}

--- a/examples/agent-runtime-middleware-state-inmemory/src/main/resources/application.yaml
+++ b/examples/agent-runtime-middleware-state-inmemory/src/main/resources/application.yaml
@@ -1,0 +1,2 @@
+server:
+  port: 18083

--- a/examples/agent-runtime-middleware-state-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/agentstate/inmemory/AgentStateInMemoryExampleTest.java
+++ b/examples/agent-runtime-middleware-state-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/agentstate/inmemory/AgentStateInMemoryExampleTest.java
@@ -14,40 +14,40 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class AgentStateInMemoryExampleTest {
-    private Checkpointer original;
+    private Checkpointer originalCheckpointer;
 
     @BeforeEach
     void captureOriginalCheckpointer() {
-        original = CheckpointerFactory.getCheckpointer();
+        originalCheckpointer = CheckpointerFactory.getCheckpointer();
     }
 
     @AfterEach
     void restoreOriginalCheckpointer() {
-        CheckpointerFactory.setDefaultCheckpointer(original);
+        CheckpointerFactory.setDefaultCheckpointer(originalCheckpointer);
     }
 
     @Test
     void inMemoryCheckpointerPersistsAndReleasesAgentSession() {
-        Checkpointer checkpointer = OpenJiuwenCheckpointerConfigurer.setInMemoryDefault();
+        Checkpointer inMemoryCheckpointer = OpenJiuwenCheckpointerConfigurer.setInMemoryDefault();
         String sessionId = "in-memory-state-" + UUID.randomUUID();
-        AgentSessionApi session = new AgentSessionApi(sessionId);
+        AgentSessionApi savedSession = new AgentSessionApi(sessionId);
 
-        checkpointer.preAgentExecute(session.getInner(), Map.of("input", "ping"));
-        session.updateState(Map.of("turn", 1, "answer", "pong"));
-        checkpointer.postAgentExecute(session.getInner());
+        inMemoryCheckpointer.preAgentExecute(savedSession.getInner(), Map.of("input", "ping"));
+        savedSession.updateState(Map.of("turn", 1, "answer", "pong"));
+        inMemoryCheckpointer.postAgentExecute(savedSession.getInner());
 
-        assertThat(checkpointer).isInstanceOf(InMemoryCheckpointer.class);
-        assertThat(checkpointer.sessionExists(sessionId)).isTrue();
+        assertThat(inMemoryCheckpointer).isInstanceOf(InMemoryCheckpointer.class);
+        assertThat(inMemoryCheckpointer.sessionExists(sessionId)).isTrue();
 
-        AgentSessionApi restored = new AgentSessionApi(sessionId);
-        checkpointer.preAgentExecute(restored.getInner(), Map.of());
-        Map<?, ?> globalState = (Map<?, ?>) restored.dumpState().get("global_state");
+        AgentSessionApi restoredSession = new AgentSessionApi(sessionId);
+        inMemoryCheckpointer.preAgentExecute(restoredSession.getInner(), Map.of());
+        Map<?, ?> restoredGlobalState = (Map<?, ?>) restoredSession.dumpState().get("global_state");
 
-        assertThat(globalState.get("turn")).isEqualTo(1);
-        assertThat(globalState.get("answer")).isEqualTo("pong");
+        assertThat(restoredGlobalState.get("turn")).isEqualTo(1);
+        assertThat(restoredGlobalState.get("answer")).isEqualTo("pong");
 
-        checkpointer.release(sessionId);
+        inMemoryCheckpointer.release(sessionId);
 
-        assertThat(checkpointer.sessionExists(sessionId)).isFalse();
+        assertThat(inMemoryCheckpointer.sessionExists(sessionId)).isFalse();
     }
 }

--- a/examples/agent-runtime-middleware-state-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/agentstate/inmemory/AgentStateInMemoryExampleTest.java
+++ b/examples/agent-runtime-middleware-state-inmemory/src/test/java/com/huawei/ascend/examples/runtime/middleware/agentstate/inmemory/AgentStateInMemoryExampleTest.java
@@ -39,6 +39,13 @@ class AgentStateInMemoryExampleTest {
         assertThat(checkpointer).isInstanceOf(InMemoryCheckpointer.class);
         assertThat(checkpointer.sessionExists(sessionId)).isTrue();
 
+        AgentSessionApi restored = new AgentSessionApi(sessionId);
+        checkpointer.preAgentExecute(restored.getInner(), Map.of());
+        Map<?, ?> globalState = (Map<?, ?>) restored.dumpState().get("global_state");
+
+        assertThat(globalState.get("turn")).isEqualTo(1);
+        assertThat(globalState.get("answer")).isEqualTo("pong");
+
         checkpointer.release(sessionId);
 
         assertThat(checkpointer.sessionExists(sessionId)).isFalse();

--- a/examples/agent-runtime-middleware-state-redis/README.md
+++ b/examples/agent-runtime-middleware-state-redis/README.md
@@ -1,66 +1,31 @@
 # Agent Runtime Agent State Redis Example
 
-本样例验证 OpenJiuwen Checkpointer 的 Redis 形态。它代表短期状态或会话 checkpoint 接入可恢复后端的方式：用户先启动 Redis，再启动样例服务，通过 curl 保存、查询、释放 state。
+本样例验证 OpenJiuwen Checkpointer 的 Redis 形态。它代表短期状态或会话 checkpoint 接入可恢复后端的方式：用户先准备 Redis，再启动样例服务，通过 curl 保存、查询、释放 state。
 
-## 外部环境
+完整 step by step 教程见：[TUTORIAL.cn.md](TUTORIAL.cn.md)。
 
-启动前需要有可访问的 Redis：
+## 快速启动
 
-```text
-redis.host=localhost
-redis.port=6379
-```
-
-可以通过启动参数覆盖：
+先准备可访问的 Redis，然后启动样例：
 
 ```bash
 ./mvnw -f examples/agent-runtime-middleware-state-redis/pom.xml spring-boot:run \
-  -Dspring-boot.run.arguments="--redis.host=localhost --redis.port=6379"
+  -Dspring-boot.run.arguments="--sample.openjiuwen.redis-url=redis://localhost:6379"
 ```
 
-## 启动服务
-
-在仓库根目录执行：
-
-```bash
-./mvnw -f examples/agent-runtime-middleware-state-redis/pom.xml spring-boot:run
-```
-
-服务默认监听：
+默认监听：
 
 ```text
 http://localhost:18084
 ```
 
-## curl 验证
+## 主要接口
 
-1. 保存一次 state：
-
-```bash
-curl -s -X POST http://localhost:18084/sample/state/save \
-  -H 'Content-Type: application/json' \
-  -d '{"stateKey":"demo-state","input":"first turn","turn":1,"answer":"pong"}'
-```
-
-2. 查询 state 是否存在：
-
-```bash
-curl -s 'http://localhost:18084/sample/state/exists?stateKey=demo-state'
-```
-
-期望返回：
-
-```json
-{"stateKey":"demo-state","exists":true}
-```
-
-3. 释放 state：
-
-```bash
-curl -s -X DELETE http://localhost:18084/sample/state/demo-state
-```
-
-释放后再次查询应返回 `exists=false`。
+| 接口 | 用途 |
+|---|---|
+| `POST /sample/state/save` | 保存一次 OpenJiuwen session checkpoint |
+| `GET /sample/state/exists?stateKey=demo-state` | 查询 checkpoint 是否存在 |
+| `DELETE /sample/state/{stateKey}` | 释放 checkpoint |
 
 ## 设计要点
 

--- a/examples/agent-runtime-middleware-state-redis/README.md
+++ b/examples/agent-runtime-middleware-state-redis/README.md
@@ -25,6 +25,7 @@ http://localhost:18084
 |---|---|
 | `POST /sample/state/save` | 保存一次 OpenJiuwen session checkpoint |
 | `GET /sample/state/exists?stateKey=demo-state` | 查询 checkpoint 是否存在 |
+| `GET /sample/state/load?stateKey=demo-state` | 用新的 session 读取并验证 checkpoint 内容 |
 | `DELETE /sample/state/{stateKey}` | 释放 checkpoint |
 
 ## 设计要点

--- a/examples/agent-runtime-middleware-state-redis/README.md
+++ b/examples/agent-runtime-middleware-state-redis/README.md
@@ -1,74 +1,69 @@
-# agent-runtime middleware state Redis example
+# Agent Runtime Agent State Redis Example
 
-这个样例验证「中间件解耦」下的 Agent State Redis 持久化路径：
-业务侧创建 OpenJiuwen 原生 `RedisCheckpointer`，再通过
-`OpenJiuwenCheckpointerConfigurer.setDefault(...)` 注入。`agent-runtime`
-公共层不绑定 Redis 或 OpenJiuwen Redis 包名。
+本样例验证 OpenJiuwen Checkpointer 的 Redis 形态。它代表短期状态或会话 checkpoint 接入可恢复后端的方式：用户先启动 Redis，再启动样例服务，通过 curl 保存、查询、释放 state。
 
-## 配置方式
+## 外部环境
 
-适用场景：
-
-- 需要跨进程、跨重启恢复 Agent State。
-- 需要用 Redis 保存 OpenJiuwen 原生 checkpoint。
-- 希望验证生产态持久化后端，但仍保持 runtime 公共层不依赖 Redis。
-
-核心配置点：
-
-```java
-Checkpointer redisCheckpointer = new RedisCheckpointer.Provider()
-        .create(Map.of("connection", Map.of("url", redisUrl)));
-OpenJiuwenCheckpointerConfigurer.setDefault(redisCheckpointer);
-```
-
-`redisUrl` 由业务部署或测试环境提供。`agent-runtime` 不解析 Redis 配置，
-也不直接依赖 Redis 包名；它只提供 `setDefault(...)` 入口，把业务侧创建好的
-OpenJiuwen checkpointer 注入到 OpenJiuwen 的 `CheckpointerFactory`。
-
-测试团队检查点：
-
-- Redis 服务可达。
-- 环境变量 `SAA_SAMPLE_OPENJIUWEN_REDIS_URL` 指向实际 Redis。
-- `preAgentExecute(...)` 能恢复 session。
-- `postAgentExecute(...)` 后 `sessionExists(sessionId)` 返回 `true`。
-- `release(sessionId)` 后 Redis 中对应 checkpoint 被清理。
-
-## Environment
-
-启动一个 Redis，并设置连接地址：
-
-```bash
-docker run --rm -p 6379:6379 redis:7-alpine
-export SAA_SAMPLE_OPENJIUWEN_REDIS_URL=redis://localhost:6379
-```
-
-如果 Docker Hub 访问不稳定，可以换成内部镜像或大陆镜像仓的 Redis 镜像；
-只要最终暴露 `localhost:6379` 即可。
-
-如果没有设置该环境变量，测试会通过 JUnit assumption 跳过。
-
-## Run
-
-```bash
-./mvnw -f examples/agent-runtime-middleware-state-redis/pom.xml test
-```
-
-## 端到端链路
+启动前需要有可访问的 Redis：
 
 ```text
-Redis service
-  -> RedisCheckpointer.Provider().create(...)
-  -> OpenJiuwenCheckpointerConfigurer.setDefault(...)
-  -> AgentSessionApi(sessionId)
-  -> checkpointer.preAgentExecute(...)
-  -> session.updateState(...)
-  -> checkpointer.postAgentExecute(...)
-  -> checkpointer.sessionExists(sessionId)
-  -> checkpointer.release(sessionId)
+redis.host=localhost
+redis.port=6379
 ```
 
-## Scope
+可以通过启动参数覆盖：
 
-- 验证 `preAgentExecute -> postAgentExecute -> release` 的一轮 Redis
-  checkpointer 状态持久化链路。
-- 不引入脚本；Redis 启动和环境变量配置由 README 说明。
+```bash
+./mvnw -f examples/agent-runtime-middleware-state-redis/pom.xml spring-boot:run \
+  -Dspring-boot.run.arguments="--redis.host=localhost --redis.port=6379"
+```
+
+## 启动服务
+
+在仓库根目录执行：
+
+```bash
+./mvnw -f examples/agent-runtime-middleware-state-redis/pom.xml spring-boot:run
+```
+
+服务默认监听：
+
+```text
+http://localhost:18084
+```
+
+## curl 验证
+
+1. 保存一次 state：
+
+```bash
+curl -s -X POST http://localhost:18084/sample/state/save \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-state","input":"first turn","turn":1,"answer":"pong"}'
+```
+
+2. 查询 state 是否存在：
+
+```bash
+curl -s 'http://localhost:18084/sample/state/exists?stateKey=demo-state'
+```
+
+期望返回：
+
+```json
+{"stateKey":"demo-state","exists":true}
+```
+
+3. 释放 state：
+
+```bash
+curl -s -X DELETE http://localhost:18084/sample/state/demo-state
+```
+
+释放后再次查询应返回 `exists=false`。
+
+## 设计要点
+
+- `OpenJiuwenCheckpointerConfigurer.setDefault(...)` 把 Redis checkpointer 设置为 OpenJiuwen 默认实现。
+- Redis 适合验证“短期状态可恢复后端”的 wiring 方式。
+- 本样例不负责启动 Redis；测试团队或客户开发团队按自己的环境准备即可。

--- a/examples/agent-runtime-middleware-state-redis/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-state-redis/TUTORIAL.cn.md
@@ -1,0 +1,143 @@
+# Redis Checkpointer 样例教程
+
+跟着做完，你会准备一个 Redis，再启动样例服务，通过 curl 保存、查询、释放一次 OpenJiuwen session checkpoint。
+
+---
+
+## 0. 你将验证什么
+
+本样例验证短期状态接入可恢复后端：
+
+```text
+Redis 启动
+        ↓
+Spring Bean 初始化
+        ↓
+RedisCheckpointer.Provider 创建 Checkpointer
+        ↓
+OpenJiuwenCheckpointerConfigurer.setDefault(...)
+        ↓
+curl 保存 / 查询 / 释放 checkpoint
+```
+
+---
+
+## 1. 环境准备
+
+在仓库根目录执行命令。需要：
+
+- JDK 21
+- curl
+- 一个可访问的 Redis
+- 本地 18084 端口未被占用
+
+Windows PowerShell 可以把下面的 `./mvnw` 换成 `./mvnw.cmd`。
+
+如果你用 Docker，可以临时启动 Redis：
+
+```bash
+docker run --name saa-redis-checkpointer -p 6379:6379 -d redis:7
+```
+
+---
+
+## 2. Step 1 — 启动样例守护进程
+
+```bash
+./mvnw -f examples/agent-runtime-middleware-state-redis/pom.xml spring-boot:run \
+  -Dspring-boot.run.arguments="--sample.openjiuwen.redis-url=redis://localhost:6379"
+```
+
+服务地址：
+
+```text
+http://localhost:18084
+```
+
+---
+
+## 3. Step 2 — 保存一次 state
+
+```bash
+curl -s -X POST http://localhost:18084/sample/state/save \
+  -H 'Content-Type: application/json' \
+  -d '{"stateKey":"demo-state","input":"first turn","turn":1,"answer":"pong"}'
+```
+
+期望响应：
+
+```json
+{
+  "stateKey": "demo-state",
+  "exists": true
+}
+```
+
+---
+
+## 4. Step 3 — 查询 state 是否存在
+
+```bash
+curl -s 'http://localhost:18084/sample/state/exists?stateKey=demo-state'
+```
+
+期望响应：
+
+```json
+{
+  "stateKey": "demo-state",
+  "exists": true
+}
+```
+
+---
+
+## 5. Step 4 — 释放 state
+
+```bash
+curl -s -X DELETE http://localhost:18084/sample/state/demo-state
+```
+
+期望响应：
+
+```json
+{
+  "stateKey": "demo-state",
+  "exists": false
+}
+```
+
+释放后再次查询应返回 `exists=false`。
+
+---
+
+## 6. Step 5 — 看代码入口
+
+关键代码在：
+
+- `AgentStateRedisApplication.java`
+- `AgentStateRedisConfiguration#openJiuwenCheckpointer(...)`
+- `OpenJiuwenCheckpointerConfigurer.setDefault(...)`
+
+用户侧要复用这个模式时，核心动作是：
+
+```java
+@Bean
+Checkpointer openJiuwenCheckpointer(String redisUrl) {
+    Checkpointer redisCheckpointer = new RedisCheckpointer.Provider()
+            .create(Map.of("connection", Map.of("url", redisUrl)));
+    return OpenJiuwenCheckpointerConfigurer.setDefault(redisCheckpointer);
+}
+```
+
+---
+
+## 7. 清理
+
+在启动服务的终端按 `Ctrl+C` 停止进程。
+
+如果你使用了上面的 Docker Redis：
+
+```bash
+docker rm -f saa-redis-checkpointer
+```

--- a/examples/agent-runtime-middleware-state-redis/TUTORIAL.cn.md
+++ b/examples/agent-runtime-middleware-state-redis/TUTORIAL.cn.md
@@ -92,7 +92,30 @@ curl -s 'http://localhost:18084/sample/state/exists?stateKey=demo-state'
 
 ---
 
-## 5. Step 4 — 释放 state
+## 5. Step 4 — 读取并验证 state 内容
+
+```bash
+curl -s 'http://localhost:18084/sample/state/load?stateKey=demo-state'
+```
+
+期望响应包含 `turn=1` 和 `answer=pong`，表示新的 session 已经从 Redis checkpointer 恢复出保存内容：
+
+```json
+{
+  "stateKey": "demo-state",
+  "exists": true,
+  "state": {
+    "global_state": {
+      "turn": 1,
+      "answer": "pong"
+    }
+  }
+}
+```
+
+---
+
+## 6. Step 5 — 释放 state
 
 ```bash
 curl -s -X DELETE http://localhost:18084/sample/state/demo-state
@@ -111,7 +134,7 @@ curl -s -X DELETE http://localhost:18084/sample/state/demo-state
 
 ---
 
-## 6. Step 5 — 看代码入口
+## 7. Step 6 — 看代码入口
 
 关键代码在：
 
@@ -132,7 +155,7 @@ Checkpointer openJiuwenCheckpointer(String redisUrl) {
 
 ---
 
-## 7. 清理
+## 8. 清理
 
 在启动服务的终端按 `Ctrl+C` 停止进程。
 

--- a/examples/agent-runtime-middleware-state-redis/pom.xml
+++ b/examples/agent-runtime-middleware-state-redis/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>com.huawei.ascend</groupId>
     <artifactId>spring-ai-ascend-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -31,9 +31,30 @@
       <version>0.1.12-jdk17</version>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.33.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <mainClass>com.huawei.ascend.examples.runtime.middleware.agentstate.redis.AgentStateRedisApplication</mainClass>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/examples/agent-runtime-middleware-state-redis/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/redis/AgentStateRedisApplication.java
+++ b/examples/agent-runtime-middleware-state-redis/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/redis/AgentStateRedisApplication.java
@@ -1,0 +1,77 @@
+package com.huawei.ascend.examples.runtime.middleware.agentstate.redis;
+
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenCheckpointerConfigurer;
+import com.openjiuwen.core.session.AgentSessionApi;
+import com.openjiuwen.core.session.checkpointer.Checkpointer;
+import com.openjiuwen.extensions.checkpointer.redis.RedisCheckpointer;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@SpringBootApplication
+public class AgentStateRedisApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(AgentStateRedisApplication.class, args);
+    }
+}
+
+@Configuration(proxyBeanMethods = false)
+class AgentStateRedisConfiguration {
+    @Bean
+    Checkpointer openJiuwenCheckpointer(
+            @Value("${sample.openjiuwen.redis-url:${SAA_SAMPLE_OPENJIUWEN_REDIS_URL:redis://localhost:6379}}")
+            String redisUrl) {
+        Checkpointer redisCheckpointer = new RedisCheckpointer.Provider()
+                .create(Map.of("connection", Map.of("url", redisUrl)));
+        return OpenJiuwenCheckpointerConfigurer.setDefault(redisCheckpointer);
+    }
+}
+
+@RestController
+class AgentStateRedisController {
+    private final Checkpointer checkpointer;
+
+    AgentStateRedisController(Checkpointer checkpointer) {
+        this.checkpointer = checkpointer;
+    }
+
+    @PostMapping("/sample/state/save")
+    Map<String, Object> save(@RequestBody StateRequest request) {
+        String stateKey = normalizeStateKey(request.stateKey());
+        String input = request.input() == null ? "" : request.input();
+        String answer = request.answer() == null ? "" : request.answer();
+        AgentSessionApi session = new AgentSessionApi(stateKey);
+        checkpointer.preAgentExecute(session.getInner(), Map.of("input", input));
+        session.updateState(Map.of("turn", request.turn(), "answer", answer));
+        checkpointer.postAgentExecute(session.getInner());
+        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey));
+    }
+
+    @GetMapping("/sample/state/exists")
+    Map<String, Object> exists(@RequestParam(defaultValue = "demo-state") String stateKey) {
+        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey));
+    }
+
+    @DeleteMapping("/sample/state/{stateKey}")
+    Map<String, Object> release(@PathVariable String stateKey) {
+        checkpointer.release(stateKey);
+        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey));
+    }
+
+    private static String normalizeStateKey(String stateKey) {
+        return stateKey == null || stateKey.isBlank() ? "demo-state" : stateKey;
+    }
+
+    record StateRequest(String stateKey, String input, int turn, String answer) {
+    }
+}

--- a/examples/agent-runtime-middleware-state-redis/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/redis/AgentStateRedisApplication.java
+++ b/examples/agent-runtime-middleware-state-redis/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/redis/AgentStateRedisApplication.java
@@ -62,6 +62,13 @@ class AgentStateRedisController {
         return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey));
     }
 
+    @GetMapping("/sample/state/load")
+    Map<String, Object> load(@RequestParam(defaultValue = "demo-state") String stateKey) {
+        AgentSessionApi session = new AgentSessionApi(stateKey);
+        checkpointer.preAgentExecute(session.getInner(), Map.of());
+        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey), "state", session.dumpState());
+    }
+
     @DeleteMapping("/sample/state/{stateKey}")
     Map<String, Object> release(@PathVariable String stateKey) {
         checkpointer.release(stateKey);

--- a/examples/agent-runtime-middleware-state-redis/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/redis/AgentStateRedisApplication.java
+++ b/examples/agent-runtime-middleware-state-redis/src/main/java/com/huawei/ascend/examples/runtime/middleware/agentstate/redis/AgentStateRedisApplication.java
@@ -48,12 +48,12 @@ class AgentStateRedisController {
     @PostMapping("/sample/state/save")
     Map<String, Object> save(@RequestBody StateRequest request) {
         String stateKey = normalizeStateKey(request.stateKey());
-        String input = request.input() == null ? "" : request.input();
-        String answer = request.answer() == null ? "" : request.answer();
-        AgentSessionApi session = new AgentSessionApi(stateKey);
-        checkpointer.preAgentExecute(session.getInner(), Map.of("input", input));
-        session.updateState(Map.of("turn", request.turn(), "answer", answer));
-        checkpointer.postAgentExecute(session.getInner());
+        String userInput = request.input() == null ? "" : request.input();
+        String agentAnswer = request.answer() == null ? "" : request.answer();
+        AgentSessionApi stateSession = new AgentSessionApi(stateKey);
+        checkpointer.preAgentExecute(stateSession.getInner(), Map.of("input", userInput));
+        stateSession.updateState(Map.of("turn", request.turn(), "answer", agentAnswer));
+        checkpointer.postAgentExecute(stateSession.getInner());
         return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey));
     }
 
@@ -64,9 +64,9 @@ class AgentStateRedisController {
 
     @GetMapping("/sample/state/load")
     Map<String, Object> load(@RequestParam(defaultValue = "demo-state") String stateKey) {
-        AgentSessionApi session = new AgentSessionApi(stateKey);
-        checkpointer.preAgentExecute(session.getInner(), Map.of());
-        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey), "state", session.dumpState());
+        AgentSessionApi restoredSession = new AgentSessionApi(stateKey);
+        checkpointer.preAgentExecute(restoredSession.getInner(), Map.of());
+        return Map.of("stateKey", stateKey, "exists", checkpointer.sessionExists(stateKey), "state", restoredSession.dumpState());
     }
 
     @DeleteMapping("/sample/state/{stateKey}")

--- a/examples/agent-runtime-middleware-state-redis/src/main/resources/application.yaml
+++ b/examples/agent-runtime-middleware-state-redis/src/main/resources/application.yaml
@@ -1,0 +1,2 @@
+server:
+  port: 18084

--- a/examples/agent-runtime-middleware-state-redis/src/test/java/com/huawei/ascend/examples/runtime/middleware/agentstate/redis/AgentStateRedisExampleTest.java
+++ b/examples/agent-runtime-middleware-state-redis/src/test/java/com/huawei/ascend/examples/runtime/middleware/agentstate/redis/AgentStateRedisExampleTest.java
@@ -17,16 +17,16 @@ import org.junit.jupiter.api.Test;
 
 @Tag("manual")
 class AgentStateRedisExampleTest {
-    private Checkpointer original;
+    private Checkpointer originalCheckpointer;
 
     @BeforeEach
     void captureOriginalCheckpointer() {
-        original = CheckpointerFactory.getCheckpointer();
+        originalCheckpointer = CheckpointerFactory.getCheckpointer();
     }
 
     @AfterEach
     void restoreOriginalCheckpointer() {
-        CheckpointerFactory.setDefaultCheckpointer(original);
+        CheckpointerFactory.setDefaultCheckpointer(originalCheckpointer);
     }
 
     @Test
@@ -36,27 +36,27 @@ class AgentStateRedisExampleTest {
 
         Checkpointer redisCheckpointer = new RedisCheckpointer.Provider()
                 .create(Map.of("connection", Map.of("url", redisUrl)));
-        Checkpointer installed = OpenJiuwenCheckpointerConfigurer.setDefault(redisCheckpointer);
+        Checkpointer installedCheckpointer = OpenJiuwenCheckpointerConfigurer.setDefault(redisCheckpointer);
         String sessionId = "redis-state-" + UUID.randomUUID();
-        AgentSessionApi session = new AgentSessionApi(sessionId);
+        AgentSessionApi savedSession = new AgentSessionApi(sessionId);
 
-        installed.preAgentExecute(session.getInner(), Map.of("input", "ping"));
-        session.updateState(Map.of("turn", 1, "answer", "pong"));
-        installed.postAgentExecute(session.getInner());
+        installedCheckpointer.preAgentExecute(savedSession.getInner(), Map.of("input", "ping"));
+        savedSession.updateState(Map.of("turn", 1, "answer", "pong"));
+        installedCheckpointer.postAgentExecute(savedSession.getInner());
 
-        assertThat(installed).isSameAs(redisCheckpointer);
-        assertThat(installed.sessionExists(sessionId)).isTrue();
+        assertThat(installedCheckpointer).isSameAs(redisCheckpointer);
+        assertThat(installedCheckpointer.sessionExists(sessionId)).isTrue();
 
-        AgentSessionApi restored = new AgentSessionApi(sessionId);
-        installed.preAgentExecute(restored.getInner(), Map.of());
-        Map<?, ?> globalState = (Map<?, ?>) restored.dumpState().get("global_state");
+        AgentSessionApi restoredSession = new AgentSessionApi(sessionId);
+        installedCheckpointer.preAgentExecute(restoredSession.getInner(), Map.of());
+        Map<?, ?> restoredGlobalState = (Map<?, ?>) restoredSession.dumpState().get("global_state");
 
-        assertThat(globalState.get("turn")).isEqualTo(1);
-        assertThat(globalState.get("answer")).isEqualTo("pong");
+        assertThat(restoredGlobalState.get("turn")).isEqualTo(1);
+        assertThat(restoredGlobalState.get("answer")).isEqualTo("pong");
 
-        installed.release(sessionId);
+        installedCheckpointer.release(sessionId);
 
-        assertThat(installed.sessionExists(sessionId)).isFalse();
+        assertThat(installedCheckpointer.sessionExists(sessionId)).isFalse();
     }
 
     private static boolean hasText(String value) {

--- a/examples/agent-runtime-middleware-state-redis/src/test/java/com/huawei/ascend/examples/runtime/middleware/agentstate/redis/AgentStateRedisExampleTest.java
+++ b/examples/agent-runtime-middleware-state-redis/src/test/java/com/huawei/ascend/examples/runtime/middleware/agentstate/redis/AgentStateRedisExampleTest.java
@@ -47,6 +47,13 @@ class AgentStateRedisExampleTest {
         assertThat(installed).isSameAs(redisCheckpointer);
         assertThat(installed.sessionExists(sessionId)).isTrue();
 
+        AgentSessionApi restored = new AgentSessionApi(sessionId);
+        installed.preAgentExecute(restored.getInner(), Map.of());
+        Map<?, ?> globalState = (Map<?, ?>) restored.dumpState().get("global_state");
+
+        assertThat(globalState.get("turn")).isEqualTo(1);
+        assertThat(globalState.get("answer")).isEqualTo("pong");
+
         installed.release(sessionId);
 
         assertThat(installed.sessionExists(sessionId)).isFalse();


### PR DESCRIPTION
﻿## Summary

- add daemon-style Spring Boot entrypoints for the four middleware examples
- document curl-based validation for InMemory/Redis state and InMemory/Mem0 memory paths
- show OpenJiuwen rail wiring through preset example handlers instead of Maven-test-only usage
- simplify memory rail wiring in the examples: each sample handler now directly holds its `MemoryProvider` and registers the single memory rail in `openJiuwenRails(context)`, instead of exposing `railFactories`
- update memory examples to use real OpenJiuwen Runner execution and real OpenAI-compatible LLM configuration from environment variables; the examples no longer override `runOpenJiuwenAgent(...)` or register fake sample model clients
- update manual memory assertions to use an LLM judge: after the real handler call returns, the test asks the same OpenAI-compatible endpoint to judge whether the answer correctly used the remembered `green tea` preference
- strengthen state examples beyond existence checks: `save` can now be followed by `load`, which restores a fresh OpenJiuwen session and returns the real `dumpState()` payload, including `global_state.turn` and `global_state.answer`

## Tutorial entrypoints

- `examples/agent-runtime-middleware-memory-inmemory/TUTORIAL.cn.md`
- `examples/agent-runtime-middleware-memory-mem0/TUTORIAL.cn.md`
- `examples/agent-runtime-middleware-state-inmemory/TUTORIAL.cn.md`
- `examples/agent-runtime-middleware-state-redis/TUTORIAL.cn.md`

## Validation

- `./mvnw.cmd -f examples/agent-runtime-middleware-memory-inmemory/pom.xml test` (without LLM env: manual test skips)
- `SAA_SAMPLE_LLM_API_KEY=<from local secret> SAA_SAMPLE_OPENJIUWEN_API_BASE=https://api.deepseek.com SAA_SAMPLE_LLM_MODEL=deepseek-chat ./mvnw.cmd -f examples/agent-runtime-middleware-memory-inmemory/pom.xml test` (real DeepSeek path passed; logs show `Relevant memory` injected into the real ReActAgent system message; the follow-up LLM judge returned `PASS`)
- `./mvnw.cmd -f examples/agent-runtime-middleware-memory-mem0/pom.xml test` (external Mem0/LLM-dependent test skips when services/env are unavailable)
- `./mvnw.cmd -f examples/agent-runtime-middleware-state-inmemory/pom.xml test`
- `./mvnw.cmd -f examples/agent-runtime-middleware-state-redis/pom.xml test` (external Redis-dependent test skips when service is unavailable)
- manually started the InMemory memory daemon and verified `remember`, `ask`, and `records` with curl
- manually started the InMemory state daemon and verified `save`, `load`, and `delete` with curl; `load` restored a fresh session and returned `state.global_state.turn=1` plus `state.global_state.answer=pong`
- docs/code formatting: `git diff --check -- examples/agent-runtime-middleware-memory-inmemory examples/agent-runtime-middleware-memory-mem0 examples/agent-runtime-middleware-state-inmemory examples/agent-runtime-middleware-state-redis`

## Notes

- Mem0 and Redis examples intentionally document external environment setup in README files instead of shipping scripts.
- This PR is draft for reviewer confirmation of the example shape.
