### PR TITLE
fix: workflow streaming COMPLETED result + skill description

### DIFF
--- a/agent-runtime/docs/guides/openjiuwen-workflow-adapter.md
+++ b/agent-runtime/docs/guides/openjiuwen-workflow-adapter.md
@@ -181,7 +181,7 @@ agent-runtime:
         skills:
           - id: ask_question
             name: ask_question
-            description: 向用户提一个问题并等待回答
+            description: 提问器工具。调用此工具会向用户提一个问题，等待用户回答后返回结果。输入应为简短的指令如"提一个问题"，无需提供具体问题内容
 ```
 
 或通过 Java 注册带 skills 的 AgentCard Bean（当 YAML 不支持 skills 时）：
@@ -193,7 +193,7 @@ agent-runtime:
         .description("...")
         .skills(List.of(AgentSkill.builder()
             .id("ask_question").name("ask_question")
-            .description("向用户提一个问题并等待回答")
+            .description("提问器工具。调用此工具会向用户提一个问题，等待用户回答后返回结果。输入应为简短的指令如"提一个问题"，无需提供具体问题内容")
             .tags(List.of()).build()))
         // ...其他字段
         .build();
@@ -252,7 +252,7 @@ public class QuestionerWorkflowConfiguration {
             .description("提问器 Workflow Agent")
             .skills(List.of(AgentSkill.builder()
                 .id("ask_question").name("ask_question")
-                .description("向用户提一个问题并等待回答")
+                .description("提问器工具。调用此工具会向用户提一个问题，等待用户回答后返回结果。输入应为简短的指令如"提一个问题"，无需提供具体问题内容")
                 .tags(List.of()).build()))
             // ...
             .build();

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenWorkflowAgentRuntimeHandler.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenWorkflowAgentRuntimeHandler.java
@@ -127,6 +127,7 @@ public abstract class OpenJiuwenWorkflowAgentRuntimeHandler
             private Object nextItem;
             private boolean done;
             private OutputSchema pendingInteraction;
+            private final StringBuilder accumulatedText = new StringBuilder();
 
             @Override
             public boolean hasNext() {
@@ -153,14 +154,18 @@ public abstract class OpenJiuwenWorkflowAgentRuntimeHandler
                 }
                 try {
                     if (!upstreamHasNextSafely()) {
-                        // Stream drained normally
-                        LOGGER.info("Workflow completed (stream) sessionId={}", sessionId);
-                        nextItem = new WorkflowOutput(null,
+                        // Stream drained normally — use accumulated text as result
+                        LOGGER.info("Workflow completed (stream) sessionId={} textLen={}",
+                                sessionId, accumulatedText.length());
+                        nextItem = new WorkflowOutput(
+                                accumulatedText.toString(),
                                 WorkflowExecutionState.COMPLETED);
                         done = true;
                         return true;
                     }
                     WorkflowChunk chunk = upstreamNextSafely();
+                    // Accumulate text from each chunk for the final COMPLETED result
+                    accumulateChunkText(chunk);
                     if (isInteractionChunk(chunk)) {
                         // Hold the interaction chunk; the next read will throw GraphInterrupt
                         pendingInteraction = (OutputSchema) chunk;
@@ -193,6 +198,22 @@ public abstract class OpenJiuwenWorkflowAgentRuntimeHandler
                     nextItem = new WorkflowOutput(errMsg, WorkflowExecutionState.ERROR);
                     done = true;
                     return true;
+                }
+            }
+
+            private void accumulateChunkText(WorkflowChunk chunk) {
+                if (chunk instanceof OutputSchema schema) {
+                    Object payload = schema.getPayload();
+                    if (payload instanceof String s) {
+                        accumulatedText.append(s);
+                    } else if (payload instanceof Map<?, ?> m) {
+                        Object out = m.get("output");
+                        if (out instanceof Map<?, ?> outputMap) {
+                            outputMap.values().forEach(v -> {
+                                if (v instanceof String s) accumulatedText.append(s);
+                            });
+                        }
+                    }
                 }
             }
 

--- a/examples/agent-runtime-a2a-openjiuwen-workflow/src/main/java/com/huawei/ascend/examples/a2a/workflow/QuestionerWorkflowConfiguration.java
+++ b/examples/agent-runtime-a2a-openjiuwen-workflow/src/main/java/com/huawei/ascend/examples/a2a/workflow/QuestionerWorkflowConfiguration.java
@@ -59,7 +59,7 @@ public class QuestionerWorkflowConfiguration {
                 .skills(List.of(AgentSkill.builder()
                         .id("ask_question")
                         .name("ask_question")
-                        .description("向用户提一个问题（1+1等于几？），等待用户回答后回显答案并确认正确")
+                        .description("提问器工具。调用此工具会向用户提一个问题，等待用户回答后返回结果。输入应为简短的指令如"提一个问题"，无需提供具体问题内容。")
                         .tags(List.of())
                         .build()))
                 .supportedInterfaces(List.of(

--- a/examples/agent-runtime-a2a-openjiuwen-workflow/src/main/java/com/huawei/ascend/examples/a2a/workflow/QuestionerWorkflowConfiguration.java
+++ b/examples/agent-runtime-a2a-openjiuwen-workflow/src/main/java/com/huawei/ascend/examples/a2a/workflow/QuestionerWorkflowConfiguration.java
@@ -59,7 +59,7 @@ public class QuestionerWorkflowConfiguration {
                 .skills(List.of(AgentSkill.builder()
                         .id("ask_question")
                         .name("ask_question")
-                        .description("提问器工具。调用此工具会向用户提一个问题，等待用户回答后返回结果。输入应为简短的指令如"提一个问题"，无需提供具体问题内容。")
+                        .description("提问器工具。调用此工具会向用户提一个问题，等待用户回答后返回结果。输入应为简短的指令如'提一个问题'，无需提供具体问题内容。")
                         .tags(List.of())
                         .build()))
                 .supportedInterfaces(List.of(

--- a/examples/agent-runtime-a2a-openjiuwen-workflow/src/main/resources/application.yaml
+++ b/examples/agent-runtime-a2a-openjiuwen-workflow/src/main/resources/application.yaml
@@ -21,7 +21,7 @@ agent-runtime:
         skills:
           - id: ask_question
             name: ask_question
-            description: 向用户提一个问题（1+1等于几？），等待用户回答后回显答案并确认正确
+            description: 提问器工具。调用此工具会向用户提一个问题，等待用户回答后返回结果。输入应为简短的指令如"提一个问题"，无需提供具体问题内容。
 
 sample:
   openjiuwen:


### PR DESCRIPTION
Follow-up to PR #304.

### Changes
- Fix streaming COMPLETED result: accumulate chunk text so the remote
  tool result is non-empty after workflow completes (was returning "")
- Update skill description to clarify the tool is a question-asker
  where input should be brief instruction, not the question content
- Fix Chinese quote escaping in Java string