### PR TITLE
[codex] Lazy-load OpenJiuwen external memory rail

### DIFF
--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenAgentRuntimeHandler.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenAgentRuntimeHandler.java
@@ -168,7 +168,7 @@ public abstract class OpenJiuwenAgentRuntimeHandler extends AbstractAgentRuntime
      * independent from OpenJiuwen memory package names.
      */
     protected final AgentRail openJiuwenExternalMemoryRail(AgentExecutionContext context, MemoryProvider memoryProvider) {
-        return new ExternalMemoryRail(
+        return createExternalMemoryRail(
                 new OpenJiuwenExternalMemoryProviderAdapter(context, memoryProvider),
                 context.getScope().userId(),
                 context.getAgentStateKey(),
@@ -252,6 +252,24 @@ public abstract class OpenJiuwenAgentRuntimeHandler extends AbstractAgentRuntime
             cursor = cursor.getCause();
         }
         return message.isEmpty() ? error.getClass().getName() : message.toString();
+    }
+
+    private static AgentRail createExternalMemoryRail(
+            com.openjiuwen.core.memory.external.MemoryProvider memoryProvider,
+            String userId,
+            String scopeId,
+            String sessionId) {
+        return ExternalMemoryRailHolder.create(memoryProvider, userId, scopeId, sessionId);
+    }
+
+    private static final class ExternalMemoryRailHolder {
+        private static AgentRail create(
+                com.openjiuwen.core.memory.external.MemoryProvider memoryProvider,
+                String userId,
+                String scopeId,
+                String sessionId) {
+            return new ExternalMemoryRail(memoryProvider, userId, scopeId, sessionId);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Move the OpenJiuwen `ExternalMemoryRail` dependency from the main handler class path to a nested lazy holder.
- Keep the implementation strongly typed against the current `agent-core-java:0.1.12-jdk17` package: `com.openjiuwen.harness.rails.ExternalMemoryRail`.
- Keep the runtime SPI independent from OpenJiuwen memory package names while avoiding reflection in the normal path.

## Context

The root cause is that `OpenJiuwenAgentRuntimeHandler` instantiated `ExternalMemoryRail` directly in the main class body. If a downstream sample or local classpath touches handler creation before the external memory rail is needed, that optional OpenJiuwen rail dependency can make Spring fail while creating an agent handler bean. The new nested holder keeps the dependency lazy and only loads it when `openJiuwenExternalMemoryRail(...)` is actually requested.

## Validation

- `./mvnw.cmd -f agent-runtime/pom.xml -Dtest=OpenJiuwenAgentRuntimeHandlerTest test`

Additional checks run before splitting the PR:

- `./mvnw.cmd -f examples/travel/agent-hotel-a2a/pom.xml test`
- `./mvnw.cmd -f examples/travel/agent-hotel/pom.xml test`
- `./mvnw.cmd -f examples/travel/agent-travel-mainplan/pom.xml test`

Note: `examples/travel/agent-trip` did not complete within the local timeout during a broader travel sweep, so it was not used as validation for this isolated runtime fix.