### PR TITLE
fix(research): stop model-pool leak, bound web run concurrency, skip dead retries

### DIFF
--- a/financial/src/main/java/com/bank/financial/research/model/NonRetryable.java
+++ b/financial/src/main/java/com/bank/financial/research/model/NonRetryable.java
@@ -1,0 +1,13 @@
+package com.bank.financial.research.model;
+
+/**
+ * Marks a model failure that a retry cannot fix, so {@link RetryReportModel}
+ * rethrows it immediately instead of backing off and trying again. Two cases:
+ * a hard timeout (the call already consumed its time budget — retrying it 2–3×
+ * just multiplies the wall-clock past the run's budget), and pool saturation
+ * (no capacity to run the call under timeout protection). Transient faults
+ * (connection refused, rate-limit, 5xx) are <em>not</em> marked and stay
+ * retryable.
+ */
+public interface NonRetryable {
+}

--- a/financial/src/main/java/com/bank/financial/research/model/RetryReportModel.java
+++ b/financial/src/main/java/com/bank/financial/research/model/RetryReportModel.java
@@ -42,7 +42,9 @@ public final class RetryReportModel implements ReportModel {
                 return delegate.generate(task);
             } catch (RuntimeException e) {
                 last = e;
-                if (attempt == maxAttempts) {
+                // A NonRetryable failure (timeout, pool saturation) can't be fixed by
+                // retrying — backing off would only multiply the wall-clock. Rethrow now.
+                if (e instanceof NonRetryable || attempt == maxAttempts) {
                     break;
                 }
                 sleep(backoffMs(attempt));

--- a/financial/src/main/java/com/bank/financial/research/model/TimeoutReportModel.java
+++ b/financial/src/main/java/com/bank/financial/research/model/TimeoutReportModel.java
@@ -2,9 +2,11 @@ package com.bank.financial.research.model;
 
 import java.time.Duration;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -15,22 +17,50 @@ import java.util.concurrent.TimeoutException;
  * report run past its budget. This decorator runs each generation on a daemon
  * worker and abandons it after {@code timeout}, throwing a
  * {@link ModelTimeoutException} the sub-agents catch and degrade on.
+ *
+ * <p>The worker pool is a single <b>process-wide, bounded</b> executor shared by
+ * every instance. An earlier design gave each instance its own
+ * {@code newCachedThreadPool} that was never shut down — and an instance is built
+ * per web request, so each live run leaked a pool. A shared pool removes the leak;
+ * bounding it (with direct hand-off + abort-on-saturation) means a burst of stuck
+ * calls degrades gracefully instead of spawning unbounded threads.
  */
 public final class TimeoutReportModel implements ReportModel {
 
+    /**
+     * Shared, bounded worker pool. corePoolSize 0 + {@link SynchronousQueue} means
+     * each submit either hands off to an idle/new thread or is rejected once
+     * {@code maxPoolSize} is reached (no unbounded queue, no unbounded threads);
+     * idle threads are reaped after 60s. Daemon so a stuck call never blocks JVM
+     * shutdown. Size via {@code RESEARCH_MODEL_POOL_MAX} (default 64).
+     */
+    private static final ExecutorService POOL = newSharedPool();
+
     private final ReportModel delegate;
     private final long timeoutMs;
-    private final ExecutorService pool;
 
     public TimeoutReportModel(ReportModel delegate, Duration timeout) {
         this.delegate = delegate;
         this.timeoutMs = timeout.toMillis();
+    }
+
+    private static ExecutorService newSharedPool() {
         ThreadFactory daemon = r -> {
             Thread t = new Thread(r, "report-model-call");
             t.setDaemon(true); // never block JVM shutdown on a stuck model call
             return t;
         };
-        this.pool = Executors.newCachedThreadPool(daemon);
+        return new ThreadPoolExecutor(0, poolMax(), 60L, TimeUnit.SECONDS,
+                new SynchronousQueue<>(), daemon, new ThreadPoolExecutor.AbortPolicy());
+    }
+
+    private static int poolMax() {
+        try {
+            String v = System.getenv("RESEARCH_MODEL_POOL_MAX");
+            return v == null || v.isBlank() ? 64 : Math.max(1, Integer.parseInt(v.trim()));
+        } catch (NumberFormatException e) {
+            return 64;
+        }
     }
 
     @Override
@@ -40,7 +70,14 @@ public final class TimeoutReportModel implements ReportModel {
 
     @Override
     public String generate(ModelTask task) {
-        Future<String> future = pool.submit(() -> delegate.generate(task));
+        Future<String> future;
+        try {
+            future = POOL.submit(() -> delegate.generate(task));
+        } catch (RejectedExecutionException e) {
+            // Pool saturated: no capacity to run under timeout protection. Degrade now
+            // rather than block — and don't retry (retrying a saturated pool won't help).
+            throw new ModelTimeoutException("report model pool saturated (role=" + task.role() + ")");
+        }
         try {
             return future.get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
@@ -59,8 +96,12 @@ public final class TimeoutReportModel implements ReportModel {
         }
     }
 
-    /** Thrown when a generation exceeds its hard time budget. */
-    public static final class ModelTimeoutException extends RuntimeException {
+    /**
+     * Thrown when a generation exceeds its hard time budget (or the worker pool is
+     * saturated). {@link NonRetryable}: the time budget is already spent, so a retry
+     * only multiplies the wall-clock — the sub-agent's degrade path applies instead.
+     */
+    public static final class ModelTimeoutException extends RuntimeException implements NonRetryable {
         public ModelTimeoutException(String message) {
             super(message);
         }

--- a/financial/src/main/java/com/bank/financial/research/web/ResearchWebServer.java
+++ b/financial/src/main/java/com/bank/financial/research/web/ResearchWebServer.java
@@ -69,6 +69,35 @@ public final class ResearchWebServer {
     private static final java.util.Map<String, java.util.concurrent.atomic.AtomicBoolean> PAUSED =
             new java.util.concurrent.ConcurrentHashMap<>();
 
+    // A report run holds its HTTP thread for its whole SSE lifetime (tens of seconds to
+    // minutes on the live model). With a fixed server pool, enough concurrent /api/run
+    // streams would starve every thread — so /, /api/control (pause/resume!) would hang
+    // too. Bound concurrent runs and reject the overflow (503) instead of queueing it, so
+    // the page and control plane always keep threads. Size via RESEARCH_WEB_MAX_RUNS.
+    private static final int MAX_CONCURRENT_RUNS = parseIntEnv("RESEARCH_WEB_MAX_RUNS", 6);
+    private static final RunSlots RUN_SLOTS = new RunSlots(MAX_CONCURRENT_RUNS);
+
+    /** Admission control for concurrent /api/run streams: reject (don't queue) the overflow. */
+    static final class RunSlots {
+        private final java.util.concurrent.Semaphore permits;
+
+        RunSlots(int max) {
+            this.permits = new java.util.concurrent.Semaphore(Math.max(1, max));
+        }
+
+        boolean tryBegin() {
+            return permits.tryAcquire();
+        }
+
+        void end() {
+            permits.release();
+        }
+
+        int available() {
+            return permits.availablePermits();
+        }
+    }
+
     private static final List<Map<String, String>> FUND_AGENTS = List.of(
             Map.of("role", "planner", "label", "规划"), Map.of("role", "data", "label", "数据"),
             Map.of("role", "performance", "label", "业绩"), Map.of("role", "risk", "label", "风险"),
@@ -100,7 +129,9 @@ public final class ResearchWebServer {
         com.bank.financial.research.LogQuieter.quiet();
         int port = parsePort(System.getenv("RESEARCH_WEB_PORT"), 8088);
         HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
-        server.setExecutor(Executors.newFixedThreadPool(4));
+        // Pool must exceed MAX_CONCURRENT_RUNS so the page + control plane always have
+        // threads even when every run slot is occupied.
+        server.setExecutor(Executors.newFixedThreadPool(MAX_CONCURRENT_RUNS + 4));
         server.createContext("/", ResearchWebServer::handlePage);
         server.createContext("/api/run", ResearchWebServer::handleRun);
         server.createContext("/api/control", ResearchWebServer::handleControl);
@@ -114,6 +145,18 @@ public final class ResearchWebServer {
         }
         try {
             return Integer.parseInt(raw.trim());
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+
+    private static int parseIntEnv(String key, int fallback) {
+        String v = System.getenv(key);
+        if (v == null || v.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Math.max(1, Integer.parseInt(v.trim()));
         } catch (NumberFormatException e) {
             return fallback;
         }
@@ -169,6 +212,10 @@ public final class ResearchWebServer {
 
     // ── GET /api/run  → SSE ─────────────────────────────────────────────────────
     private static void handleRun(HttpExchange ex) {
+        if (!RUN_SLOTS.tryBegin()) {
+            rejectBusy(ex); // all run slots occupied — shed load, keep the control plane alive
+            return;
+        }
         OutputStream os = null;
         final java.util.concurrent.atomic.AtomicBoolean alive = new java.util.concurrent.atomic.AtomicBoolean(true);
         final Thread[] hb = new Thread[1];
@@ -322,6 +369,25 @@ public final class ResearchWebServer {
                     // ignore
                 }
             }
+            ex.close();
+            RUN_SLOTS.end(); // free the slot for a waiting caller
+        }
+    }
+
+    /** All run slots are taken: shed this request with 503 + Retry-After rather than queue it. */
+    private static void rejectBusy(HttpExchange ex) {
+        try {
+            byte[] body = "{\"error\":\"server busy: too many concurrent reports, retry shortly\"}"
+                    .getBytes(StandardCharsets.UTF_8);
+            ex.getResponseHeaders().set("Content-Type", "application/json;charset=utf-8");
+            ex.getResponseHeaders().set("Retry-After", "5");
+            ex.sendResponseHeaders(503, body.length);
+            try (OutputStream o = ex.getResponseBody()) {
+                o.write(body);
+            }
+        } catch (IOException ignored) {
+            // client gone
+        } finally {
             ex.close();
         }
     }

--- a/financial/src/test/java/com/bank/financial/research/model/RetryReportModelTest.java
+++ b/financial/src/test/java/com/bank/financial/research/model/RetryReportModelTest.java
@@ -53,4 +53,26 @@ class RetryReportModelTest {
             assertTrue(m.backoffMs(attempt) <= 4000, "backoff must respect cap");
         }
     }
+
+    @Test
+    void nonRetryableFailsFastWithoutRetrying() {
+        AtomicInteger calls = new AtomicInteger();
+        // A timeout already spent its budget — retrying it 2 more times would just
+        // multiply the wall-clock, so it must be thrown on the first attempt.
+        ReportModel timingOut = new ReportModel() {
+            @Override
+            public String name() {
+                return "timeout";
+            }
+
+            @Override
+            public String generate(ModelTask t) {
+                calls.incrementAndGet();
+                throw new TimeoutReportModel.ModelTimeoutException("timed out");
+            }
+        };
+        RetryReportModel m = new RetryReportModel(timingOut, 3, 1);
+        assertThrows(TimeoutReportModel.ModelTimeoutException.class, () -> m.generate(TASK));
+        assertEquals(1, calls.get(), "NonRetryable failure must not be retried");
+    }
 }

--- a/financial/src/test/java/com/bank/financial/research/model/TimeoutReportModelTest.java
+++ b/financial/src/test/java/com/bank/financial/research/model/TimeoutReportModelTest.java
@@ -2,6 +2,7 @@ package com.bank.financial.research.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.bank.financial.research.model.ReportModel.ModelTask;
 import com.bank.financial.research.model.TimeoutReportModel.ModelTimeoutException;
@@ -54,5 +55,13 @@ class TimeoutReportModelTest {
                     throw new IllegalStateException("upstream 500");
                 }), Duration.ofSeconds(2));
         assertThrows(RuntimeException.class, () -> m.generate(TASK));
+    }
+
+    @Test
+    void timeoutExceptionIsNonRetryable() {
+        // Wiring guard: RetryReportModel keys off this marker to avoid re-running a
+        // call whose time budget is already spent.
+        assertTrue(new ModelTimeoutException("x") instanceof NonRetryable,
+                "a hard timeout must be flagged non-retryable");
     }
 }

--- a/financial/src/test/java/com/bank/financial/research/web/RunSlotsTest.java
+++ b/financial/src/test/java/com/bank/financial/research/web/RunSlotsTest.java
@@ -1,0 +1,35 @@
+package com.bank.financial.research.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The /api/run admission gate: concurrent report streams are bounded and the
+ * overflow is rejected (so the page + pause/resume control plane keep their
+ * threads) rather than queued.
+ */
+class RunSlotsTest {
+
+    @Test
+    void admitsUpToLimitThenRejectsUntilOneEnds() {
+        ResearchWebServer.RunSlots slots = new ResearchWebServer.RunSlots(2);
+        assertTrue(slots.tryBegin());
+        assertTrue(slots.tryBegin());
+        assertFalse(slots.tryBegin(), "overflow run rejected once both slots are taken");
+        assertEquals(0, slots.available());
+
+        slots.end(); // a run finished
+        assertEquals(1, slots.available());
+        assertTrue(slots.tryBegin(), "the freed slot admits a waiting run");
+    }
+
+    @Test
+    void clampsToAtLeastOneSlot() {
+        ResearchWebServer.RunSlots slots = new ResearchWebServer.RunSlots(0);
+        assertTrue(slots.tryBegin(), "a non-positive limit is clamped to one usable slot");
+        assertFalse(slots.tryBegin());
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up hardening on the research-report agent introduced in #311, fixing the three resilience issues surfaced in a post-merge code review. No behavioural change on the happy path; additive only.

## What & why

- **Model thread-pool leak** — `TimeoutReportModel` built a per-instance `newCachedThreadPool` that was **never shut down**, and an instance is constructed **per web request** (`ResearchReports.modelChoice` → `/api/run`), so every live run leaked a pool. Replaced with a single **process-wide, bounded** daemon pool (`corePoolSize 0` + `SynchronousQueue` + abort-on-saturation, sized via `RESEARCH_MODEL_POOL_MAX`, default 64): the leak is gone, and a burst of stuck calls degrades gracefully instead of spawning unbounded threads.
- **Web run concurrency** — a report run holds its HTTP thread for the **whole SSE lifetime** (tens of seconds to minutes on the live model), so enough concurrent `/api/run` streams starved the fixed 4-thread server pool — `/` and the pause/resume control plane (`/api/control`) hung too. Added a `RunSlots` admission gate (sized via `RESEARCH_WEB_MAX_RUNS`, default 6) that **sheds the overflow with `503` + `Retry-After`** rather than queueing, and sized the server pool above the run cap so the page + control plane always keep threads.
- **Dead retries** — `RetryReportModel` retried *every* `RuntimeException`, so a hard timeout (whose time budget is already spent) was re-run 2–3×, multiplying the wall-clock past the run budget. Added a `NonRetryable` marker — implemented by `ModelTimeoutException` (covers both timeout and pool saturation) — that `RetryReportModel` rethrows immediately. Transient faults (connection refused, rate-limit, 5xx) stay retryable.

## Tests

- `RetryReportModelTest`: NonRetryable failure is **not** retried (exactly one attempt).
- `TimeoutReportModelTest`: `ModelTimeoutException` carries the `NonRetryable` marker.
- New `RunSlotsTest`: admit-to-limit → reject overflow → release frees a slot → non-positive limit clamps to one.
- **62 tests green (was 58).** Module build offline-verified (`mvnw -o test`); gate `check_architecture_sync.sh` exits 0; Rule D-9 scan clean.

## Deferred (separate follow-ups, not in scope here)

- 4xx-vs-transient classification at the `OpenJiuwenReportModel` boundary (the framework `agent.invoke` path doesn't surface HTTP status cleanly) — only timeout/saturation are marked non-retryable here.
- Per-run wall-clock budget that also accounts for retry backoff sleeps.
- `CompositeReportEngine.global()` bypasses the per-run model-call budget; web-input validation (`code`/`theme`/`lenses`/`pace` length caps) and `MdHtml` XSS-escaping confirmation.
- Full HTTP-level integration test of the 503 admission path (the gate logic is unit-tested via `RunSlots`).

---

### 中文摘要

针对 #311 合入后检视发现的三个韧性问题做后续加固(happy path 无行为变化,纯增量):

- **模型线程池泄漏**:`TimeoutReportModel` 每实例新建 `newCachedThreadPool` 且从不 shutdown,而实例是每个 web 请求新建 → 每次 live run 漏一个池。改为**进程级共享、有界** daemon 池(core 0 + SynchronousQueue + 饱和即拒,`RESEARCH_MODEL_POOL_MAX` 可调):消除泄漏,超时风暴下优雅降级而非线程无界增长。
- **Web 并发饿死**:一次 run 全程占 HTTP 线程(几十秒~数分钟),足够并发的 `/api/run` 打满固定 4 线程池,连 `/` 和 pause/resume 都饿死。新增 `RunSlots` 限流(`RESEARCH_WEB_MAX_RUNS`,默认 6),溢出**返回 `503` + `Retry-After`** 而非排队;server 池调到大于 run 上限,保证页面与控制面始终有线程。
- **无效重试**:`RetryReportModel` 对所有 `RuntimeException` 重试,导致超时(预算已耗尽)被重跑 2–3 次,墙钟翻倍。新增 `NonRetryable` 标记(`ModelTimeoutException` 实现),命中即立刻抛出;瞬时故障仍可重试。

测试:非重试快速失败、超时标记、`RunSlots` 准入,共 62 测试通过(原 58);本地离线构建 + gate 退出 0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)