### PR TITLE
Fix hardcoded Versatile agent card provider URL  && Extend `AgentCardProperties` to bind YAML-defined A2A Agent Card metadata for capabilities, default input/output modes, and skills.

### DIFF
--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/AgentCardProperties.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/AgentCardProperties.java
@@ -1,8 +1,12 @@
 package com.huawei.ascend.runtime.engine.a2a;
 
 import org.a2aproject.sdk.spec.AgentCard;
+import org.a2aproject.sdk.spec.AgentCapabilities;
 import org.a2aproject.sdk.spec.AgentProvider;
+import org.a2aproject.sdk.spec.AgentSkill;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
 
 /**
  * A2A agent-card metadata configurable via {@code application.yaml}.
@@ -49,6 +53,18 @@ public class AgentCardProperties {
     /** A2A endpoint path. Defaults to {@code "/a2a"}. */
     private String endpoint;
 
+    /** Default card-level input modes. Defaults to {@code ["text"]}. */
+    private List<String> defaultInputModes;
+
+    /** Default card-level output modes. Defaults to {@code ["text", "artifact"]}. */
+    private List<String> defaultOutputModes;
+
+    /** Agent capability overrides. Unset flags preserve the default card shape. */
+    private CapabilitiesProperties capabilities;
+
+    /** Published A2A skills. Defaults to an empty list. */
+    private List<SkillProperties> skills;
+
     public String getName() { return name; }
     public void setName(String name) { this.name = name; }
 
