### PR TITLE
- Add native OpenJiuwen DeepAgent runtime support alongside the existing ReAct handler. - Update the remote-agent-tool E2E sample to avoid overriding the now-final shared OpenJiuwen input conversion hook.

### DIFF
--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/A2aClientAutoConfiguration.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/A2aClientAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.huawei.ascend.runtime.engine.a2a;
 
 import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenAgentRuntimeHandler;
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenDeepAgentRuntimeHandler;
 import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenRemoteToolInstaller;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -89,18 +90,26 @@ public class A2aClientAutoConfiguration {
         @ConditionalOnMissingBean
         public OpenJiuwenRemoteToolInstaller openJiuwenRemoteToolInstaller(
                 RemoteAgentCardCache cardCache,
-                ObjectProvider<OpenJiuwenAgentRuntimeHandler> handlers) {
+                ObjectProvider<OpenJiuwenAgentRuntimeHandler> handlers,
+                ObjectProvider<OpenJiuwenDeepAgentRuntimeHandler> deepHandlers) {
             OpenJiuwenRemoteToolInstaller installer =
                     new OpenJiuwenRemoteToolInstaller(cardCache::availableToolSpecs);
-            int count = 0;
+            int reactCount = 0;
             for (OpenJiuwenAgentRuntimeHandler handler : handlers.orderedStream().toList()) {
                 handler.setRuntimeToolInstaller(installer);
-                count++;
+                reactCount++;
                 LOG.info("installed remote tool installer into openjiuwen handler agentId={}",
                         handler.agentId());
             }
-            if (count == 0) {
-                LOG.warn("remote tool installer created but no OpenJiuwenAgentRuntimeHandler beans found");
+            int deepCount = 0;
+            for (OpenJiuwenDeepAgentRuntimeHandler handler : deepHandlers.orderedStream().toList()) {
+                handler.setRuntimeToolInstaller(installer);
+                deepCount++;
+                LOG.info("installed remote tool installer into openjiuwen deepagent handler agentId={}",
+                        handler.agentId());
+            }
+            if (reactCount == 0 && deepCount == 0) {
+                LOG.warn("remote tool installer created but no OpenJiuwen runtime handler beans found");
             }
             return installer;
         }

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/AbstractOpenJiuwenRuntimeSupport.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/AbstractOpenJiuwenRuntimeSupport.java
@@ -1,0 +1,120 @@
+package com.huawei.ascend.runtime.engine.openjiuwen;
+
+import com.huawei.ascend.runtime.engine.AgentExecutionContext;
+import com.huawei.ascend.runtime.engine.spi.AbstractAgentRuntimeHandler;
+import com.huawei.ascend.runtime.engine.spi.AgentExecutionResult;
+import com.huawei.ascend.runtime.engine.spi.StreamAdapter;
+import com.huawei.ascend.runtime.engine.spi.TrajectoryDraft;
+import com.huawei.ascend.runtime.engine.spi.TrajectoryEmitter;
+import com.openjiuwen.core.session.stream.OutputSchema;
+import java.util.Iterator;
+import java.util.Objects;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract class AbstractOpenJiuwenRuntimeSupport extends AbstractAgentRuntimeHandler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractOpenJiuwenRuntimeSupport.class);
+
+    private final OpenJiuwenMessageAdapter messageConverter;
+    private final OpenJiuwenStreamAdapter resultMapper;
+
+    AbstractOpenJiuwenRuntimeSupport(String agentId) {
+        this(agentId, new OpenJiuwenMessageAdapter());
+    }
+
+    AbstractOpenJiuwenRuntimeSupport(String agentId, OpenJiuwenMessageAdapter messageConverter) {
+        this(agentId, messageConverter, new OpenJiuwenStreamAdapter());
+    }
+
+    AbstractOpenJiuwenRuntimeSupport(String agentId, OpenJiuwenMessageAdapter messageConverter,
+            OpenJiuwenStreamAdapter resultMapper) {
+        super(agentId);
+        this.messageConverter = Objects.requireNonNull(messageConverter, "messageConverter");
+        this.resultMapper = Objects.requireNonNull(resultMapper, "resultMapper");
+    }
+
+    protected final Object toOpenJiuwenInput(AgentExecutionContext context) {
+        LOGGER.info("openjiuwen input convert tenantId={} sessionId={} taskId={} agentId={} inputType={} messages={}",
+                context.getScope().tenantId(),
+                context.getScope().sessionId(),
+                context.getScope().taskId(),
+                context.getScope().agentId(),
+                context.getInputType(),
+                context.getMessages().size());
+        return messageConverter.toOpenJiuwenInput(context);
+    }
+
+    protected final String openJiuwenConversationId(AgentExecutionContext context) {
+        String conversationId = context.getAgentStateKey();
+        LOGGER.info("openjiuwen conversation resolve tenantId={} sessionId={} taskId={} agentId={} conversationId={}",
+                context.getScope().tenantId(),
+                context.getScope().sessionId(),
+                context.getScope().taskId(),
+                context.getScope().agentId(),
+                conversationId);
+        return conversationId;
+    }
+
+    protected final Stream<?> flattenIterator(Iterator<Object> iterator) {
+        if (iterator == null) {
+            return Stream.of((Object) null);
+        }
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
+    }
+
+    protected final Stream<?> failedResult(
+            AgentExecutionContext context,
+            TrajectoryEmitter trajectory,
+            Throwable error) {
+        LOGGER.warn("openjiuwen execute failed tenantId={} sessionId={} taskId={} errorClass={} message={}",
+                context.getScope().tenantId(),
+                context.getScope().sessionId(),
+                context.getScope().taskId(),
+                error.getClass().getSimpleName(),
+                errorMessage(error));
+        trajectory.emit(TrajectoryDraft.error(null, "OPENJIUWEN_RUN_ERROR", errorMessage(error), null, false));
+        return Stream.of(AgentExecutionResult.failed("OPENJIUWEN_RUN_ERROR", errorMessage(error)));
+    }
+
+    @Override
+    public StreamAdapter resultAdapter() {
+        return rawResults -> rawResults.map(this::mapRawResult).filter(Objects::nonNull);
+    }
+
+    protected AgentExecutionResult mapRawResult(Object rawResult) {
+        LOGGER.info("openjiuwen raw result received type={}",
+                rawResult == null ? "null" : rawResult.getClass().getName());
+        if (rawResult instanceof AgentExecutionResult result) {
+            return result;
+        }
+        if (rawResult == null) {
+            return AgentExecutionResult.failed(
+                    OpenJiuwenStreamAdapter.ERROR_CODE, "openjiuwen runner returned no result");
+        }
+        if (rawResult instanceof OutputSchema chunk) {
+            return resultMapper.map(chunk);
+        }
+        return AgentExecutionResult.output(String.valueOf(rawResult));
+    }
+
+    protected static String errorMessage(Throwable error) {
+        StringBuilder message = new StringBuilder();
+        Throwable cursor = error;
+        while (cursor != null) {
+            String part = cursor.getMessage();
+            if (part != null && !part.isBlank()) {
+                if (!message.isEmpty()) {
+                    message.append(": ");
+                }
+                message.append(part);
+            }
+            cursor = cursor.getCause();
+        }
+        return message.isEmpty() ? error.getClass().getName() : message.toString();
+    }
+}

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenAgentRuntimeHandler.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenAgentRuntimeHandler.java
@@ -1,12 +1,8 @@
 package com.huawei.ascend.runtime.engine.openjiuwen;
 
 import com.huawei.ascend.runtime.engine.AgentExecutionContext;
-import com.huawei.ascend.runtime.engine.spi.AbstractAgentRuntimeHandler;
-import com.huawei.ascend.runtime.engine.spi.AgentExecutionResult;
 import com.huawei.ascend.runtime.engine.spi.AgentRuntimeHandler;
 import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
-import com.huawei.ascend.runtime.engine.spi.StreamAdapter;
-import com.huawei.ascend.runtime.engine.spi.TrajectoryDraft;
 import com.huawei.ascend.runtime.engine.spi.TrajectoryEmitter;
 import com.huawei.ascend.runtime.engine.spi.TrajectoryEvent.Kind;
 import com.openjiuwen.core.context.ModelContext;
@@ -24,11 +20,8 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Spliterator;
 import java.util.Set;
-import java.util.Spliterators;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,12 +36,10 @@ import org.slf4j.LoggerFactory;
  * maps standard {@link OutputSchema} chunks into the framework-neutral result
  * stream.
  */
