### PR TITLE
fix(memopt): harden circuit (half-open), observable degradation, bounded inputs

### DIFF
--- a/a2a-shared-memory-memopt/src/main/java/com/huawei/ascend/a2a/memory/memopt/Circuit.java
+++ b/a2a-shared-memory-memopt/src/main/java/com/huawei/ascend/a2a/memory/memopt/Circuit.java
@@ -1,42 +1,87 @@
 package com.huawei.ascend.a2a.memory.memopt;
 
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 
 /**
  * A small fail-open circuit guarding the MemOpt HTTP backend. Memory is a side
  * service that must never drag down the agent's main path: after
- * {@code failureThreshold} consecutive failures the circuit opens for {@code openMs},
- * during which calls short-circuit (no network round-trip); a success closes it.
+ * {@code failureThreshold} consecutive failures the circuit OPENs for {@code openMs},
+ * during which calls short-circuit (no network round-trip). When the window
+ * elapses the circuit goes HALF_OPEN and lets exactly <b>one</b> probe through —
+ * its success CLOSEs the circuit, its failure re-OPENs immediately. The single
+ * probe stops a thundering herd of concurrent callers from all hitting a backend
+ * that is likely still unhealthy the instant the window expires.
+ *
+ * <p>All state transitions are taken under the monitor so the
+ * count→open→half-open→close machine is observed atomically; the per-call cost is
+ * a single uncontended lock, negligible for a side-service guard.
  */
 final class Circuit {
+
+    private enum State { CLOSED, OPEN, HALF_OPEN }
 
     private final int failureThreshold;
     private final long openMs;
     private final LongSupplier clock;
-    private final AtomicInteger consecutiveFailures = new AtomicInteger();
-    private final AtomicLong openUntil = new AtomicLong();
+
+    private State state = State.CLOSED;
+    private int consecutiveFailures;
+    private long openUntil;
 
     Circuit(int failureThreshold, long openMs, LongSupplier clock) {
-        this.failureThreshold = failureThreshold;
-        this.openMs = openMs;
+        this.failureThreshold = Math.max(1, failureThreshold);
+        this.openMs = Math.max(0, openMs);
         this.clock = clock == null ? System::currentTimeMillis : clock;
     }
 
-    boolean isOpen() {
-        long until = openUntil.get();
-        return until != 0 && clock.getAsLong() < until;
-    }
-
-    void onSuccess() {
-        consecutiveFailures.set(0);
-        openUntil.set(0);
-    }
-
-    void onFailure() {
-        if (consecutiveFailures.incrementAndGet() >= failureThreshold) {
-            openUntil.set(clock.getAsLong() + openMs);
+    /**
+     * Whether a caller may proceed with the real backend call. CLOSED always
+     * admits; OPEN admits nothing until the window elapses, at which point the
+     * first caller is promoted to the HALF_OPEN probe; HALF_OPEN admits no further
+     * callers while a probe is outstanding. Every {@code true} return must be
+     * paired with exactly one {@link #onSuccess()} / {@link #onFailure()}.
+     */
+    synchronized boolean tryAcquire() {
+        switch (state) {
+            case CLOSED:
+                return true;
+            case OPEN:
+                if (clock.getAsLong() >= openUntil) {
+                    state = State.HALF_OPEN; // promote this caller to the lone probe
+                    return true;
+                }
+                return false;
+            case HALF_OPEN:
+            default:
+                return false; // a probe is already in flight
         }
+    }
+
+    /** True while the circuit is rejecting calls (OPEN window not yet elapsed). */
+    synchronized boolean isOpen() {
+        return state == State.OPEN && clock.getAsLong() < openUntil;
+    }
+
+    synchronized void onSuccess() {
+        state = State.CLOSED;
+        consecutiveFailures = 0;
+        openUntil = 0;
+    }
+
+    synchronized void onFailure() {
+        if (state == State.HALF_OPEN) {
+            open(); // probe failed → straight back to OPEN, fresh window
+            return;
+        }
+        if (++consecutiveFailures >= failureThreshold) {
+            open();
+        }
+    }
+
+    /** Caller holds the monitor. */
+    private void open() {
+        state = State.OPEN;
+        openUntil = clock.getAsLong() + openMs;
+        consecutiveFailures = failureThreshold; // stay tripped until a probe closes us
     }
 }

--- a/a2a-shared-memory-memopt/src/main/java/com/huawei/ascend/a2a/memory/memopt/MemOptExperienceStore.java
+++ b/a2a-shared-memory-memopt/src/main/java/com/huawei/ascend/a2a/memory/memopt/MemOptExperienceStore.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +54,15 @@ public final class MemOptExperienceStore implements ExperienceStore {
     private static final String SEARCH_PATH = "/v1/memory/search";
 
     /**
+     * Bound a single record() request so a runaway caller can't serialise an
+     * unbounded body into one POST (which would risk a backend 413 / OOM):
+     * lessons beyond {@code MAX_LESSONS_PER_RECORD} are dropped and each lesson's
+     * text is truncated to {@code MAX_LESSON_CHARS}.
+     */
+    private static final int MAX_LESSONS_PER_RECORD = 64;
+    private static final int MAX_LESSON_CHARS = 8192;
+
+    /**
      * Timeout / fail-open / circuit tunables, plus an optional bearer token for
      * reaching a containerised MemOpt across a network boundary ({@code authToken}
      * null/blank ⇒ no {@code Authorization} header, for localhost / network-isolated
@@ -74,6 +84,13 @@ public final class MemOptExperienceStore implements ExperienceStore {
     private final String baseUrl;
     private final Options options;
     private final Circuit circuit;
+
+    // Lightweight, dependency-free observability: a down/misbehaving MemOpt is
+    // otherwise invisible (it fails open and the agent path is unaffected). These
+    // let a host surface degradation as metrics; see {@link #stats()}.
+    private final AtomicLong degraded = new AtomicLong();
+    private final AtomicLong clientRejected = new AtomicLong();
+    private final AtomicLong shortCircuited = new AtomicLong();
 
     public MemOptExperienceStore(String baseUrl) {
         this(baseUrl, Options.defaults());
@@ -97,6 +114,15 @@ public final class MemOptExperienceStore implements ExperienceStore {
             if (lesson == null || lesson.text() == null || lesson.text().isBlank()) {
                 continue;
             }
+            if (records.size() >= MAX_LESSONS_PER_RECORD) {
+                LOG.warn("memopt record: lessons capped at {} (got {}); extra dropped",
+                        MAX_LESSONS_PER_RECORD, lessons.size());
+                break;
+            }
+            String text = lesson.text();
+            if (text.length() > MAX_LESSON_CHARS) {
+                text = text.substring(0, MAX_LESSON_CHARS);
+            }
             Map<String, Object> meta = new LinkedHashMap<>();
             meta.put("kind", "a2a-experience");
             meta.put("signature", signatureKey(signature));
@@ -105,7 +131,7 @@ public final class MemOptExperienceStore implements ExperienceStore {
             records.add(Map.of(
                     "id", UUID.randomUUID().toString(),
                     "role", "assistant",
-                    "content", lesson.text(),
+                    "content", text,
                     "metadata", meta));
         }
         if (records.isEmpty()) {
@@ -113,13 +139,16 @@ public final class MemOptExperienceStore implements ExperienceStore {
         }
         String partition = partition(tenantId, signature);
         Map<String, Object> body = Map.of("user_id", partition, "session_id", partition, "records", records);
-        if (circuit.isOpen()) {
-            degrade("record", "circuit open", null);
+        if (!circuit.tryAcquire()) {
+            shortCircuit("record");
             return;
         }
         try {
             post(SAVE_PATH, body);
             circuit.onSuccess();
+        } catch (MemOptClientException e) {
+            // 4xx: our request/contract is wrong, the backend is up — don't trip the circuit.
+            degradeClient("record", e.getMessage(), e);
         } catch (RuntimeException e) {
             circuit.onFailure();
             degrade("record", e.getMessage(), e);
@@ -131,18 +160,23 @@ public final class MemOptExperienceStore implements ExperienceStore {
         if (topK <= 0) {
             return List.of();
         }
-        if (circuit.isOpen()) {
-            return degradeList("recall", "circuit open", null);
-        }
         String partition = partition(tenantId, signature);
         Map<String, Object> body = Map.of(
                 "user_id", partition, "session_id", partition,
                 "query", signatureQuery(signature), "top_k", topK,
                 "scope", Map.of("tenantId", tenantId, "signature", signatureKey(signature)));
+        if (!circuit.tryAcquire()) {
+            shortCircuit("recall");
+            return List.of();
+        }
         try {
             Map<String, Object> resp = post(SEARCH_PATH, body);
             circuit.onSuccess();
             return toLessons(resp, topK);
+        } catch (MemOptClientException e) {
+            // 4xx: request/contract error, not a backend outage — don't trip the circuit.
+            degradeClient("recall", e.getMessage(), e);
+            return List.of();
         } catch (RuntimeException e) {
             circuit.onFailure();
             return degradeList("recall", e.getMessage(), e);
@@ -203,8 +237,15 @@ public final class MemOptExperienceStore implements ExperienceStore {
                     .POST(HttpRequest.BodyPublishers.ofString(MAPPER.writeValueAsString(body), StandardCharsets.UTF_8))
                     .build();
             HttpResponse<String> resp = http.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
-            if (resp.statusCode() < 200 || resp.statusCode() >= 300) {
-                throw new IllegalStateException("MemOpt " + path + " status " + resp.statusCode());
+            int code = resp.statusCode();
+            if (code >= 400 && code < 500) {
+                // Client error: auth (401/403), bad request (400), contract mismatch.
+                // The backend is reachable — surface it distinctly so it isn't mistaken
+                // for an outage and doesn't trip the unhealthy-backend circuit.
+                throw new MemOptClientException("MemOpt " + path + " client error " + code);
+            }
+            if (code < 200 || code >= 300) {
+                throw new IllegalStateException("MemOpt " + path + " status " + code);
             }
             String b = resp.body();
             return b == null || b.isBlank() ? Map.of() : MAPPER.readValue(b, MAP_TYPE);
@@ -216,11 +257,14 @@ public final class MemOptExperienceStore implements ExperienceStore {
         }
     }
 
+    /** A 2xx-less backend failure or transport error — the backend looks unhealthy. */
     private void degrade(String op, String reason, RuntimeException error) {
+        degraded.incrementAndGet();
         if (!options.failOpen()) {
             throw error != null ? error : new IllegalStateException("MemOpt " + op + " unavailable: " + reason);
         }
-        LOG.debug("memopt experience {} degraded ({}); continuing", op, reason);
+        // WARN, not DEBUG: a silently-failing side service must be visible to ops.
+        LOG.warn("memopt experience {} degraded ({}); continuing fail-open", op, reason);
     }
 
     private List<Lesson> degradeList(String op, String reason, RuntimeException error) {
@@ -228,9 +272,54 @@ public final class MemOptExperienceStore implements ExperienceStore {
         return List.of();
     }
 
+    /** A 4xx — the request/contract is wrong, not a backend outage. Reported separately. */
+    private void degradeClient(String op, String reason, RuntimeException error) {
+        clientRejected.incrementAndGet();
+        if (!options.failOpen()) {
+            throw error;
+        }
+        LOG.warn("memopt experience {} rejected by backend ({}); check request/contract — continuing fail-open",
+                op, reason);
+    }
+
+    /** The circuit is open: expected backpressure, not an error — logged quietly. */
+    private void shortCircuit(String op) {
+        shortCircuited.incrementAndGet();
+        if (!options.failOpen()) {
+            throw new IllegalStateException("MemOpt " + op + " unavailable: circuit open");
+        }
+        LOG.debug("memopt experience {} short-circuited (circuit open); continuing", op);
+    }
+
+    /** Snapshot of degradation counters, for a host to export as metrics. */
+    public Stats stats() {
+        return new Stats(degraded.get(), clientRejected.get(), shortCircuited.get());
+    }
+
+    /** Immutable counter snapshot: backend-unhealthy degradations, 4xx rejections, circuit short-circuits. */
+    public record Stats(long degraded, long clientRejected, long shortCircuited) {
+    }
+
+    /** Raised on a 4xx from the MemOpt backend: a request/contract error, not an outage. */
+    static final class MemOptClientException extends IllegalStateException {
+        MemOptClientException(String message) {
+            super(message);
+        }
+    }
+
     /** Stable per-(tenant, signature) MemOpt partition key. */
     static String partition(String tenantId, CollaborationSignature signature) {
-        return "a2a-exp::" + (tenantId == null ? "default" : tenantId) + "::" + signatureKey(signature);
+        return "a2a-exp::" + sanitize(tenantId == null ? "default" : tenantId)
+                + "::" + sanitize(signatureKey(signature));
+    }
+
+    /**
+     * Neutralise the {@code ::} segment delimiter inside a key component so a
+     * crafted {@code tenantId} / signature can't forge a boundary and collide with
+     * (or read) another tenant's partition.
+     */
+    private static String sanitize(String s) {
+        return s.indexOf(':') < 0 ? s : s.replace(':', '_');
     }
 
     static String signatureKey(CollaborationSignature signature) {

--- a/a2a-shared-memory-memopt/src/test/java/com/huawei/ascend/a2a/memory/memopt/CircuitTest.java
+++ b/a2a-shared-memory-memopt/src/test/java/com/huawei/ascend/a2a/memory/memopt/CircuitTest.java
@@ -1,0 +1,108 @@
+package com.huawei.ascend.a2a.memory.memopt;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Exercises the fail-open {@link Circuit} state machine directly, including the
+ * half-open single-probe transition and its behaviour under concurrent callers —
+ * the failure mode that motivated the rewrite (count→open→half-open→close must be
+ * observed atomically, and only one caller may probe a recovering backend).
+ */
+class CircuitTest {
+
+    /** Manual clock so window expiry is deterministic, not wall-clock dependent. */
+    private final AtomicLong now = new AtomicLong(1_000);
+
+    private Circuit circuit(int threshold, long openMs) {
+        return new Circuit(threshold, openMs, now::get);
+    }
+
+    @Test
+    void closedAdmitsUntilThresholdConsecutiveFailures() {
+        Circuit c = circuit(3, 1_000);
+        assertTrue(c.tryAcquire());
+        c.onFailure();
+        c.onFailure();
+        assertTrue(c.tryAcquire(), "still closed below threshold");
+        c.onFailure(); // third consecutive failure trips it
+        assertTrue(c.isOpen());
+        assertFalse(c.tryAcquire(), "open window rejects calls");
+    }
+
+    @Test
+    void successResetsTheConsecutiveFailureCount() {
+        Circuit c = circuit(3, 1_000);
+        c.onFailure();
+        c.onFailure();
+        c.onSuccess(); // resets — the next two failures must not trip it
+        c.onFailure();
+        c.onFailure();
+        assertTrue(c.tryAcquire(), "counter reset by success");
+    }
+
+    @Test
+    void halfOpenAdmitsExactlyOneProbeThenSuccessCloses() {
+        Circuit c = circuit(1, 1_000);
+        c.onFailure(); // open
+        assertFalse(c.tryAcquire());
+        now.addAndGet(1_000); // window elapses
+        assertTrue(c.tryAcquire(), "first caller becomes the half-open probe");
+        assertFalse(c.tryAcquire(), "no second probe while one is in flight");
+        c.onSuccess();
+        assertTrue(c.tryAcquire(), "probe success closes the circuit");
+    }
+
+    @Test
+    void halfOpenProbeFailureReopensImmediately() {
+        Circuit c = circuit(1, 1_000);
+        c.onFailure(); // open
+        now.addAndGet(1_000);
+        assertTrue(c.tryAcquire()); // probe
+        c.onFailure(); // probe fails → reopen, fresh window
+        assertFalse(c.tryAcquire(), "reopened immediately, not after another threshold count");
+        now.addAndGet(1_000);
+        assertTrue(c.tryAcquire(), "next window admits a fresh probe");
+    }
+
+    @Test
+    void underConcurrencyOnlyOneCallerProbesAfterWindow() throws InterruptedException {
+        Circuit c = circuit(1, 1_000);
+        c.onFailure(); // open
+        now.addAndGet(1_000); // window elapsed: exactly one of the racers may probe
+
+        int racers = 64;
+        CountDownLatch ready = new CountDownLatch(racers);
+        CountDownLatch go = new CountDownLatch(1);
+        AtomicInteger admitted = new AtomicInteger();
+        Thread[] threads = new Thread[racers];
+        for (int i = 0; i < racers; i++) {
+            threads[i] = new Thread(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                if (c.tryAcquire()) {
+                    admitted.incrementAndGet();
+                }
+            });
+            threads[i].start();
+        }
+        assertTrue(ready.await(5, TimeUnit.SECONDS));
+        go.countDown();
+        for (Thread t : threads) {
+            t.join(TimeUnit.SECONDS.toMillis(5));
+        }
+        assertEquals(1, admitted.get(), "half-open admits exactly one probe even under a thundering herd");
+    }
+}

--- a/a2a-shared-memory-memopt/src/test/java/com/huawei/ascend/a2a/memory/memopt/MemOptExperienceStoreTest.java
+++ b/a2a-shared-memory-memopt/src/test/java/com/huawei/ascend/a2a/memory/memopt/MemOptExperienceStoreTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.huawei.ascend.a2a.memory.experience.CollaborationSignature;
 import com.huawei.ascend.a2a.memory.experience.Lesson;
@@ -127,5 +129,60 @@ class MemOptExperienceStoreTest {
         assertEquals(MemOptExperienceStore.signatureKey(a), MemOptExperienceStore.signatureKey(b));
         assertEquals("loan,risk|wealth-advice", MemOptExperienceStore.signatureKey(a));
         assertFalse(MemOptExperienceStore.partition("bank", a).isBlank());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void recordCapsLessonCountAndTruncatesLongText() throws Exception {
+        List<Lesson> many = new ArrayList<>();
+        many.add(new Lesson("x".repeat(20_000), "agent", 1L)); // first, so it survives the cap and is truncated
+        for (int i = 0; i < 100; i++) {
+            many.add(new Lesson("lesson " + i, "agent", 1L));
+        }
+
+        MemOptExperienceStore store = new MemOptExperienceStore(baseUrl);
+        store.record("bank", SIG, many);
+
+        Map<String, Object> body = MAPPER.readValue(lastSaveBody.get(), Map.class);
+        List<Map<String, Object>> records = (List<Map<String, Object>>) body.get("records");
+        assertEquals(64, records.size(), "lessons capped at MAX_LESSONS_PER_RECORD");
+        assertEquals(8192, ((String) records.get(0).get("content")).length(), "long text truncated to MAX_LESSON_CHARS");
+        for (Map<String, Object> rec : records) {
+            assertTrue(((String) rec.get("content")).length() <= 8192, "no record exceeds MAX_LESSON_CHARS");
+        }
+    }
+
+    @Test
+    void clientErrorsFailOpenWithoutTrippingTheCircuit() {
+        status = 400; // bad request: a contract error, not a backend outage
+        MemOptExperienceStore store = new MemOptExperienceStore(baseUrl); // failOpen, threshold 5
+        for (int i = 0; i < 10; i++) {
+            store.record("bank", SIG, List.of(new Lesson("x", "a", 1L))); // must not throw
+        }
+        MemOptExperienceStore.Stats s = store.stats();
+        assertEquals(10, s.clientRejected(), "every 4xx counted as a client rejection");
+        assertEquals(0, s.shortCircuited(), "4xx must not open the circuit (no short-circuiting)");
+        assertEquals(0, s.degraded(), "4xx is not a backend-unhealthy degradation");
+    }
+
+    @Test
+    void serverErrorsTripCircuitAndShortCircuitSubsequentCalls() {
+        status = 503; // backend unhealthy
+        MemOptExperienceStore store = new MemOptExperienceStore(baseUrl,
+                new MemOptExperienceStore.Options(java.time.Duration.ofSeconds(2), true, 3, 30_000L));
+        for (int i = 0; i < 8; i++) {
+            store.recall("bank", SIG, 5); // fail-open empty
+        }
+        MemOptExperienceStore.Stats s = store.stats();
+        assertTrue(s.degraded() >= 3, "first failures degrade and trip the circuit");
+        assertTrue(s.shortCircuited() > 0, "once open, later calls short-circuit without a round-trip");
+    }
+
+    @Test
+    void tenantIdIsSanitizedSoSegmentDelimiterCannotBeForged() {
+        // A tenant containing the '::' delimiter must not be able to forge a boundary.
+        String forged = MemOptExperienceStore.partition("a::evil", SIG);
+        assertFalse(forged.contains("a::evil"), "raw delimiter must be neutralised in the key");
+        assertEquals("a2a-exp::a__evil::" + MemOptExperienceStore.signatureKey(SIG), forged);
     }
 }


### PR DESCRIPTION
## Summary

Follow-up hardening on the MemOpt experience store introduced in #287, addressing resilience and observability gaps surfaced in a post-merge code review. Pure follow-up — no SPI/contract changes, additive public surface only (`stats()`).

## What & why

- **Circuit half-open + atomic state machine** — the old `Circuit` used two independent atomics (`consecutiveFailures`, `openUntil`); under concurrency a success could erase a freshly-opened window, and there was **no half-open phase**, so the instant the open window elapsed *every* concurrent caller stampeded a still-unhealthy backend. Rewritten as a monitor-guarded `CLOSED/OPEN/HALF_OPEN` machine: window expiry promotes **exactly one** probe; its success closes, its failure reopens with a fresh window.
- **Observable degradation** — degradations were logged at `DEBUG` with no metrics, leaving a silently-failing side service invisible to ops. Real (backend-unhealthy) failures now log at `WARN`; dependency-free counters are exposed via `stats()` (`degraded` / `clientRejected` / `shortCircuited`).
- **4xx vs 5xx** — a 4xx (auth/contract error) no longer trips the unhealthy-backend circuit and is reported separately: the request is wrong, not the backend down.
- **Input bounds** — cap lessons-per-record (64) and truncate per-lesson text (8192 chars) so a runaway caller can't serialise an unbounded body into a single POST (413 / memory amplification).
- **Partition-key safety** — neutralise the `::` segment delimiter inside `tenantId` / signature so a crafted value can't forge a boundary and collide with (or read) another tenant's partition.

## Tests

- New `CircuitTest`: state-machine transitions + **concurrent single-probe** (64 racers → exactly 1 admitted after the window).
- `MemOptExperienceStoreTest`: 4xx-fails-open-without-tripping-circuit, server-error trip + short-circuit, input caps + truncation, tenant sanitization.
- **16 tests green (was 7).** Module build offline-verified (`mvnw -o test`); gate `check_architecture_sync.sh` exits 0; Rule D-9 scan clean.

## Deferred (separate follow-ups, not in scope here)

- No retry/backoff on transient save failures (record currently lost on a blip) — needs a persistence/compensation decision.
- `reinforce()` re-records rather than bumping reinforcement; recall stamps local time instead of backend recency.
- `deploy/.env.example` defaults the image to a personal GHCR namespace (`ghcr.io/kevin-708090`, marked TEMP) — should move to an org namespace before release.

---

### 中文摘要

针对 #287 合入后代码检视发现的韧性与可观测缺口做的后续加固(纯 follow-up,不动 SPI/契约):

- **熔断器 half-open + 原子状态机**:旧实现两个独立 atomic 在并发下会被 success 擦掉刚开的窗口,且无 half-open——窗口一过所有并发请求惊群冲向仍不健康的后端。重写为 `CLOSED/OPEN/HALF_OPEN`,窗口过后只放行一个探测,成功则关、失败则重开。
- **降级可观测**:原来降级只打 `DEBUG`、无指标 → 静默挂掉 SRE 无感。真实失败升到 `WARN`,新增无依赖计数器 `stats()`。
- **4xx/5xx 区分**:4xx(鉴权/契约)不再误触发"后端不健康"熔断,单独上报。
- **输入上限**:lesson 条数(64)+ 单条长度(8192)封顶,防单次请求体无界 → 413/内存放大。
- **分区键净化**:净化 `tenantId`/signature 中的 `::` 分隔符,防跨租户串键。

测试:新增 `CircuitTest`(状态机 + 并发单探测)及多条 store 用例,16 测试通过(原 7);本地离线构建 + gate 退出 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)