@@ -66,6 +82,24 @@ public class AgentCardProperties {
 
     public String getEndpoint() { return endpoint; }
     public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
+
+    public List<String> getDefaultInputModes() { return defaultInputModes; }
+    public void setDefaultInputModes(List<String> defaultInputModes) {
+        this.defaultInputModes = defaultInputModes;
+    }
+
+    public List<String> getDefaultOutputModes() { return defaultOutputModes; }
+    public void setDefaultOutputModes(List<String> defaultOutputModes) {
+        this.defaultOutputModes = defaultOutputModes;
+    }
+
+    public CapabilitiesProperties getCapabilities() { return capabilities; }
+    public void setCapabilities(CapabilitiesProperties capabilities) {
+        this.capabilities = capabilities;
+    }
+
+    public List<SkillProperties> getSkills() { return skills; }
+    public void setSkills(List<SkillProperties> skills) { this.skills = skills; }
 
     /** Returns {@code true} when the user explicitly configured a card name. */
     public boolean hasExplicitName() {
@@ -85,19 +119,111 @@ public class AgentCardProperties {
                 blankToDefault(description, "agent-runtime"),
                 blankToDefault(version, "0.1.0"),
                 blankToDefault(endpoint, "/a2a"));
+        AgentCard.Builder builder = AgentCard.builder(card);
+
+        if (capabilities != null) {
+            builder.capabilities(toAgentCapabilities(card.capabilities(), capabilities));
+        }
+        if (hasItems(defaultInputModes)) {
+            builder.defaultInputModes(defaultInputModes);
+        }
+        if (hasItems(defaultOutputModes)) {
+            builder.defaultOutputModes(defaultOutputModes);
+        }
+        if (skills != null) {
+            builder.skills(skills.stream()
+                    .map(AgentCardProperties::toAgentSkill)
+                    .toList());
+        }
+
         boolean hasOrganization = organization != null && !organization.isBlank();
         boolean hasOrganizationUrl = organizationUrl != null && !organizationUrl.isBlank();
-        if (!hasOrganization && !hasOrganizationUrl) {
-            return card;
+        if (hasOrganization || hasOrganizationUrl) {
+            builder.provider(new AgentProvider(
+                    blankToDefault(organization, "spring-ai-ascend"),
+                    blankToDefault(organizationUrl, "")));
         }
-        return AgentCard.builder(card)
-                .provider(new AgentProvider(
-                        blankToDefault(organization, "spring-ai-ascend"),
-                        blankToDefault(organizationUrl, "")))
-                .build();
+        return builder.build();
     }
 
     private static String blankToDefault(String value, String defaultValue) {
         return value == null || value.isBlank() ? defaultValue : value;
+    }
+
+    private static boolean hasItems(List<String> values) {
+        return values != null && !values.isEmpty();
+    }
+
+    private static AgentCapabilities toAgentCapabilities(
+            AgentCapabilities defaults, CapabilitiesProperties configured) {
+        return AgentCapabilities.builder()
+                .streaming(configured.streaming != null ? configured.streaming : defaults.streaming())
+                .pushNotifications(configured.pushNotifications != null
+                        ? configured.pushNotifications : defaults.pushNotifications())
+                .extendedAgentCard(configured.extendedAgentCard != null
+                        ? configured.extendedAgentCard : defaults.extendedAgentCard())
+                .build();
+    }
+
+    private static AgentSkill toAgentSkill(SkillProperties skill) {
+        return AgentSkill.builder()
+                .id(skill.id)
+                .name(skill.name)
+                .description(skill.description)
+                .tags(skill.tags != null ? skill.tags : List.of())
+                .examples(skill.examples)
+                .inputModes(skill.inputModes)
+                .outputModes(skill.outputModes)
+                .build();
+    }
+
+    public static class CapabilitiesProperties {
+        private Boolean streaming;
+        private Boolean pushNotifications;
+        private Boolean extendedAgentCard;
+
+        public Boolean getStreaming() { return streaming; }
+        public void setStreaming(Boolean streaming) { this.streaming = streaming; }
+
+        public Boolean getPushNotifications() { return pushNotifications; }
+        public void setPushNotifications(Boolean pushNotifications) {
+            this.pushNotifications = pushNotifications;
+        }
+
+        public Boolean getExtendedAgentCard() { return extendedAgentCard; }
+        public void setExtendedAgentCard(Boolean extendedAgentCard) {
+            this.extendedAgentCard = extendedAgentCard;
+        }
+    }
+
+    public static class SkillProperties {
+        private String id;
+        private String name;
+        private String description;
+        private List<String> tags;
+        private List<String> examples;
+        private List<String> inputModes;
+        private List<String> outputModes;
+
+        public String getId() { return id; }
+        public void setId(String id) { this.id = id; }
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+
+        public String getDescription() { return description; }
+        public void setDescription(String description) { this.description = description; }
+
+        public List<String> getTags() { return tags; }
+        public void setTags(List<String> tags) { this.tags = tags; }
+
+        public List<String> getExamples() { return examples; }
+        public void setExamples(List<String> examples) { this.examples = examples; }
+
+        public List<String> getInputModes() { return inputModes; }
+        public void setInputModes(List<String> inputModes) { this.inputModes = inputModes; }
+
+        public List<String> getOutputModes() { return outputModes; }
+        public void setOutputModes(List<String> outputModes) { this.outputModes = outputModes; }
     }
 }

--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/versatile/VersatileAgentRuntimeHandler.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/versatile/VersatileAgentRuntimeHandler.java
@@ -111,7 +111,7 @@ public final class VersatileAgentRuntimeHandler implements AgentRuntimeHandler, 
                 .name(name)
                 .description(description)
                 .version("0.1.0")
-                .provider(new AgentProvider("spring-ai-ascend", "http://localhost:18082"))
+                .provider(new AgentProvider("spring-ai-ascend", ""))
                 .capabilities(AgentCapabilities.builder()
                         .streaming(true)
                         .pushNotifications(false)

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/a2a/AgentCardPropertiesTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/a2a/AgentCardPropertiesTest.java
@@ -1,0 +1,105 @@
+package com.huawei.ascend.runtime.engine.a2a;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.a2aproject.sdk.spec.AgentCard;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Configuration;
+
+class AgentCardPropertiesTest {
+
+    private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(PropertiesBindingConfiguration.class);
+
+    @Test
+    void yamlCardFieldsOverrideDefaultCapabilitiesModesAndSkills() {
+        AgentCardProperties properties = new AgentCardProperties();
+        properties.setDescription("Configured card");
+        properties.setVersion("2.0.0");
+        properties.setDefaultOutputModes(List.of("text"));
+
+        AgentCardProperties.CapabilitiesProperties capabilities =
+                new AgentCardProperties.CapabilitiesProperties();
+        capabilities.setStreaming(false);
+        capabilities.setPushNotifications(false);
+        properties.setCapabilities(capabilities);
+
+        AgentCardProperties.SkillProperties skill = new AgentCardProperties.SkillProperties();
+        skill.setId("issue-315-demo-skill");
+        skill.setName("Issue 315 Demo Skill");
+        skill.setDescription("Configured through YAML properties.");
+        skill.setTags(List.of("issue-315", "yaml-card"));
+        skill.setExamples(List.of("Show the configured Agent Card skill."));
+        skill.setInputModes(List.of("text"));
+        skill.setOutputModes(List.of("text"));
+        properties.setSkills(List.of(skill));
+
+        AgentCard card = properties.createAgentCard("configured-agent");
+
+        assertThat(card.description()).isEqualTo("Configured card");
+        assertThat(card.version()).isEqualTo("2.0.0");
+        assertThat(card.capabilities().streaming()).isFalse();
+        assertThat(card.capabilities().pushNotifications()).isFalse();
+        assertThat(card.capabilities().extendedAgentCard()).isFalse();
+        assertThat(card.defaultInputModes()).containsExactly("text");
+        assertThat(card.defaultOutputModes()).containsExactly("text");
+        assertThat(card.skills()).hasSize(1);
+        assertThat(card.skills().get(0).id()).isEqualTo("issue-315-demo-skill");
+        assertThat(card.skills().get(0).name()).isEqualTo("Issue 315 Demo Skill");
+        assertThat(card.skills().get(0).description()).isEqualTo("Configured through YAML properties.");
+        assertThat(card.skills().get(0).tags()).containsExactly("issue-315", "yaml-card");
+        assertThat(card.skills().get(0).examples()).containsExactly("Show the configured Agent Card skill.");
+        assertThat(card.skills().get(0).inputModes()).containsExactly("text");
+        assertThat(card.skills().get(0).outputModes()).containsExactly("text");
+    }
+
+    @Test
+    void defaultCardShapeIsPreservedWhenYamlFieldsAreUnset() {
+        AgentCard card = new AgentCardProperties().createAgentCard("default-agent");
+
+        assertThat(card.capabilities().streaming()).isTrue();
+        assertThat(card.capabilities().pushNotifications()).isTrue();
+        assertThat(card.capabilities().extendedAgentCard()).isFalse();
+        assertThat(card.defaultInputModes()).containsExactly("text");
+        assertThat(card.defaultOutputModes()).containsExactly("text", "artifact");
+        assertThat(card.skills()).isEmpty();
+    }
+
+    @Test
+    void springBootBindsKebabCaseYamlProperties() {
+        contextRunner
+                .withPropertyValues(
+                        "agent-runtime.access.a2a.agent-card.name=bound-agent",
+                        "agent-runtime.access.a2a.agent-card.capabilities.streaming=false",
+                        "agent-runtime.access.a2a.agent-card.capabilities.push-notifications=false",
+                        "agent-runtime.access.a2a.agent-card.default-output-modes[0]=text",
+                        "agent-runtime.access.a2a.agent-card.skills[0].id=bound-skill",
+                        "agent-runtime.access.a2a.agent-card.skills[0].name=Bound Skill",
+                        "agent-runtime.access.a2a.agent-card.skills[0].description=Bound from properties",
+                        "agent-runtime.access.a2a.agent-card.skills[0].tags[0]=bound",
+                        "agent-runtime.access.a2a.agent-card.skills[0].examples[0]=Use the bound skill",
+                        "agent-runtime.access.a2a.agent-card.skills[0].input-modes[0]=text",
+                        "agent-runtime.access.a2a.agent-card.skills[0].output-modes[0]=text")
+                .run(context -> {
+                    AgentCardProperties properties = context.getBean(AgentCardProperties.class);
+
+                    AgentCard card = properties.createAgentCard(properties.getName());
+
+                    assertThat(card.capabilities().streaming()).isFalse();
+                    assertThat(card.capabilities().pushNotifications()).isFalse();
+                    assertThat(card.defaultOutputModes()).containsExactly("text");
+                    assertThat(card.skills()).hasSize(1);
+                    assertThat(card.skills().get(0).id()).isEqualTo("bound-skill");
+                    assertThat(card.skills().get(0).inputModes()).containsExactly("text");
+                    assertThat(card.skills().get(0).outputModes()).containsExactly("text");
+                });
+    }
+
+    @Configuration(proxyBeanMethods = false)
+    @EnableConfigurationProperties(AgentCardProperties.class)
+    static class PropertiesBindingConfiguration {
+    }
+}


### PR DESCRIPTION
Fix hardcoded Versatile agent card provider URL