-public abstract class OpenJiuwenAgentRuntimeHandler extends AbstractAgentRuntimeHandler {
+public abstract class OpenJiuwenAgentRuntimeHandler extends AbstractOpenJiuwenRuntimeSupport {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenJiuwenAgentRuntimeHandler.class);
 
-    private final OpenJiuwenMessageAdapter messageConverter;
-    private final OpenJiuwenStreamAdapter resultMapper;
     private OpenJiuwenRemoteToolInstaller runtimeToolInstaller;
 
     protected OpenJiuwenAgentRuntimeHandler(String agentId) {
@@ -61,9 +52,7 @@ public abstract class OpenJiuwenAgentRuntimeHandler extends AbstractAgentRuntime
 
     OpenJiuwenAgentRuntimeHandler(String agentId, OpenJiuwenMessageAdapter messageConverter,
             OpenJiuwenStreamAdapter resultMapper) {
-        super(agentId);
-        this.messageConverter = Objects.requireNonNull(messageConverter, "messageConverter");
-        this.resultMapper = Objects.requireNonNull(resultMapper, "resultMapper");
+        super(agentId, messageConverter, resultMapper);
     }
 
     /**
@@ -103,22 +92,9 @@ public abstract class OpenJiuwenAgentRuntimeHandler extends AbstractAgentRuntime
                     context.getScope().sessionId(),
                     context.getScope().taskId(),
                     result == null ? "null" : result.getClass().getName());
-            if (result == null) {
-                return java.util.stream.Stream.of((Object) null);
-            }
-            return java.util.stream.StreamSupport.stream(
-                    Spliterators.spliteratorUnknownSize(result, Spliterator.ORDERED), false);
+            return flattenIterator(result);
         } catch (RuntimeException error) {
-            LOGGER.warn("openjiuwen execute failed tenantId={} sessionId={} taskId={} errorClass={} message={}",
-                    context.getScope().tenantId(),
-                    context.getScope().sessionId(),
-                    context.getScope().taskId(),
-                    error.getClass().getSimpleName(),
-                    errorMessage(error));
-            // ERROR is a mandatory trajectory kind: surface the run-level failure northbound even though
-            // the failure is mapped to a result (not rethrown), so the trajectory is not silently truncated.
-            trajectory.emit(TrajectoryDraft.error(null, "OPENJIUWEN_RUN_ERROR", errorMessage(error), null, false));
-            return java.util.stream.Stream.of(AgentExecutionResult.failed("OPENJIUWEN_RUN_ERROR", errorMessage(error)));
+            return failedResult(context, trajectory, error);
         }
     }
 
@@ -191,77 +167,12 @@ public abstract class OpenJiuwenAgentRuntimeHandler extends AbstractAgentRuntime
         return List.of(StreamMode.OUTPUT);
     }
 
-    /**
-     * Returns the stable conversation id openJiuwen should use for native
-     * checkpointer restore/save. Subclasses pass this value as the Runner
-     * session id, or rely on {@link #toOpenJiuwenInput(AgentExecutionContext)}
-     * to place it in {@code conversation_id}.
-     */
-    protected String openJiuwenConversationId(AgentExecutionContext context) {
-        String conversationId = context.getAgentStateKey();
-        LOGGER.info("openjiuwen conversation resolve tenantId={} sessionId={} taskId={} agentId={} conversationId={}",
-                context.getScope().tenantId(),
-                context.getScope().sessionId(),
-                context.getScope().taskId(),
-                context.getScope().agentId(),
-                conversationId);
-        return conversationId;
-    }
-
-    protected Object toOpenJiuwenInput(AgentExecutionContext context) {
-        LOGGER.info("openjiuwen input convert tenantId={} sessionId={} taskId={} agentId={} inputType={} messages={}",
-                context.getScope().tenantId(),
-                context.getScope().sessionId(),
-                context.getScope().taskId(),
-                context.getScope().agentId(),
-                context.getInputType(),
-                context.getMessages().size());
-        return messageConverter.toOpenJiuwenInput(context);
-    }
-
     private void installRails(BaseAgent agent, AgentExecutionContext context) {
         for (AgentRail rail : openJiuwenRails(context)) {
             if (rail != null) {
                 agent.registerRail(rail);
             }
         }
-    }
-
-    @Override
-    public StreamAdapter resultAdapter() {
-        return rawResults -> rawResults.map(this::mapRawResult).filter(Objects::nonNull);
-    }
-
-    private AgentExecutionResult mapRawResult(Object rawResult) {
-        LOGGER.info("openjiuwen raw result received type={}",
-                rawResult == null ? "null" : rawResult.getClass().getName());
-        if (rawResult instanceof AgentExecutionResult result) {
-            return result;
-        }
-        if (rawResult == null) {
-            return AgentExecutionResult.failed(
-                    OpenJiuwenStreamAdapter.ERROR_CODE, "openjiuwen runner returned no result");
-        }
-        if (rawResult instanceof OutputSchema chunk) {
-            return resultMapper.map(chunk);
-        }
-        return AgentExecutionResult.output(String.valueOf(rawResult));
-    }
-
-    protected static String errorMessage(Throwable error) {
-        StringBuilder message = new StringBuilder();
-        Throwable cursor = error;
-        while (cursor != null) {
-            String part = cursor.getMessage();
-            if (part != null && !part.isBlank()) {
-                if (!message.isEmpty()) {
-                    message.append(": ");
-                }
-                message.append(part);
-            }
-            cursor = cursor.getCause();
-        }
-        return message.isEmpty() ? error.getClass().getName() : message.toString();
     }
 
     private static AgentRail createExternalMemoryRail(

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenDeepAgentRuntimeHandler.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenDeepAgentRuntimeHandler.java
@@ -1,0 +1,175 @@
+package com.huawei.ascend.runtime.engine.openjiuwen;
+
+import com.huawei.ascend.runtime.engine.AgentExecutionContext;
+import com.huawei.ascend.runtime.engine.spi.TrajectoryEmitter;
+import com.huawei.ascend.runtime.engine.spi.TrajectoryEvent.Kind;
+import com.openjiuwen.core.session.stream.StreamMode;
+import com.openjiuwen.harness.deep_agent.DeepAgent;
+import java.util.EnumSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for OpenJiuwen DeepAgent runtime handlers.
+ *
+ * <p>DeepAgent owns its own session lifecycle in {@code stream(...)}, so this
+ * handler calls the harness entrypoint directly instead of wrapping it with
+ * OpenJiuwen {@code Runner.runAgentStreaming(...)}.
+ */
+public abstract class OpenJiuwenDeepAgentRuntimeHandler extends AbstractOpenJiuwenRuntimeSupport {
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpenJiuwenDeepAgentRuntimeHandler.class);
+
+    private final ConcurrentMap<String, DeepAgent> runningAgents = new ConcurrentHashMap<>();
+    private OpenJiuwenRemoteToolInstaller runtimeToolInstaller;
+
+    protected OpenJiuwenDeepAgentRuntimeHandler(String agentId) {
+        super(agentId);
+    }
+
+    protected OpenJiuwenDeepAgentRuntimeHandler(String agentId, OpenJiuwenMessageAdapter messageConverter) {
+        super(agentId, messageConverter);
+    }
+
+    OpenJiuwenDeepAgentRuntimeHandler(String agentId, OpenJiuwenMessageAdapter messageConverter,
+            OpenJiuwenStreamAdapter resultMapper) {
+        super(agentId, messageConverter, resultMapper);
+    }
+
+    @Override
+    protected Set<Kind> supportedKinds() {
+        return EnumSet.of(
+                Kind.RUN_START, Kind.RUN_END,
+                Kind.MODEL_CALL_START, Kind.MODEL_CALL_END,
+                Kind.TOOL_CALL_START, Kind.TOOL_CALL_END,
+                Kind.ERROR);
+    }
+
+    @Override
+    protected final Stream<?> doExecute(AgentExecutionContext context, TrajectoryEmitter trajectory) {
+        String taskId = context.getScope().taskId();
+        DeepAgent agent = null;
+        boolean registered = false;
+        try {
+            LOGGER.info("openjiuwen deepagent execute start tenantId={} sessionId={} taskId={} agentId={}",
+                    context.getScope().tenantId(),
+                    context.getScope().sessionId(),
+                    taskId,
+                    context.getScope().agentId());
+            agent = Objects.requireNonNull(createOpenJiuwenDeepAgent(context), "openJiuwen deepAgent");
+            runningAgents.put(taskId, agent);
+            registered = true;
+
+            installRuntimeTools(agent, context);
+            if (trajectory != TrajectoryEmitter.NOOP) {
+                agent.getAgent().registerRail(new OpenJiuwenTrajectoryRail(trajectory));
+            }
+
+            Map<String, Object> input = requireMap(toOpenJiuwenInput(context));
+            Iterator<Object> iterator = runOpenJiuwenDeepAgentStreaming(
+                    agent, input, openJiuwenConversationId(context), openJiuwenStreamModes(context));
+            DeepAgent registeredAgent = agent;
+            return flattenIterator(cleaningIterator(iterator, () -> runningAgents.remove(taskId, registeredAgent)))
+                    .onClose(() -> runningAgents.remove(taskId, registeredAgent));
+        } catch (RuntimeException error) {
+            if (registered) {
+                runningAgents.remove(taskId, agent);
+            }
+            return failedResult(context, trajectory, error);
+        }
+    }
+
+    protected abstract DeepAgent createOpenJiuwenDeepAgent(AgentExecutionContext context);
+
+    protected void installRuntimeTools(DeepAgent agent, AgentExecutionContext context) {
+        if (runtimeToolInstaller != null) {
+            runtimeToolInstaller.install(agent, context);
+        }
+    }
+
+    public final void setRuntimeToolInstaller(OpenJiuwenRemoteToolInstaller runtimeToolInstaller) {
+        this.runtimeToolInstaller = runtimeToolInstaller;
+    }
+
+    protected Iterator<Object> runOpenJiuwenDeepAgentStreaming(
+            DeepAgent agent,
+            Map<String, Object> input,
+            String conversationId,
+            List<StreamMode> streamModes) {
+        input.putIfAbsent("conversation_id", conversationId);
+        return agent.stream(input, null, streamModes);
+    }
+
+    protected List<StreamMode> openJiuwenStreamModes(AgentExecutionContext context) {
+        return List.of(StreamMode.OUTPUT);
+    }
+
+    @Override
+    public void cancel(String taskId) {
+        DeepAgent agent = runningAgents.get(taskId);
+        if (agent != null) {
+            agent.requestAbort();
+        }
+    }
+
+    int runningAgentCount() {
+        return runningAgents.size();
+    }
+
+    private static Map<String, Object> requireMap(Object rawInput) {
+        if (rawInput instanceof Map<?, ?> map) {
+            Map<String, Object> normalized = new LinkedHashMap<>();
+            map.forEach((key, value) -> normalized.put(String.valueOf(key), value));
+            return normalized;
+        }
+        throw new IllegalArgumentException("OpenJiuwen DeepAgent input must be a Map<String,Object>");
+    }
+
+    private static Iterator<Object> cleaningIterator(Iterator<Object> delegate, Runnable cleanup) {
+        Iterator<Object> safeDelegate = delegate != null ? delegate : List.of((Object) null).iterator();
+        AtomicBoolean cleaned = new AtomicBoolean();
+        Runnable cleanOnce = () -> {
+            if (cleaned.compareAndSet(false, true)) {
+                cleanup.run();
+            }
+        };
+        return new Iterator<>() {
+            @Override
+            public boolean hasNext() {
+                try {
+                    boolean hasNext = safeDelegate.hasNext();
+                    if (!hasNext) {
+                        cleanOnce.run();
+                    }
+                    return hasNext;
+                } catch (RuntimeException error) {
+                    cleanOnce.run();
+                    throw error;
+                }
+            }
+
+            @Override
+            public Object next() {
+                try {
+                    Object next = safeDelegate.next();
+                    if (!safeDelegate.hasNext()) {
+                        cleanOnce.run();
+                    }
+                    return next;
+                } catch (RuntimeException error) {
+                    cleanOnce.run();
+                    throw error;
+                }
+            }
+        };
+    }
+}

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenRemoteToolInstaller.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenRemoteToolInstaller.java
@@ -6,6 +6,7 @@ import com.openjiuwen.core.foundation.tool.Tool;
 import com.openjiuwen.core.foundation.tool.ToolCard;
 import com.openjiuwen.core.runner.Runner;
 import com.openjiuwen.core.singleagent.BaseAgent;
+import com.openjiuwen.harness.deep_agent.DeepAgent;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,28 @@ public final class OpenJiuwenRemoteToolInstaller {
         }
         agent.registerRail(new OpenJiuwenRemoteAgentInterruptRail(context, specs));
         LOG.info("installed {} remote A2A tool(s) into openjiuwen agent={}", specs.size(), agent.getCard().getId());
+    }
+
+    public void install(DeepAgent agent, AgentExecutionContext context) {
+        Objects.requireNonNull(agent, "agent");
+        Objects.requireNonNull(context, "context");
+        List<RemoteAgentToolSpec> specs = toolSpecs.get();
+        if (specs == null || specs.isEmpty()) {
+            LOG.info("no remote A2A tools to install into deepagent={} (card cache may not be refreshed yet)",
+                    agent.getCard().getId());
+            return;
+        }
+        LOG.info("installing {} remote A2A tool(s) into openjiuwen deepagent={}:",
+                specs.size(), agent.getCard().getId());
+        for (RemoteAgentToolSpec spec : specs) {
+            LOG.info("  tool name={} remoteAgentId={}", spec.toolName(), spec.remoteAgentId());
+            LOG.info("  tool description={}", spec.description());
+            LOG.info("  tool inputSchema={}", spec.inputSchema());
+            agent.registerHarnessTool(new PlaceholderRemoteAgentTool(toCard(spec)));
+        }
+        agent.getAgent().registerRail(new OpenJiuwenRemoteAgentInterruptRail(context, specs));
+        LOG.info("installed {} remote A2A tool(s) into openjiuwen deepagent={}",
+                specs.size(), agent.getCard().getId());
     }
 
     private static ToolCard toCard(RemoteAgentToolSpec spec) {

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/boot/RuntimeRemoteAgentAutoConfigurationTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/boot/RuntimeRemoteAgentAutoConfigurationTest.java
@@ -9,9 +9,14 @@ import com.huawei.ascend.runtime.engine.a2a.A2aRemoteAgentOutboundAdapter;
 import com.huawei.ascend.runtime.engine.a2a.RemoteAgentCardCache;
 import com.huawei.ascend.runtime.engine.a2a.RemoteAgentInvocationService;
 import com.huawei.ascend.runtime.engine.a2a.RemoteAgentProperties;
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenDeepAgentRuntimeHandler;
 import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenRemoteToolInstaller;
 import com.huawei.ascend.runtime.engine.spi.AgentRuntimeHandler;
 import com.huawei.ascend.runtime.engine.spi.StreamAdapter;
+import com.openjiuwen.harness.deep_agent.DeepAgent;
+import com.openjiuwen.core.singleagent.schema.AgentCard;
+import com.openjiuwen.harness.schema.config.DeepAgentConfig;
+import com.openjiuwen.harness.workspace.Workspace;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -46,6 +51,25 @@ class RuntimeRemoteAgentAutoConfigurationTest {
                     assertThat(context).hasSingleBean(org.a2aproject.sdk.server.agentexecution.AgentExecutor.class);
                     assertThat(context.getBean(org.a2aproject.sdk.server.agentexecution.AgentExecutor.class))
                             .isInstanceOf(A2aAgentExecutor.class);
+                });
+    }
+
+    @Test
+    void remoteAgentToolInstallerIsInjectedIntoDeepAgentHandlers() {
+        contextRunner
+                .withUserConfiguration(DeepAgentHandlerConfiguration.class)
+                .withPropertyValues("agent-runtime.remote-agents[0].url=http://localhost:18081")
+                .run(context -> {
+                    assertThat(context).hasSingleBean(OpenJiuwenRemoteToolInstaller.class);
+                    DeepAgentHandler handler = context.getBean(DeepAgentHandler.class);
+                    handler.execute(new AgentExecutionContext(
+                            new com.huawei.ascend.runtime.common.RuntimeIdentity(
+                                    "tenant", "user", "session", "task", "deep-agent"),
+                            "USER_MESSAGE",
+                            List.of(com.huawei.ascend.runtime.common.RuntimeMessage.user("ping")),
+                            java.util.Map.of())).close();
+
+                    assertThat(handler.installRuntimeToolsCalled).isTrue();
                 });
     }
 
