### PR TITLE
refactor(travel/hotel-a2a): switch HotelAgentHandler to OpenJiuwen rail

### DIFF
--- a/examples/travel/agent-hotel-a2a/src/main/java/com/huawei/ascend/examples/hotel/a2a/HotelAgentHandler.java
+++ b/examples/travel/agent-hotel-a2a/src/main/java/com/huawei/ascend/examples/hotel/a2a/HotelAgentHandler.java
@@ -6,166 +6,38 @@ package com.huawei.ascend.examples.hotel.a2a;
 
 import com.huawei.ascend.examples.hotel.HotelPlanningAgent;
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
-import com.huawei.ascend.runtime.engine.spi.AgentExecutionResult;
-import com.huawei.ascend.runtime.engine.spi.AgentRuntimeHandler;
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenAgentRuntimeHandler;
 import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
-import com.huawei.ascend.runtime.engine.spi.MemoryProvider.MemoryHit;
-import com.huawei.ascend.runtime.engine.spi.MemoryProvider.MemoryRecord;
-import com.huawei.ascend.runtime.engine.spi.StreamAdapter;
-import java.util.ArrayList;
+import com.openjiuwen.core.singleagent.BaseAgent;
+import com.openjiuwen.core.singleagent.rail.AgentRail;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Stream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Plain SPI handler for the hotel sub-agent that wires memory recall by hand.
- *
- * <p>{@link com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenAgentRuntimeHandler}
- * registers a memory rail that adds a {@code runtime_long_term_memory} prompt
- * section in its {@code beforeInvoke} callback, but empirically that section
- * never surfaces in the assembled system message — the same
- * {@code addPromptBuilderSection} API works fine for sections registered
- * synchronously at agent construction (see
- * {@link HotelPlanningAgent#newBaseAgent()} registering
- * {@code hotel_business_rules}). Suspected root cause is the dual
- * {@code SystemPromptBuilder} fields on the upstream openJiuwen ReActAgent
- * (writer touches one, renderer reads the other). Tracked as a follow-up to
- * agent-runtime PR #248.
- *
- * <p>Until that lands we do recall in the handler: search before
- * {@link HotelPlanningAgent#chat(String)}, prepend a {@code Relevant memory:}
- * block to the user query, and persist the original user/assistant turn
- * after. {@code SystemPromptBuilder} rule 8 already instructs the LLM to
- * treat such a block as recallable history.
+ * OpenJiuwen-rail-based handler: delegates RUN lifecycle, memory recall and
+ * memory save to {@link OpenJiuwenAgentRuntimeHandler} + its built-in
+ * {@code MemoryRuntimeRail}, which writes the recalled block into the same
+ * prompt-builder section ({@code runtime_long_term_memory}, priority 50) that
+ * {@link HotelPlanningAgent#newBaseAgent()} is built for.
  */
-final class HotelAgentHandler implements AgentRuntimeHandler {
+final class HotelAgentHandler extends OpenJiuwenAgentRuntimeHandler {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(HotelAgentHandler.class);
-    private static final StreamAdapter ADAPTER = rawResults -> rawResults.map(AgentExecutionResult.class::cast);
-
-    private static final String RECALL_OPEN = "Relevant memory:\n";
-    private static final String RECALL_CLOSE = "\n---\n";
-    private static final int RECALL_LIMIT = 6;
-
-    private final String agentId;
     private final HotelPlanningAgent agent;
     private final MemoryProvider memoryProvider;
 
     HotelAgentHandler(String agentId, HotelPlanningAgent agent, MemoryProvider memoryProvider) {
-        this.agentId = agentId;
+        super(agentId);
         this.agent = Objects.requireNonNull(agent, "agent");
-        this.memoryProvider = memoryProvider;
+        this.memoryProvider = Objects.requireNonNull(memoryProvider, "memoryProvider");
     }
 
     @Override
-    public String agentId() {
-        return agentId;
+    protected BaseAgent createOpenJiuwenAgent(AgentExecutionContext context) {
+        return agent.newBaseAgent();
     }
 
     @Override
-    public boolean isHealthy() {
-        return true;
-    }
-
-    @Override
-    public Stream<?> execute(AgentExecutionContext context) {
-        String query = context.lastUserText();
-        LOGGER.info("hotel a2a execute tenantId={} userId={} sessionId={} taskId={} queryLength={}",
-                context.getScope().tenantId(),
-                context.getScope().userId(),
-                context.getScope().sessionId(),
-                context.getScope().taskId(),
-                query.length());
-        try {
-            initMemory(context);
-            String enrichedQuery = prependRecall(context, query);
-            String markdown = agent.chat(enrichedQuery);
-            saveTurn(context, query, markdown);
-            return Stream.of(AgentExecutionResult.completed(markdown));
-        } catch (Exception e) {
-            LOGGER.warn("hotel a2a execute failed tenantId={} userId={} taskId={} errorClass={} message={}",
-                    context.getScope().tenantId(),
-                    context.getScope().userId(),
-                    context.getScope().taskId(),
-                    e.getClass().getSimpleName(),
-                    errorMessage(e));
-            throw new IllegalStateException(errorMessage(e), e);
-        }
-    }
-
-    @Override
-    public StreamAdapter resultAdapter() {
-        return ADAPTER;
-    }
-
-    private String prependRecall(AgentExecutionContext context, String query) {
-        if (query == null || query.isBlank()) {
-            return query;
-        }
-        if (memoryProvider == null) {
-            return query;
-        }
-        List<MemoryHit> hits = memoryProvider.search(context, query, RECALL_LIMIT);
-        if (hits == null || hits.isEmpty()) {
-            return query;
-        }
-        StringBuilder block = new StringBuilder(RECALL_OPEN);
-        int written = 0;
-        for (MemoryHit hit : hits) {
-            String content = hit == null ? null : hit.content();
-            if (content == null || content.isBlank()) {
-                continue;
-            }
-            block.append("- ").append(content.replace("\n", " ").trim()).append('\n');
-            written++;
-        }
-        if (written == 0) {
-            return query;
-        }
-        block.append(RECALL_CLOSE);
-        LOGGER.info("hotel a2a recall written={} previewLen={}", written, block.length());
-        return block + query;
-    }
-
-    private void saveTurn(AgentExecutionContext context, String originalQuery, String assistantReply) {
-        if (memoryProvider == null) {
-            return;
-        }
-        List<MemoryRecord> records = new ArrayList<>(2);
-        if (originalQuery != null && !originalQuery.isBlank()) {
-            records.add(new MemoryRecord(UUID.randomUUID().toString(), "user", originalQuery, Map.of()));
-        }
-        if (assistantReply != null && !assistantReply.isBlank()) {
-            records.add(new MemoryRecord(UUID.randomUUID().toString(), "assistant", assistantReply, Map.of()));
-        }
-        if (!records.isEmpty()) {
-            memoryProvider.save(context, records);
-        }
-    }
-
-    private void initMemory(AgentExecutionContext context) {
-        if (memoryProvider != null) {
-            memoryProvider.init(context);
-        }
-    }
-
-    private static String errorMessage(Throwable error) {
-        StringBuilder message = new StringBuilder();
-        Throwable cursor = error;
-        while (cursor != null) {
-            String part = cursor.getMessage();
-            if (part != null && !part.isBlank()) {
-                if (!message.isEmpty()) {
-                    message.append(": ");
-                }
-                message.append(part);
-            }
-            cursor = cursor.getCause();
-        }
-        return message.isEmpty() ? error.getClass().getName() : message.toString();
+    protected List<AgentRail> openJiuwenRails(AgentExecutionContext context) {
+        return List.of(memoryRuntimeRail(context, memoryProvider));
     }
 }


### PR DESCRIPTION
## Summary

- 把 `HotelAgentHandler` 从 `implements AgentRuntimeHandler` + 手动 `prependRecall` 切换为 `extends OpenJiuwenAgentRuntimeHandler` + `memoryRuntimeRail(context, memoryProvider)`
- 长期记忆召回改走 prompt-builder section `runtime_long_term_memory` (priority 50)，与 `hotel_business_rules` 共用同一条 system message 装配路径
- 业务侧不再承担 search / recall block / strip marker 协议，仅声明 rail 即可

随 PR #271 合入后，rail 真实路径在 `Runner.runAgent` 下端到端验证通过（参考 issue #247 跟进），手动 recall workaround 不再必要。

## Test plan

- [x] 本地 `./mvnw package -f examples/travel/agent-hotel-a2a/pom.xml -DskipTests`
- [x] 服务器上 deepseek-v4-pro 真实模型路径，Round 1 触发 save → Round 2 期望召回前一轮 city / budget 等信息，命中且不幻觉
- [x] 日志检查：`[HOTEL-MEM] search ... returned N hits`、且**不出现** `openjiuwen memory inject skipped ... callbackAgentType=...` WARN
- [x] LLM system message 含 `Relevant memory:` 块（来自 rail，不再来自 user-query 前缀）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