@@ -200,6 +224,44 @@ class RuntimeRemoteAgentAutoConfigurationTest {
                             com.huawei.ascend.runtime.engine.spi.AgentExecutionResult.completed(""));
                 }
             };
+        }
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    static class DeepAgentHandlerConfiguration {
+        @Bean
+        DeepAgentHandler deepAgentHandler() {
+            return new DeepAgentHandler();
+        }
+    }
+
+    static final class DeepAgentHandler extends OpenJiuwenDeepAgentRuntimeHandler {
+        private boolean installRuntimeToolsCalled;
+
+        private DeepAgentHandler() {
+            super("deep-agent");
+        }
+
+        @Override
+        protected DeepAgent createOpenJiuwenDeepAgent(AgentExecutionContext context) {
+            return new DeepAgent(
+                    AgentCard.builder().id("deep-agent").name("deep-agent").description("test").build(),
+                    DeepAgentConfig.builder().enableTaskLoop(true).build(),
+                    Workspace.builder().rootPath("./target/deep-agent-autoconfig-test").build()) {
+                @Override
+                public java.util.Iterator<Object> stream(
+                        java.util.Map<String, Object> inputs,
+                        com.openjiuwen.core.session.AgentSessionApi session,
+                        java.util.List<com.openjiuwen.core.session.stream.StreamMode> streamModes) {
+                    return java.util.List.of().iterator();
+                }
+            };
+        }
+
+        @Override
+        protected void installRuntimeTools(DeepAgent agent, AgentExecutionContext context) {
+            installRuntimeToolsCalled = true;
+            super.installRuntimeTools(agent, context);
         }
     }
 

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenRemoteToolInstallerTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenRemoteToolInstallerTest.java
@@ -14,9 +14,12 @@ import com.openjiuwen.core.singleagent.BaseAgent;
 import com.openjiuwen.core.singleagent.interrupt.InterruptRequest;
 import com.openjiuwen.core.singleagent.rail.AgentRail;
 import com.openjiuwen.core.singleagent.schema.AgentCard;
+import com.openjiuwen.harness.deep_agent.DeepAgent;
 import com.openjiuwen.harness.rails.interrupt.InterruptDecision;
 import com.openjiuwen.harness.rails.interrupt.InterruptResult;
 import com.openjiuwen.harness.rails.interrupt.RejectResult;
+import com.openjiuwen.harness.schema.config.DeepAgentConfig;
+import com.openjiuwen.harness.workspace.Workspace;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -40,6 +43,23 @@ class OpenJiuwenRemoteToolInstallerTest {
                 .hasSize(1)
                 .first()
                 .isInstanceOf(OpenJiuwenRemoteAgentInterruptRail.class);
+    }
+
+    @Test
+    void installsRemoteToolCardAndInterruptRailOnDeepAgentHarness() {
+        DeepAgent agent = new DeepAgent(
+                AgentCard.builder().id("deep-agent").name("deep-agent").description("test").build(),
+                DeepAgentConfig.builder().enableTaskLoop(true).build(),
+                Workspace.builder().rootPath("./target/deep-agent-installer-test").build());
+        RemoteAgentToolSpec spec = toolSpec();
+        OpenJiuwenRemoteToolInstaller installer = new OpenJiuwenRemoteToolInstaller(() -> List.of(spec));
+
+        installer.install(agent, context());
+
+        assertThat(agent.getRegisteredTools()).hasSize(1);
+        assertThat(agent.getAgent().getAbilityManager().get("remote-planner")).isNotNull();
+        assertThat(agent.getAgent().getAbilityManager().listToolInfo())
+                .anySatisfy(info -> assertThat(info.getName()).isEqualTo("remote-planner"));
     }
 
     @Test

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/README.cn.md
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/README.cn.md
@@ -1,0 +1,367 @@
+# Agent Runtime A2A OpenJiuwen DeepAgent E2E 示例
+
+## 目的
+
+本示例用于验证 `agent-runtime` 可以托管 openJiuwen `DeepAgent`，并且调用方只通过 A2A JSON-RPC streaming endpoint 访问它。
+
+示例位于 `examples/agent-runtime-a2a-openjiuwen-deepagent-e2e`，包含：
+
+- Spring Boot 服务端：`com.huawei.ascend.examples.a2a.OpenJiuwenA2aAgentRuntimeApplication`
+- openJiuwen DeepAgent 配置：`com.huawei.ascend.examples.a2a.OpenJiuwenDeepAgentConfiguration`
+- A2A SDK 客户端测试辅助：`com.huawei.ascend.examples.a2a.SampleA2aClient`
+- 交互式控制台客户端：`com.huawei.ascend.examples.a2a.A2aConsoleClientApplication`
+- 端到端测试：`OpenJiuwenDeepAgentA2aE2eTest`
+
+## 验证内容
+
+自动化测试覆盖以下路径：
+
+1. 启动一个嵌入式 Spring Boot runtime。
+2. 注册一个 openJiuwen DeepAgent，agent id 为 `openjiuwen-deep-agent`。
+3. 通过 `/.well-known/agent-card.json` 发现 AgentCard。
+4. 确认 AgentCard 支持 JSON-RPC streaming。
+5. 如果 `SAA_SAMPLE_LLM_API_KEY` 非空，则通过 A2A SDK streaming 发送 `ping`。
+6. 客户端消费 SSE stream，直到任务进入终态。
+7. 最终用户可见文本应为 `pong`。
+
+如果没有配置真实模型 key，测试仍会启动服务并验证 AgentCard；真实 LLM 分支会被 JUnit `assumeTrue()` 跳过。
+
+## 环境变量
+
+本示例不提供脚本包装，也不提供环境变量模板文件。请在当前终端中直接设置环境变量，然后运行 Maven 命令。
+
+### Bash
+
+```bash
+export SAA_SAMPLE_LLM_API_KEY="sk-local-placeholder"
+export SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER="openai"
+export SAA_SAMPLE_OPENJIUWEN_API_BASE="http://localhost:4000/v1"
+export SAA_SAMPLE_LLM_MODEL="gpt-5.4-mini"
+export SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY="false"
+export SAA_SAMPLE_OPENJIUWEN_CHECKPOINTER="in-memory"
+export SAA_SAMPLE_OPENJIUWEN_WORKSPACE_PATH="./target/deepagent-workspace"
+```
+
+### PowerShell
+
+```powershell
+$env:SAA_SAMPLE_LLM_API_KEY = "sk-local-placeholder"
+$env:SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER = "openai"
+$env:SAA_SAMPLE_OPENJIUWEN_API_BASE = "http://localhost:4000/v1"
+$env:SAA_SAMPLE_LLM_MODEL = "gpt-5.4-mini"
+$env:SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY = "false"
+$env:SAA_SAMPLE_OPENJIUWEN_CHECKPOINTER = "in-memory"
+$env:SAA_SAMPLE_OPENJIUWEN_WORKSPACE_PATH = "./target/deepagent-workspace"
+```
+
+变量说明：
+
+- `SAA_SAMPLE_LLM_API_KEY`：模型服务 key。Ollama 或本地 OpenAI-compatible gateway 可使用任意非空占位值；为空时自动化测试会跳过真实 LLM 调用。
+- `SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER`：openJiuwen model provider，本示例使用 `openai` 表示 OpenAI-compatible `/v1`。
+- `SAA_SAMPLE_OPENJIUWEN_API_BASE`：模型服务 base URL，例如 `http://localhost:4000/v1`、`http://localhost:11434/v1` 或 `https://api.openai.com/v1`。
+- `SAA_SAMPLE_LLM_MODEL`：模型名。
+- `SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY`：是否校验证书；本地 HTTP 通常为 `false`，云端 HTTPS 通常为 `true`。
+- `SAA_SAMPLE_OPENJIUWEN_CHECKPOINTER`：`in-memory` 或 `redis`。
+- `SAA_SAMPLE_OPENJIUWEN_REDIS_URL`：只在 checkpointer 设置为 `redis` 时使用，例如 `redis://localhost:6379`。
+- `SAA_SAMPLE_OPENJIUWEN_WORKSPACE_PATH`：DeepAgent workspace 路径。
+
+runtime 默认绑定配置在 `src/main/resources/application.yaml`：
+
+```yaml
+agent-runtime:
+  access:
+    a2a:
+      default-tenant-id: sample-tenant
+      default-agent-id: openjiuwen-deep-agent
+```
+
+## 执行自动化测试
+
+以下命令均从仓库根目录执行。
+
+先安装当前工作区的 `agent-runtime` 到本地 Maven 仓库，确保示例使用本地最新代码：
+
+### Bash
+
+```bash
+./mvnw -pl agent-runtime install -DskipTests -Dmaven.test.skip=true
+```
+
+### PowerShell
+
+```powershell
+.\mvnw.cmd -pl agent-runtime install -DskipTests "-Dmaven.test.skip=true"
+```
+
+然后运行 DeepAgent 示例测试：
+
+### Bash
+
+```bash
+./mvnw -f examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/pom.xml test
+```
+
+### PowerShell
+
+```powershell
+.\mvnw.cmd -f examples\agent-runtime-a2a-openjiuwen-deepagent-e2e\pom.xml test
+```
+
+## 手工验证
+
+### 1. 确认模型 gateway 可访问
+
+### Bash
+
+```bash
+curl http://localhost:4000/v1/models \
+  -H "Authorization: Bearer ${SAA_SAMPLE_LLM_API_KEY}"
+```
+
+### PowerShell
+
+```powershell
+curl.exe http://localhost:4000/v1/models `
+  -H "Authorization: Bearer $env:SAA_SAMPLE_LLM_API_KEY"
+```
+
+如果你的 `SAA_SAMPLE_OPENJIUWEN_API_BASE` 不是 `http://localhost:4000/v1`，请把上面的 URL 换成对应 gateway 的 `/models` 地址。
+
+### 2. 启动服务端
+
+### Bash
+
+```bash
+./mvnw -f examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/pom.xml spring-boot:run
+```
+
+### PowerShell
+
+```powershell
+.\mvnw.cmd -f examples\agent-runtime-a2a-openjiuwen-deepagent-e2e\pom.xml spring-boot:run
+```
+
+服务默认监听 `http://localhost:8080`。
+
+### 3. 使用交互式客户端验证 ping/pong
+
+另开一个终端，并保持服务端终端继续运行。
+
+### Bash
+
+```bash
+./mvnw -f examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/pom.xml \
+  exec:java \
+  -Dexec.mainClass=com.huawei.ascend.examples.a2a.A2aConsoleClientApplication
+```
+
+### PowerShell
+
+```powershell
+.\mvnw.cmd -f examples\agent-runtime-a2a-openjiuwen-deepagent-e2e\pom.xml `
+  exec:java `
+  "-Dexec.mainClass=com.huawei.ascend.examples.a2a.A2aConsoleClientApplication"
+```
+
+客户端启动后会打印类似：
+
+```text
+Connected to openjiuwen-deep-agent at http://localhost:8080
+Type a message and press Enter. Type exit to quit.
+>
+```
+
+输入：
+
+```text
+ping
+```
+
+期望输出：
+
+```text
+pong
+```
+
+退出客户端：
+
+```text
+exit
+```
+
+如果服务端不在默认地址，可直接传 Maven 参数：
+
+### Bash
+
+```bash
+./mvnw -f examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/pom.xml \
+  exec:java \
+  -Dexec.mainClass=com.huawei.ascend.examples.a2a.A2aConsoleClientApplication \
+  -Dexec.args="http://localhost:18080 openjiuwen-deep-agent manual-user"
+```
+
+### PowerShell
+
+```powershell
+.\mvnw.cmd -f examples\agent-runtime-a2a-openjiuwen-deepagent-e2e\pom.xml `
+  exec:java `
+  "-Dexec.mainClass=com.huawei.ascend.examples.a2a.A2aConsoleClientApplication" `
+  "-Dexec.args=http://localhost:18080 openjiuwen-deep-agent manual-user"
+```
+
+也可以通过环境变量覆盖：
+
+### Bash
+
+```bash
+export SAA_SAMPLE_A2A_BASE_URL="http://localhost:18080"
+export SAA_SAMPLE_AGENT_ID="openjiuwen-deep-agent"
+export SAA_SAMPLE_USER_ID="manual-user"
+./mvnw -f examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/pom.xml \
+  exec:java \
+  -Dexec.mainClass=com.huawei.ascend.examples.a2a.A2aConsoleClientApplication
+```
+
+### PowerShell
+
+```powershell
+$env:SAA_SAMPLE_A2A_BASE_URL = "http://localhost:18080"
+$env:SAA_SAMPLE_AGENT_ID = "openjiuwen-deep-agent"
+$env:SAA_SAMPLE_USER_ID = "manual-user"
+.\mvnw.cmd -f examples\agent-runtime-a2a-openjiuwen-deepagent-e2e\pom.xml `
+  exec:java `
+  "-Dexec.mainClass=com.huawei.ascend.examples.a2a.A2aConsoleClientApplication"
+```
+
+### 4. 使用 HTTP 命令验证 A2A surface
+
+检查 AgentCard：
+
+### Bash
+
+```bash
+curl http://localhost:8080/.well-known/agent-card.json
+```
+
+### PowerShell
+
+```powershell
+curl.exe http://localhost:8080/.well-known/agent-card.json
+```
+
+期望看到：
+
+- `name` 为 `openjiuwen-deep-agent`
+- `capabilities.streaming` 为 `true`
+- `supportedInterfaces` 包含 JSON-RPC
+
+发送 A2A streaming 请求：
+
+### Bash
+
+```bash
+curl http://localhost:8080/a2a \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  --data-raw '{
+    "jsonrpc": "2.0",
+    "id": "manual-1",
+    "method": "SendStreamingMessage",
+    "params": {
+      "metadata": {
+        "userId": "manual-user",
+        "agentId": "openjiuwen-deep-agent"
+      },
+      "message": {
+        "role": "ROLE_USER",
+        "messageId": "manual-message-1",
+        "contextId": "manual-session-1",
+        "parts": [
+          {
+            "text": "ping"
+          }
+        ]
+      }
+    }
+  }'
+```
+
+### PowerShell
+
+```powershell
+$body = @'
+{
+  "jsonrpc": "2.0",
+  "id": "manual-1",
+  "method": "SendStreamingMessage",
+  "params": {
+    "metadata": {
+      "userId": "manual-user",
+      "agentId": "openjiuwen-deep-agent"
+    },
+    "message": {
+      "role": "ROLE_USER",
+      "messageId": "manual-message-1",
+      "contextId": "manual-session-1",
+      "parts": [
+        {
+          "text": "ping"
+        }
+      ]
+    }
+  }
+}
+'@
+
+curl.exe http://localhost:8080/a2a `
+  -H "Content-Type: application/json" `
+  -H "Accept: text/event-stream" `
+  --data-raw $body
+```
+
+## 输入是什么
+
+A2A 输入是一个 JSON-RPC 2.0 请求：
+
+- `method`：`SendStreamingMessage`，表示请求服务端以 SSE stream 返回消息执行结果。
+- `params.message.role`：`ROLE_USER`，表示调用方输入。
+- `params.message.messageId`：调用方生成的消息 ID。
+- `params.message.contextId`：会话 ID，同一会话可复用。
+- `params.metadata.userId`：示例用户 ID。
+- `params.metadata.agentId`：目标 agent，本示例固定为 `openjiuwen-deep-agent`。
+- `params.message.parts[0].text`：用户输入文本，本示例 happy path 使用 `ping`。
+
+DeepAgent 配置中的 system prompt 明确要求：如果用户消息正好是 `ping`，则只回答 `pong`。
+
+## 输出是什么
+
+HTTP 响应是 `text/event-stream`。每个 SSE `data:` 都是一个完整 JSON-RPC response，response 的 `result` 是 A2A SDK streaming event。
+
+典型输出顺序：
+
+1. accepted/working 类事件：表示 runtime 已接收并开始执行任务。
+2. artifact 或 status message 事件：携带 agent 生成的文本片段。
+3. terminal status event：`TaskStatusUpdateEvent` 中的 state 进入 `completed`、`failed`、`canceled` 或 `rejected`。
+
+happy path 的最终用户可见文本是：
+
+```text
+pong
+```
+
+自动化测试不依赖 message metadata 判断终态，而是优先按 A2A SDK 的 stream event 判断是否终止，然后从 `Message`、`TaskStatusUpdateEvent.status.message` 和 `TaskArtifactUpdateEvent.artifact` 中抽取文本。
+
+## 排错
+
+- `SAA_SAMPLE_LLM_API_KEY` 为空
+  - 自动化测试会跳过真实 LLM 调用。设置环境变量后重新运行示例测试。
+- 模型调用失败
+  - 检查 `SAA_SAMPLE_OPENJIUWEN_API_BASE`、`SAA_SAMPLE_LLM_MODEL` 和 key。
+  - 用同一组 base URL/key 直接请求 `/v1/models` 或 `/v1/chat/completions`。
+  - 修改环境变量后需要重启服务端进程。
+- Maven 找不到本地 `agent-runtime`
+  - 先运行上文的 `agent-runtime` 本地安装命令。
+- HTTP stream 没有 completed 事件
+  - 确认请求头包含 `Accept: text/event-stream`。
+  - 确认 `agentId` 是 `openjiuwen-deep-agent`。
+  - 查看服务端日志中是否出现 openJiuwen execute failed。

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/pom.xml
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.huawei.ascend</groupId>
+    <artifactId>spring-ai-ascend-parent</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>agent-runtime-a2a-openjiuwen-deepagent-e2e-example</artifactId>
+  <packaging>jar</packaging>
+  <name>spring-ai-ascend agent-runtime A2A openJiuwen DeepAgent E2E example</name>
+  <description>
+    End-to-end example that starts one agent-runtime instance, binds one
+    openJiuwen DeepAgent, and verifies access through the A2A JSON-RPC
+    streaming endpoint.
+  </description>
+
+  <properties>
+    <enforcer.skip>true</enforcer.skip>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.huawei.ascend</groupId>
+      <artifactId>agent-runtime</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.openjiuwen</groupId>
+      <artifactId>agent-core-java</artifactId>
+      <!-- Must match the version agent-runtime compiles against (its dep is
+           <optional>); 0.1.12-jdk17 carries memory.external.MemoryProvider, which
+           the openJiuwen handler needs at boot â€?0.1.7 lacks it and the context
+           fails with NoClassDefFoundError. -->
+      <version>0.1.12-jdk17</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>4.33.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.6.2</version>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <configuration>
+          <mainClass>com.huawei.ascend.examples.a2a.OpenJiuwenA2aAgentRuntimeApplication</mainClass>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/java/com/huawei/ascend/examples/a2a/A2aConsoleClientApplication.java
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/java/com/huawei/ascend/examples/a2a/A2aConsoleClientApplication.java
@@ -1,0 +1,53 @@
+package com.huawei.ascend.examples.a2a;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Scanner;
+import java.util.UUID;
+
+public final class A2aConsoleClientApplication {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(60);
+    private static final String DEFAULT_BASE_URL = "http://localhost:8080";
+    private static final String DEFAULT_AGENT_ID = "openjiuwen-deep-agent";
+    private static final String DEFAULT_USER_ID = "manual-user";
+
+    private A2aConsoleClientApplication() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        URI baseUri = URI.create(value(args, 0, "SAA_SAMPLE_A2A_BASE_URL", DEFAULT_BASE_URL));
+        String agentId = value(args, 1, "SAA_SAMPLE_AGENT_ID", DEFAULT_AGENT_ID);
+        String userId = value(args, 2, "SAA_SAMPLE_USER_ID", DEFAULT_USER_ID);
+        String sessionId = "manual-session-" + UUID.randomUUID();
+        SampleA2aClient client = new SampleA2aClient(baseUri, TIMEOUT);
+
+        System.out.println("Connected to " + client.agentCard().name() + " at " + baseUri);
+        System.out.println("Type a message and press Enter. Type exit to quit.");
+        try (Scanner scanner = new Scanner(System.in)) {
+            while (true) {
+                System.out.print("> ");
+                if (!scanner.hasNextLine()) {
+                    return;
+                }
+                String input = scanner.nextLine().trim();
+                if (input.isBlank()) {
+                    continue;
+                }
+                if ("exit".equalsIgnoreCase(input) || "quit".equalsIgnoreCase(input)) {
+                    return;
+                }
+                String answer = SampleA2aClient.textFrom(client.streamMessage(userId, agentId, sessionId, input));
+                System.out.println(answer.isBlank() ? "(empty response)" : answer);
+            }
+        }
+    }
+
+    private static String value(String[] args, int index, String envName, String defaultValue) {
+        if (args.length > index && !args[index].isBlank()) {
+            return args[index];
+        }
+        String envValue = System.getenv(envName);
+        return envValue == null || envValue.isBlank() ? defaultValue : envValue;
+    }
+}

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/java/com/huawei/ascend/examples/a2a/InMemoryMemoryProvider.java
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/java/com/huawei/ascend/examples/a2a/InMemoryMemoryProvider.java
@@ -1,0 +1,103 @@
+package com.huawei.ascend.examples.a2a;
+
+import com.huawei.ascend.runtime.engine.AgentExecutionContext;
+import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Lightweight in-memory {@link MemoryProvider} for this example module.
+ *
+ * <p>This is not a production memory backend. It keeps records scoped by
+ * {@link AgentExecutionContext#getAgentStateKey()} so the OpenJiuwen memory rail
+ * can be exercised without Redis, vector stores, or vendor memory SDKs.
+ */
+final class InMemoryMemoryProvider implements MemoryProvider {
+
+    private final ConcurrentMap<String, CopyOnWriteArrayList<MemoryRecord>> recordsByStateKey =
+            new ConcurrentHashMap<>();
+
+    @Override
+    public void init(AgentExecutionContext context) {
+        recordsByStateKey.computeIfAbsent(scopeKey(context), ignored -> new CopyOnWriteArrayList<>());
+    }
+
+    @Override
+    public List<MemoryHit> search(AgentExecutionContext context, String query, int limit) {
+        if (limit <= 0 || !hasText(query)) {
+            return List.of();
+        }
+        String normalizedQuery = normalize(query);
+        return recordsByStateKey.getOrDefault(scopeKey(context), new CopyOnWriteArrayList<>()).stream()
+                .filter(record -> hasText(record.content()))
+                .map(record -> toHit(record, normalizedQuery))
+                .filter(hit -> hit.score() != null && hit.score() > 0.0)
+                .sorted(Comparator.comparingDouble(InMemoryMemoryProvider::scoreOrLowest).reversed())
+                .limit(limit)
+                .toList();
+    }
+
+    @Override
+    public void save(AgentExecutionContext context, List<MemoryRecord> records) {
+        if (records == null || records.isEmpty()) {
+            return;
+        }
+        CopyOnWriteArrayList<MemoryRecord> scopedRecords =
+                recordsByStateKey.computeIfAbsent(scopeKey(context), ignored -> new CopyOnWriteArrayList<>());
+        for (MemoryRecord record : records) {
+            if (record != null && hasText(record.content())) {
+                scopedRecords.add(stableRecord(record));
+            }
+        }
+    }
+
+    List<MemoryRecord> records(AgentExecutionContext context) {
+        return List.copyOf(recordsByStateKey.getOrDefault(scopeKey(context), new CopyOnWriteArrayList<>()));
+    }
+
+    private static MemoryHit toHit(MemoryRecord record, String normalizedQuery) {
+        String normalizedContent = normalize(record.content());
+        if (normalizedContent.contains(normalizedQuery)) {
+            return new MemoryHit(record.id(), record.content(), 1.0, record.metadata());
+        }
+        double score = wordOverlapScore(normalizedQuery, normalizedContent);
+        return new MemoryHit(record.id(), record.content(), score, record.metadata());
+    }
+
+    private static double wordOverlapScore(String normalizedQuery, String normalizedContent) {
+        String[] terms = normalizedQuery.split("\\s+");
+        int matched = 0;
+        for (String term : terms) {
+            if (!term.isBlank() && normalizedContent.contains(term)) {
+                matched++;
+            }
+        }
+        return terms.length == 0 ? 0.0 : (double) matched / terms.length;
+    }
+
+    private static double scoreOrLowest(MemoryHit hit) {
+        return hit.score() == null ? Double.NEGATIVE_INFINITY : hit.score();
+    }
+
+    private static MemoryRecord stableRecord(MemoryRecord record) {
+        String id = hasText(record.id()) ? record.id() : UUID.randomUUID().toString();
+        return new MemoryRecord(id, record.role(), record.content(), record.metadata());
+    }
+
+    private static String scopeKey(AgentExecutionContext context) {
+        return context.getAgentStateKey();
+    }
+
+    private static String normalize(String value) {
+        return String.valueOf(value).trim().toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/java/com/huawei/ascend/examples/a2a/OpenJiuwenA2aAgentRuntimeApplication.java
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/java/com/huawei/ascend/examples/a2a/OpenJiuwenA2aAgentRuntimeApplication.java
@@ -1,0 +1,14 @@
+package com.huawei.ascend.examples.a2a;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication(scanBasePackages = {
+        "com.huawei.ascend.examples.a2a",
+        "com.huawei.ascend.runtime.boot"})
+public class OpenJiuwenA2aAgentRuntimeApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OpenJiuwenA2aAgentRuntimeApplication.class, args);
+    }
+}

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/java/com/huawei/ascend/examples/a2a/OpenJiuwenDeepAgentConfiguration.java
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/java/com/huawei/ascend/examples/a2a/OpenJiuwenDeepAgentConfiguration.java
@@ -1,0 +1,138 @@
+package com.huawei.ascend.examples.a2a;
+
+import com.huawei.ascend.runtime.engine.AgentExecutionContext;
+import com.huawei.ascend.runtime.engine.a2a.AgentCards;
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenCheckpointerConfigurer;
+import com.huawei.ascend.runtime.engine.openjiuwen.OpenJiuwenDeepAgentRuntimeHandler;
+import com.openjiuwen.core.session.checkpointer.Checkpointer;
+import com.openjiuwen.core.singleagent.schema.AgentCard;
+import com.openjiuwen.extensions.checkpointer.redis.RedisCheckpointer;
+import com.openjiuwen.harness.deep_agent.DeepAgent;
+import com.openjiuwen.harness.factory.HarnessFactory;
+import com.openjiuwen.harness.schema.config.DeepAgentConfig;
+import com.openjiuwen.harness.workspace.Workspace;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class OpenJiuwenDeepAgentConfiguration {
+
+    static final String AGENT_ID = "openjiuwen-deep-agent";
+
+    @Bean
+    Checkpointer openJiuwenCheckpointer(
+            @Value("${sample.openjiuwen.checkpointer:${SAA_SAMPLE_OPENJIUWEN_CHECKPOINTER:in-memory}}")
+            String checkpointerType,
+            @Value("${sample.openjiuwen.redis-url:${SAA_SAMPLE_OPENJIUWEN_REDIS_URL:redis://localhost:6379}}")
+            String redisUrl) {
+        if (!isRedisCheckpointer(checkpointerType)) {
+            return OpenJiuwenCheckpointerConfigurer.setInMemoryDefault();
+        }
+        return setRedisCheckpointer(redisUrl);
+    }
+
+    private static boolean isRedisCheckpointer(String checkpointerType) {
+        return "redis".equals(String.valueOf(checkpointerType).trim().toLowerCase(Locale.ROOT));
+    }
+
+    private static Checkpointer setRedisCheckpointer(String redisUrl) {
+        Checkpointer redisCheckpointer = new RedisCheckpointer.Provider()
+                .create(Map.of("connection", Map.of("url", redisUrl)));
+        return OpenJiuwenCheckpointerConfigurer.setDefault(redisCheckpointer);
+    }
+
+    @Bean
+    OpenJiuwenDeepAgentRuntimeHandler openJiuwenDeepAgentHandler(
+            @Value("${sample.openjiuwen.model-provider:${SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER:openai}}")
+            String modelProvider,
+            @Value("${sample.openjiuwen.api-key:${SAA_SAMPLE_LLM_API_KEY:sk-local-placeholder}}") String apiKey,
+            @Value("${sample.openjiuwen.api-base:${SAA_SAMPLE_OPENJIUWEN_API_BASE:http://localhost:4000/v1}}")
+            String apiBase,
+            @Value("${sample.openjiuwen.model-name:${SAA_SAMPLE_LLM_MODEL:gpt-5.4-mini}}") String modelName,
+            @Value("${sample.openjiuwen.ssl-verify:${SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY:false}}")
+            boolean sslVerify,
+            @Value("${sample.openjiuwen.workspace-path:${SAA_SAMPLE_OPENJIUWEN_WORKSPACE_PATH:./target/deepagent-workspace}}")
+            String workspacePath) {
+        return new SampleOpenJiuwenDeepAgentHandler(
+                modelProvider, apiKey, apiBase, modelName, sslVerify, workspacePath);
+    }
+
+    @Bean
+    org.a2aproject.sdk.spec.AgentCard sampleDefaultAgentCard() {
+        return AgentCards.create(AGENT_ID, "Sample openJiuwen DeepAgent hosted by agent-runtime.");
+    }
+
+    static final class SampleOpenJiuwenDeepAgentHandler extends OpenJiuwenDeepAgentRuntimeHandler {
+        private static final String SYSTEM_PROMPT = """
+                You are a concise assistant exposed only through the A2A protocol.
+                If the user's message is exactly ping, reply exactly pong and nothing else.
+                For all other messages, reply to the user's message directly and briefly.
+                """;
+        private final String modelProvider;
+        private final String apiKey;
+        private final String apiBase;
+        private final String modelName;
+        private final boolean sslVerify;
+        private final String workspacePath;
+
+        SampleOpenJiuwenDeepAgentHandler(
+                String modelProvider,
+                String apiKey,
+                String apiBase,
+                String modelName,
+                boolean sslVerify,
+                String workspacePath) {
+            super(AGENT_ID);
+            this.modelProvider = modelProvider;
+            this.apiKey = apiKey;
+            this.apiBase = apiBase;
+            this.modelName = modelName;
+            this.sslVerify = sslVerify;
+            this.workspacePath = workspacePath;
+        }
+
+        @Override
+        protected DeepAgent createOpenJiuwenDeepAgent(AgentExecutionContext context) {
+            AgentCard card = AgentCard.builder()
+                    .id(AGENT_ID)
+                    .name(AGENT_ID)
+                    .description("Example openJiuwen DeepAgent served by agent-runtime A2A.")
+                    .build();
+            DeepAgentConfig config = DeepAgentConfig.builder()
+                    .systemPrompt(SYSTEM_PROMPT)
+                    .maxIterations(3)
+                    .enableTaskLoop(true)
+                    .language("en")
+                    .workspacePath(workspacePath)
+                    .model(modelConfig())
+                    .backend(backendConfig())
+                    .build();
+            Workspace workspace = Workspace.builder()
+                    .rootPath(workspacePath)
+                    .language("en")
+                    .build();
+            return HarnessFactory.createDeepAgent(card, config, workspace);
+        }
+
+        private Map<String, Object> modelConfig() {
+            Map<String, Object> model = new LinkedHashMap<>();
+            model.put("model", modelName);
+            model.put("temperature", 0.0);
+            model.put("max_tokens", 64);
+            return model;
+        }
+
+        private Map<String, Object> backendConfig() {
+            Map<String, Object> backend = new LinkedHashMap<>();
+            backend.put("provider", modelProvider);
+            backend.put("api_key", apiKey);
+            backend.put("api_base", apiBase);
+            backend.put("verify_ssl", sslVerify);
+            return backend;
+        }
+    }
+}

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/java/com/huawei/ascend/examples/a2a/SampleA2aClient.java
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/java/com/huawei/ascend/examples/a2a/SampleA2aClient.java
@@ -1,0 +1,164 @@
+package com.huawei.ascend.examples.a2a;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.a2aproject.sdk.client.http.A2ACardResolver;
+import org.a2aproject.sdk.client.transport.jsonrpc.JSONRPCTransport;
+import org.a2aproject.sdk.client.transport.spi.interceptors.ClientCallContext;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.Message;
+import org.a2aproject.sdk.spec.MessageSendParams;
+import org.a2aproject.sdk.spec.Part;
+import org.a2aproject.sdk.spec.StreamingEventKind;
+import org.a2aproject.sdk.spec.TaskArtifactUpdateEvent;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
+import org.a2aproject.sdk.spec.TextPart;
+
+public final class SampleA2aClient {
+
+    private final URI baseUri;
+    private final Duration timeout;
+
+    public SampleA2aClient(URI baseUri, Duration timeout) {
+        this.baseUri = baseUri;
+        this.timeout = timeout;
+    }
+
+    public AgentCard agentCard() throws Exception {
+        return A2ACardResolver.builder().baseUrl(baseUri.toString()).build().getAgentCard();
+    }
+
+    public List<StreamingEventKind> streamMessage(String userId, String agentId, String sessionId, String text)
+            throws Exception {
+        AgentCard card = agentCard();
+        List<StreamingEventKind> events = new ArrayList<>();
+        CountDownLatch completed = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicBoolean sawTerminal = new AtomicBoolean(false);
+        JSONRPCTransport transport = new JSONRPCTransport(card);
+        try {
+            transport.sendMessageStreaming(
+                    messageSendParams(userId, agentId, sessionId, text),
+                    event -> {
+                        events.add(event);
+                        if (isTerminal(event)) {
+                            sawTerminal.set(true);
+                            completed.countDown();
+                        }
+                    },
+                    error -> {
+                        if (isFailureError(error, sawTerminal.get())) {
+                            failure.set(error);
+                        }
+                        completed.countDown();
+                    },
+                    new ClientCallContext(Map.of(), Map.of()));
+            if (!completed.await(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException("A2A stream did not complete before timeout");
+            }
+        } finally {
+            transport.close();
+        }
+        if (failure.get() != null) {
+            throw new IllegalStateException("A2A stream failed", failure.get());
+        }
+        return List.copyOf(events);
+    }
+
+    public static String textFrom(List<StreamingEventKind> events) {
+        StringBuilder finalText = new StringBuilder();
+        StringBuilder streamingText = new StringBuilder();
+        for (StreamingEventKind event : events) {
+            if (event instanceof Message message) {
+                if (message.metadata() == null || !Boolean.TRUE.equals(message.metadata().get("accepted"))) {
+                    String text = textFromParts(message.parts());
+                    if (isTerminal(message)) {
+                        finalText.append(text);
+                    } else {
+                        streamingText.append(text);
+                    }
+                }
+            } else if (event instanceof TaskStatusUpdateEvent statusEvent
+                    && statusEvent.status() != null
+                    && statusEvent.status().message() != null) {
+                String text = textFromParts(statusEvent.status().message().parts());
+                if (isTerminal(statusEvent)) {
+                    finalText.append(text);
+                } else {
+                    streamingText.append(text);
+                }
+            } else if (event instanceof TaskArtifactUpdateEvent artifactEvent
+                    && artifactEvent.artifact() != null) {
+                streamingText.append(textFromParts(artifactEvent.artifact().parts()));
+            }
+        }
+        return !finalText.isEmpty() ? finalText.toString() : streamingText.toString();
+    }
+
+    private static String textFromParts(List<Part<?>> parts) {
+        StringBuilder result = new StringBuilder();
+        for (Part<?> part : parts) {
+            if (part instanceof TextPart textPart && !textPart.text().isBlank()) {
+                result.append(textPart.text());
+            }
+        }
+        return result.toString();
+    }
+
+    private MessageSendParams messageSendParams(String userId, String agentId, String sessionId, String text) {
+        Message message = Message.builder()
+                .role(Message.Role.ROLE_USER)
+                .messageId(UUID.randomUUID().toString())
+                .contextId(sessionId)
+                .metadata(Map.of(
+                        "userId", userId,
+                        "agentId", agentId,
+                        "sessionId", sessionId))
+                .parts(List.of(new TextPart(text)))
+                .build();
+        return MessageSendParams.builder()
+                .message(message)
+                .build();
+    }
+
+    private static final java.util.Set<String> TERMINAL_RUN_STATUSES =
+            java.util.Set.of("completed", "failed", "canceled", "rejected", "cancelled");
+
+    public static boolean isTerminal(StreamingEventKind event) {
+        if (event instanceof TaskStatusUpdateEvent statusEvent
+                && statusEvent.status() != null
+                && statusEvent.status().state() != null) {
+            TaskState state = statusEvent.status().state();
+            return state == TaskState.TASK_STATE_COMPLETED
+                    || state == TaskState.TASK_STATE_FAILED
+                    || state == TaskState.TASK_STATE_CANCELED
+                    || state == TaskState.TASK_STATE_REJECTED;
+        }
+        if (event instanceof Message message && message.metadata() != null) {
+            return TERMINAL_RUN_STATUSES.contains(String.valueOf(message.metadata().get("runStatus")));
+        }
+        return false;
+    }
+
+    static boolean isFailureError(Throwable error, boolean sawTerminal) {
+        return !(causedByCancellation(error) && sawTerminal);
+    }
+
+    private static boolean causedByCancellation(Throwable error) {
+        for (Throwable t = error; t != null; t = t.getCause()) {
+            if (t instanceof java.util.concurrent.CancellationException) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/resources/application.yaml
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/main/resources/application.yaml
@@ -1,0 +1,18 @@
+debug: false
+
+agent-runtime:
+  access:
+    a2a:
+      default-tenant-id: sample-tenant
+      default-agent-id: openjiuwen-deep-agent
+
+sample:
+  openjiuwen:
+    model-provider: ${SAA_SAMPLE_OPENJIUWEN_MODEL_PROVIDER:openai}
+    api-key: ${SAA_SAMPLE_LLM_API_KEY:sk-local-placeholder}
+    api-base: ${SAA_SAMPLE_OPENJIUWEN_API_BASE:http://localhost:4000/v1}
+    model-name: ${SAA_SAMPLE_LLM_MODEL:gpt-5.4-mini}
+    ssl-verify: ${SAA_SAMPLE_OPENJIUWEN_SSL_VERIFY:true}
+    checkpointer: ${SAA_SAMPLE_OPENJIUWEN_CHECKPOINTER:in-memory}
+    redis-url: ${SAA_SAMPLE_OPENJIUWEN_REDIS_URL:redis://localhost:6379}
+    workspace-path: ${SAA_SAMPLE_OPENJIUWEN_WORKSPACE_PATH:./target/deepagent-workspace}

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/test/java/com/huawei/ascend/examples/a2a/InMemoryMemoryProviderTest.java
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/test/java/com/huawei/ascend/examples/a2a/InMemoryMemoryProviderTest.java
@@ -1,0 +1,39 @@
+package com.huawei.ascend.examples.a2a;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.huawei.ascend.runtime.common.RuntimeIdentity;
+import com.huawei.ascend.runtime.common.RuntimeMessage;
+import com.huawei.ascend.runtime.engine.AgentExecutionContext;
+import com.huawei.ascend.runtime.engine.spi.MemoryProvider;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InMemoryMemoryProviderTest {
+
+    @Test
+    void savesAndSearchesWithinAgentStateKeyScope() {
+        InMemoryMemoryProvider provider = new InMemoryMemoryProvider();
+        AgentExecutionContext firstScope = context("scope-a");
+        AgentExecutionContext secondScope = context("scope-b");
+
+        provider.init(firstScope);
+        provider.save(firstScope, List.of(new MemoryProvider.MemoryRecord(null, "assistant",
+                "remember the user likes green tea", Map.of())));
+
+        assertThat(provider.search(firstScope, "green tea", 5))
+                .singleElement()
+                .satisfies(hit -> assertThat(hit.content()).contains("green tea"));
+        assertThat(provider.search(secondScope, "green tea", 5)).isEmpty();
+        assertThat(provider.records(firstScope))
+                .singleElement()
+                .satisfies(record -> assertThat(record.id()).isNotBlank());
+    }
+
+    private static AgentExecutionContext context(String stateKey) {
+        return new AgentExecutionContext(new RuntimeIdentity("tenant", "user", "session", "task", "agent"),
+                "USER_MESSAGE", List.of(RuntimeMessage.user("ping")),
+                Map.of(AgentExecutionContext.AGENT_STATE_KEY_VARIABLE, stateKey));
+    }
+}

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/test/java/com/huawei/ascend/examples/a2a/OpenJiuwenDeepAgentA2aE2eTest.java
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/test/java/com/huawei/ascend/examples/a2a/OpenJiuwenDeepAgentA2aE2eTest.java
@@ -1,0 +1,66 @@
+package com.huawei.ascend.examples.a2a;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentInterface;
+import org.a2aproject.sdk.spec.StreamingEventKind;
+import org.a2aproject.sdk.spec.TransportProtocol;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@Tag("e2e")
+@ResourceLock("real-llm")
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        classes = OpenJiuwenA2aAgentRuntimeApplication.class)
+class OpenJiuwenDeepAgentA2aE2eTest {
+
+    private static final Duration TIMEOUT = Duration.ofSeconds(45);
+    private static final String AGENT_ID = OpenJiuwenDeepAgentConfiguration.AGENT_ID;
+
+    @LocalServerPort
+    private int port;
+
+    @Test
+    void a2aClientCanStreamOpenJiuwenDeepAgentThroughAgentRuntimeOnly() throws Exception {
+        SampleA2aClient client = new SampleA2aClient(URI.create("http://localhost:" + port), TIMEOUT);
+
+        AgentCard agentCard = client.agentCard();
+        assertThat(agentCard.name()).isEqualTo(AGENT_ID);
+        assertThat(agentCard.description()).contains("openJiuwen DeepAgent");
+        assertThat(agentCard.capabilities().streaming()).isTrue();
+        assertThat(agentCard.supportedInterfaces())
+                .extracting(AgentInterface::protocolBinding)
+                .contains(TransportProtocol.JSONRPC.asString());
+
+        assumeTrue(hasText(System.getenv("SAA_SAMPLE_LLM_API_KEY")),
+                "SAA_SAMPLE_LLM_API_KEY not set; skipping real openJiuwen DeepAgent E2E sample");
+
+        String sessionId = "session-" + UUID.randomUUID();
+        List<StreamingEventKind> events = client.streamMessage("sample-user", AGENT_ID, sessionId, "ping");
+
+        assertThat(events).isNotEmpty();
+        assertThat(events).anySatisfy(event -> assertThat(SampleA2aClient.isTerminal(event)).isTrue());
+        assertThat(normalizeAnswer(SampleA2aClient.textFrom(events))).isEqualTo("pong");
+    }
+
+    private static String normalizeAnswer(String answer) {
+        return answer.strip()
+                .toLowerCase(Locale.ROOT)
+                .replaceFirst("[\\p{Punct}\\s]+$", "");
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isBlank();
+    }
+}

--- a/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/test/java/com/huawei/ascend/examples/a2a/SampleA2aClientTest.java
+++ b/examples/agent-runtime-a2a-openjiuwen-deepagent-e2e/src/test/java/com/huawei/ascend/examples/a2a/SampleA2aClientTest.java
@@ -1,0 +1,153 @@
+package com.huawei.ascend.examples.a2a;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.a2aproject.sdk.spec.Artifact;
+import org.a2aproject.sdk.spec.Message;
+import org.a2aproject.sdk.spec.TaskArtifactUpdateEvent;
+import org.a2aproject.sdk.spec.TaskState;
+import org.a2aproject.sdk.spec.TaskStatus;
+import org.a2aproject.sdk.spec.TaskStatusUpdateEvent;
+import org.a2aproject.sdk.spec.TextPart;
+import org.junit.jupiter.api.Test;
+
+class SampleA2aClientTest {
+
+    @Test
+    void extractsTextFromAllA2aStreamingEventShapes() {
+        Message message = Message.builder()
+                .role(Message.Role.ROLE_AGENT)
+                .messageId("message-1")
+                .parts(List.of(new TextPart("message ")))
+                .build();
+        Message statusMessage = Message.builder()
+                .role(Message.Role.ROLE_AGENT)
+                .messageId("message-2")
+                .parts(List.of(new TextPart("status ")))
+                .build();
+        TaskStatusUpdateEvent status = new TaskStatusUpdateEvent(
+                "task-1",
+                new TaskStatus(TaskState.TASK_STATE_WORKING, statusMessage, null),
+                "session-1",
+                java.util.Map.of());
+        Artifact artifact = Artifact.builder()
+                .artifactId("artifact-1")
+                .parts(List.of(new TextPart("artifact")))
+                .build();
+        TaskArtifactUpdateEvent artifactEvent = new TaskArtifactUpdateEvent(
+                "task-1",
+                artifact,
+                "session-1",
+                Boolean.TRUE,
+                Boolean.TRUE,
+                java.util.Map.of());
+
+        assertThat(SampleA2aClient.textFrom(List.of(message, status, artifactEvent)))
+                .isEqualTo("message status artifact");
+    }
+
+    @Test
+    void excludesAcceptedMessageFromUserVisibleAnswer() {
+        Message accepted = Message.builder()
+                .role(Message.Role.ROLE_AGENT)
+                .messageId("message-accepted")
+                .metadata(java.util.Map.of("accepted", Boolean.TRUE))
+                .parts(List.of(new TextPart("execution enqueued")))
+                .build();
+        Message completed = Message.builder()
+                .role(Message.Role.ROLE_AGENT)
+                .messageId("message-completed")
+                .metadata(java.util.Map.of("runStatus", "completed"))
+                .parts(List.of(new TextPart("pong")))
+                .build();
+
+        assertThat(SampleA2aClient.textFrom(List.of(accepted, completed))).isEqualTo("pong");
+    }
+
+    @Test
+    void prefersTerminalStatusMessageOverStreamingArtifactDeltas() {
+        Artifact firstDelta = Artifact.builder()
+                .artifactId("artifact-1")
+                .parts(List.of(new TextPart("p")))
+                .build();
+        TaskArtifactUpdateEvent firstArtifact = new TaskArtifactUpdateEvent(
+                "task-1",
+                firstDelta,
+                "session-1",
+                Boolean.FALSE,
+                Boolean.FALSE,
+                java.util.Map.of());
+        Artifact secondDelta = Artifact.builder()
+                .artifactId("artifact-1")
+                .parts(List.of(new TextPart("ong")))
+                .build();
+        TaskArtifactUpdateEvent secondArtifact = new TaskArtifactUpdateEvent(
+                "task-1",
+                secondDelta,
+                "session-1",
+                Boolean.TRUE,
+                Boolean.FALSE,
+                java.util.Map.of());
+        Message finalMessage = Message.builder()
+                .role(Message.Role.ROLE_AGENT)
+                .messageId("message-completed")
+                .parts(List.of(new TextPart("pong")))
+                .build();
+        TaskStatusUpdateEvent completed = new TaskStatusUpdateEvent(
+                "task-1",
+                new TaskStatus(TaskState.TASK_STATE_COMPLETED, finalMessage, null),
+                "session-1",
+                java.util.Map.of());
+
+        assertThat(SampleA2aClient.textFrom(List.of(firstArtifact, secondArtifact, completed)))
+                .isEqualTo("pong");
+    }
+
+    @Test
+    void recognizesEveryRuntimeTerminalRunStatusIncludingCanceledSpelling() {
+        assertThat(SampleA2aClient.isTerminal(messageWithRunStatus("completed"))).isTrue();
+        assertThat(SampleA2aClient.isTerminal(messageWithRunStatus("failed"))).isTrue();
+        assertThat(SampleA2aClient.isTerminal(messageWithRunStatus("canceled"))).isTrue();
+        assertThat(SampleA2aClient.isTerminal(messageWithRunStatus("rejected"))).isTrue();
+        assertThat(SampleA2aClient.isTerminal(messageWithRunStatus("in_progress"))).isFalse();
+        assertThat(SampleA2aClient.isTerminal(messageWithRunStatus("incomplete"))).isFalse();
+    }
+
+    @Test
+    void recognizesFinalA2aTaskStatusUpdateAsTerminal() {
+        TaskStatusUpdateEvent completed = new TaskStatusUpdateEvent(
+                "task-1",
+                new TaskStatus(TaskState.TASK_STATE_COMPLETED, null, null),
+                "session-1",
+                java.util.Map.of());
+        TaskStatusUpdateEvent working = new TaskStatusUpdateEvent(
+                "task-1",
+                new TaskStatus(TaskState.TASK_STATE_WORKING, null, null),
+                "session-1",
+                java.util.Map.of());
+
+        assertThat(SampleA2aClient.isTerminal(completed)).isTrue();
+        assertThat(SampleA2aClient.isTerminal(working)).isFalse();
+    }
+
+    @Test
+    void cancellationIsNormalCompletionOnlyAfterTerminalEvent() {
+        java.util.concurrent.CancellationException cancel =
+                new java.util.concurrent.CancellationException("sse unsubscribed");
+
+        assertThat(SampleA2aClient.isFailureError(cancel, true)).isFalse();
+        assertThat(SampleA2aClient.isFailureError(cancel, false)).isTrue();
+        assertThat(SampleA2aClient.isFailureError(new RuntimeException("io", cancel), true)).isFalse();
+        assertThat(SampleA2aClient.isFailureError(new RuntimeException("transport reset"), true)).isTrue();
+    }
+
+    private static Message messageWithRunStatus(String runStatus) {
+        return Message.builder()
+                .role(Message.Role.ROLE_AGENT)
+                .messageId("message-" + runStatus)
+                .metadata(java.util.Map.of("runStatus", runStatus))
+                .parts(List.of(new TextPart("x")))
+                .build();
+    }
+}

--- a/examples/agent-runtime-a2a-remote-agent-tool-e2e/src/main/java/com/huawei/ascend/examples/a2a/remoteagenttool/RemoteA2aAgentConfiguration.java
+++ b/examples/agent-runtime-a2a-remote-agent-tool-e2e/src/main/java/com/huawei/ascend/examples/a2a/remoteagenttool/RemoteA2aAgentConfiguration.java
@@ -74,22 +74,13 @@ public class RemoteA2aAgentConfiguration {
         }
 
         @Override
-        protected Object toOpenJiuwenInput(AgentExecutionContext context) {
-            String conversationId = context.getAgentStateKey();
-            boolean firstTurn = !STARTED_CONVERSATIONS.contains(conversationId);
-            LOG.info("remote-agent received message taskId={} conversationId={} turn={} messages={} text={}",
-                    context.getScope().taskId(),
-                    conversationId,
-                    firstTurn ? "first" : "continuation",
-                    context.getMessages().size(),
-                    context.lastUserText());
-            return super.toOpenJiuwenInput(context);
-        }
-
-        @Override
         protected Iterator<Object> runOpenJiuwenAgentStreaming(BaseAgent agent, Object input, String conversationId,
                 List<StreamMode> streamModes) {
             boolean firstTurn = STARTED_CONVERSATIONS.add(conversationId);
+            LOG.info("remote-agent received message conversationId={} turn={} inputType={}",
+                    conversationId,
+                    firstTurn ? "first" : "continuation",
+                    input == null ? "null" : input.getClass().getName());
             if (firstTurn) {
                 return Stream.<Object>of(
                         AgentExecutionResult.output("Remote agent first stream message 1: remote task started. "),


### PR DESCRIPTION
- Add native OpenJiuwen DeepAgent runtime support alongside the existing ReAct handler.
- Update the remote-agent-tool E2E sample to avoid overriding the now-final shared OpenJiuwen input conversion hook.