### PR TITLE
docs: add MCP and SkillHub middleware guides

### DIFF
--- a/agent-runtime/docs/guides/README.md
+++ b/agent-runtime/docs/guides/README.md
@@ -17,6 +17,8 @@
 | [agent-card-configuration.md](agent-card-configuration.md) | 配置 A2A Agent 发现卡片、skills 和 capabilities |
 | [memory-services.md](memory-services.md) | `MemoryProvider` SPI 与 OpenJiuwen 记忆集成 |
 | [state-persistence.md](state-persistence.md) | Agent 执行状态与 checkpoint 持久化 |
+| [mcp-tools.md](mcp-tools.md) | MCP 工具发现、调用与 OpenJiuwen 安装 |
+| [skillhub.md](skillhub.md) | SkillHub 渐进式技能加载与 OpenJiuwen 安装 |
 | [remote-invocation.md](remote-invocation.md) | Agent 通过 A2A 协议调用其他 Agent 作为工具 |
 | [trajectory-observability.md](trajectory-observability.md) | 执行轨迹记录与敏感信息掩码 |
 | [operations-guide.md](operations-guide.md) | 生命周期管理、健康检查、日志诊断、嵌入式部署 |
@@ -38,6 +40,8 @@
 | Agent 调用其他 A2A Agent | [remote-invocation.md](remote-invocation.md) |
 | 添加会话记忆 | [memory-services.md](memory-services.md) |
 | 持久化 Agent 状态 | [state-persistence.md](state-persistence.md) |
+| 接入 MCP Server 工具 | [mcp-tools.md](mcp-tools.md) |
+| 接入 SkillHub 技能目录 | [skillhub.md](skillhub.md) |
 | 理解轨迹事件 | [trajectory-observability.md](trajectory-observability.md) |
 | 修改 AgentCard 名称、描述或 skills | [agent-card-configuration.md](agent-card-configuration.md) |
 | 编写 `SKILL.md` 引导 LLM | [versatile-adapter.md](versatile-adapter.md) 的 `SKILL.md` 实践 |

--- a/agent-runtime/docs/guides/mcp-tools.md
+++ b/agent-runtime/docs/guides/mcp-tools.md
@@ -1,0 +1,121 @@
+# MCP 工具中间件
+
+通过 MCP 工具中间件，OpenJiuwen Agent 可以在执行时发现并调用 MCP Server 暴露的工具。公共层使用 `McpProvider` SPI，OpenJiuwen 通过 `OpenJiuwenMcpToolInstaller` 安装工具。
+
+## 1. 概述
+
+```java
+public interface McpProvider {
+    List<McpToolSpec> listTools(AgentExecutionContext context);
+
+    McpToolResult callTool(AgentExecutionContext context, String serverId,
+            String name, Map<String, Object> arguments);
+}
+```
+
+MCP 工具中间件不改变 `AgentRuntimeHandler` 的执行接口。无 MCP 配置时，不创建 provider，也不影响 Agent 启动。
+
+## 2. 快速开始
+
+### Step 1 — 配置 MCP Server
+
+```yaml
+agent-runtime:
+  mcp:
+    servers:
+      - server-id: localtime
+        transport: streamable-http
+        url: http://localhost:8091/mcp
+        connect-timeout: 5s
+        request-timeout: 30s
+```
+
+SSE Server 和静态 Header 示例：
+
+```yaml
+agent-runtime:
+  mcp:
+    servers:
+      - server-id: howtocook-mcp
+        transport: sse
+        url: https://mcp.api-inference.modelscope.net/136ad5a3226b4d/sse
+        headers:
+          Authorization: Bearer ${MCP_API_TOKEN}
+```
+
+### Step 2 — 自动或手工安装到 OpenJiuwen
+
+Spring Boot 自动装配条件：
+
+- 存在 `agent-runtime.mcp.servers[0].url`
+- classpath 中存在 OpenJiuwen
+- Spring 容器中存在 `OpenJiuwenAgentRuntimeHandler`
+
+满足条件时，runtime 创建 `HttpMcpProvider` 和 `OpenJiuwenMcpToolInstaller`，并注入 handler。
+
+手工 wiring：
+
+```java
+OpenJiuwenAgentRuntimeHandler handler = ...;
+handler.setMcpToolInstaller(new OpenJiuwenMcpToolInstaller(mcpProvider));
+```
+
+## 3. 工作原理
+
+```text
+OpenJiuwenAgentRuntimeHandler.doExecute(...)
+  │
+  ├─ createOpenJiuwenAgent(context)
+  ├─ installRuntimeTools(agent, context)
+  │     └─ OpenJiuwenMcpToolInstaller.install(...)
+  │          ├─ mcpProvider.listTools(context)
+  │          ├─ 生成 ToolCard
+  │          └─ 注册 OpenJiuwen Tool
+  └─ Runner.runAgentStreaming(...)
+        └─ 模型触发 Tool.invoke(...)
+              └─ mcpProvider.callTool(...)
+```
+
+`McpToolSpec.name` 是 MCP 原始工具名。多个 server 出现同名工具时，OpenJiuwen installer 会生成框架内名称，例如 `mcp_weather_query`，同时在 ToolCard properties 中保留原始 `serverId` 和 `toolName`。
+
+## 4. 常用配置
+
+| 配置 | 说明 |
+|---|---|
+| `agent-runtime.mcp.servers[*].server-id` | MCP Server 标识 |
+| `agent-runtime.mcp.servers[*].transport` | `streamable-http` 或 `sse` |
+| `agent-runtime.mcp.servers[*].url` | MCP endpoint |
+| `agent-runtime.mcp.servers[*].headers` | 静态 Header |
+| `agent-runtime.mcp.servers[*].connect-timeout` | 连接超时 |
+| `agent-runtime.mcp.servers[*].request-timeout` | 请求超时 |
+
+## 5. 错误处理
+
+| 场景 | 行为 |
+|---|---|
+| MCP Server 不可达 | 工具发现失败只记录日志；工具调用返回 `MCP_SERVER_UNAVAILABLE` |
+| 鉴权失败 | 返回 `MCP_AUTH_FAILED` |
+| 响应不是合法 JSON-RPC | 返回 `MCP_BAD_RESPONSE` |
+| serverId 未配置 | 返回 `MCP_SERVER_NOT_CONFIGURED` |
+
+## 6. 示例
+
+| Example | 说明 |
+|---|---|
+| `examples/agent-runtime-middleware-mcp-localtime/` | 本地 date/time MCP Server + OpenJiuwen runtime |
+| `examples/agent-runtime-middleware-mcp-remote-json/` | 从 JSON 文件接入远端 MCP Server |
+
+运行示例：
+
+```bash
+./mvnw -f examples/agent-runtime-middleware-mcp-localtime/pom.xml verify
+./mvnw -f examples/agent-runtime-middleware-mcp-remote-json/pom.xml verify
+```
+
+手工 curl 流程见对应 example 的 `README.md` 和 `TUTORIAL.cn.md`。
+
+## 7. 相关资源
+
+- 设计文档：`architecture/docs/L2/agent-runtime/mcp-runtime-tool-middleware-design.md`
+- Proposal：`docs/logs/reviews/2026-06-16-agent-runtime-mcp-middleware-proposal.cn.md`
+- [OpenJiuwen Adapter](openjiuwen-adapter.md)

--- a/agent-runtime/docs/guides/skillhub.md
+++ b/agent-runtime/docs/guides/skillhub.md
@@ -1,0 +1,125 @@
+# SkillHub 中间件
+
+SkillHub 中间件用于渐进式加载 Agent 技能：先列出轻量摘要，再按需加载完整技能定义或技能包。它和 MCP 解耦：SkillHub 管理技能说明，MCP 管理工具调用。
+
+## 1. 概述
+
+```java
+public interface SkillHubProvider {
+    List<SkillSummary> listSkills(AgentExecutionContext context);
+
+    SkillDefinition loadSkill(AgentExecutionContext context, String skillId);
+
+    default SkillPackage loadSkillPackage(AgentExecutionContext context, String skillId);
+}
+```
+
+OpenJiuwen 当前通过 `OpenJiuwenSkillHubInstaller` 把 SkillHub 返回的本地 skill 路径注册到 `BaseAgent`。
+
+## 2. 快速开始
+
+### Step 1 — 提供 SkillHubProvider
+
+```java
+@Bean
+SkillHubProvider skillHubProvider() {
+    return new LocalDirectorySkillHubProvider(Path.of("skills"));
+}
+```
+
+Provider 至少需要实现：
+
+- `listSkills(context)`：返回 `SkillSummary` 列表。
+- `loadSkill(context, skillId)`：返回完整 `SkillDefinition`。
+
+### Step 2 — 设置 OpenJiuwen metadata
+
+OpenJiuwen Wave 1 从 `SkillDefinition.metadata` 中读取本地路径：
+
+```java
+new SkillDefinition(
+        "date-helper",
+        "date-helper",
+        "帮助用户处理日期表达",
+        instructions,
+        List.of(),
+        List.of(),
+        Map.of("openjiuwen.skill.path", "skills/date-helper"));
+```
+
+多个路径可以使用：
+
+```java
+Map.of("openjiuwen.skill.paths", List.of("skills/a", "skills/b"))
+```
+
+### Step 3 — 自动或手工安装
+
+Spring Boot 自动装配条件：
+
+- classpath 中存在 OpenJiuwen
+- Spring 容器中存在 `SkillHubProvider`
+- Spring 容器中存在 `OpenJiuwenAgentRuntimeHandler`
+
+满足条件时，runtime 创建 `OpenJiuwenSkillHubInstaller` 并注入 handler。
+
+手工 wiring：
+
+```java
+handler.setSkillHubInstaller(new OpenJiuwenSkillHubInstaller(skillHubProvider));
+```
+
+## 3. 工作原理
+
+```text
+OpenJiuwenAgentRuntimeHandler.doExecute(...)
+  │
+  ├─ createOpenJiuwenAgent(context)
+  ├─ installRuntimeTools(agent, context)
+  │     └─ OpenJiuwenSkillHubInstaller.install(...)
+  │          ├─ skillHubProvider.listSkills(context)
+  │          ├─ skillHubProvider.loadSkill(context, skillId)
+  │          ├─ 读取 openjiuwen.skill.path(s)
+  │          └─ agent.registerSkill(path)
+  └─ Runner.runAgentStreaming(...)
+```
+
+SkillHub installer 每次执行前安装技能。Provider 可以自己缓存 summary/definition，也可以按 tenant、user、agentId 返回不同技能集合。
+
+## 4. 数据模型
+
+| 类型 | 用途 |
+|---|---|
+| `SkillSummary` | 轻量摘要，包含 `skillId`、`name`、`description`、`tags`、`metadata` |
+| `SkillDefinition` | 完整技能定义，包含 `instructions`、`referenceUris`、`toolDependencies`、`metadata` |
+| `SkillToolDependency` | 描述推荐工具依赖，例如某个 MCP tool |
+| `SkillPackage` | 可选打包 payload，通常是包含 `SKILL.md` 和参考文件的 zip |
+
+## 5. 示例
+
+| Example | 说明 |
+|---|---|
+| `examples/agent-runtime-middleware-skillhub-local/` | 本地 `skills/` 目录作为 SkillHub |
+| `examples/agent-runtime-middleware-skillhub-remote-json/` | 远端 HTTP JSON catalog 作为 SkillHub |
+
+运行示例：
+
+```bash
+./mvnw -f examples/agent-runtime-middleware-skillhub-local/pom.xml verify
+./mvnw -f examples/agent-runtime-middleware-skillhub-remote-json/pom.xml verify
+```
+
+手工 curl 流程见对应 example 的 `README.md` 和 `TUTORIAL.cn.md`。
+
+## 6. 限制
+
+- 当前不实现 Nacos Skill Registry。
+- 当前不实现动态技能热更新。
+- SkillHub 不负责执行工具调用；需要工具调用时通过 MCP 或其他 tool installer 接入。
+- 多租户权限过滤由业务自定义 `SkillHubProvider` 实现。
+
+## 7. 相关资源
+
+- 设计文档：`architecture/docs/L2/agent-runtime/skillhub-runtime-middleware-design.md`
+- Proposal：`docs/logs/reviews/2026-06-17-agent-runtime-skill-hub-middleware-proposal.cn.md`
+- 测试设计：`architecture/docs/L1/agent-runtime/features/skillhub-middleware-test-design.cn.md`

--- a/architecture/docs/L2/agent-runtime/mcp-runtime-tool-middleware-design.md
+++ b/architecture/docs/L2/agent-runtime/mcp-runtime-tool-middleware-design.md
@@ -1,0 +1,212 @@
+# MCP Runtime Tool Middleware — 设计文档
+
+> 适用目录：`architecture/docs/L2/agent-runtime/`
+> 目标模块：`agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/mcp/`、`agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/`
+> 最后更新：2026-06-22
+
+---
+
+## 1. 概述
+
+### 1.1 特性定位
+
+agent-runtime 的 MCP 接入定位为 **工具中间件**：runtime 通过 MCP Server 发现外部工具，再由具体 Agent 框架 adapter 把这些工具安装为框架原生工具。MCP 不进入 A2A protocol bridge，也不改变 `AgentRuntimeHandler` 的执行 SPI。
+
+- **解决的问题**：业务不需要为每个远端工具手写 Java wrapper；MCP Server 暴露的工具可以被 Agent 自动发现和调用。
+- **适用场景**：接入 ModelScope MCP Server、本地工具 MCP Server、企业内部 MCP Server。如果只是远端 Agent 互调，应使用远程 A2A tool，而不是 MCP。
+
+### 1.2 核心设计原则
+
+1. **公共层保持窄 SPI** — `McpProvider` 只表达工具发现和工具调用，不暴露 MCP SDK、OpenJiuwen 或 AgentScope 类型。
+2. **框架本地安装** — OpenJiuwen 使用 `OpenJiuwenMcpToolInstaller` 把 MCP tool 安装成 OpenJiuwen `Tool`；其他框架未来使用自己的 Toolkit / Tool registry。
+3. **MCP 与 A2A Tool 解耦** — MCP tool 是一次工具调用；远程 A2A tool 可能涉及 task、stream、input-required 和中断续接。
+4. **无配置不影响启动** — 没有 MCP 配置或 `McpProvider` 时，不创建 installer，Agent 正常启动。
+
+### 1.3 子特性全景
+
+| 子特性 | 职责 | 关键抽象 | 状态 |
+|---|---|---|---|
+| MCP Provider SPI | 框架中立的 tools/list 与 tools/call | `McpProvider` | ✅ |
+| MCP Tool 数据模型 | 对齐 MCP Tool / ToolResult | `McpToolSpec`、`McpToolResult` | ✅ |
+| HTTP/SSE Provider | 通过 JSON-RPC over HTTP/SSE 连接 MCP Server | `HttpMcpProvider`、`McpProperties` | ✅ |
+| OpenJiuwen 工具安装 | 将 MCP tool 注册进 OpenJiuwen Agent | `OpenJiuwenMcpToolInstaller` | ✅ |
+| 自动装配 | 有 MCP 配置时自动创建 provider 并注入 OpenJiuwen handler | `McpAutoConfiguration` | ✅ |
+| stdio 托管 | 启停本地 stdio MCP server 进程 | — | ⬜ |
+| MCP resources/prompts | 接入 MCP 非 tool 能力 | — | ⬜ |
+
+---
+
+## 2. 功能规格
+
+### 2.1 能力清单
+
+| 能力 | 状态 | 说明 |
+|---|---|---|
+| MCP tool discovery | ✅ | `McpProvider.listTools(context)` 返回当前上下文可见工具 |
+| MCP tool call | ✅ | `McpProvider.callTool(context, serverId, name, arguments)` 调用工具 |
+| HTTP Streamable MCP | ✅ | 通过 `agent-runtime.mcp.servers[*].transport=streamable-http` 配置 |
+| SSE MCP | ✅ | 通过 `agent-runtime.mcp.servers[*].transport=sse` 配置 |
+| 静态 headers | ✅ | 支持配置 Authorization 等 server 级 Header |
+| 多 server 聚合 | ✅ | `serverId` 用于路由和命名冲突处理 |
+| 工具命名冲突处理 | ✅ | 同名工具跨 server 时生成 `mcp_<serverId>_<name>` |
+| 工具发现失败降级 | ✅ | 发现失败只记录日志，不阻止 Agent 启动 |
+| 动态鉴权 | ⬜ | 生产动态鉴权由业务自定义 `McpProvider` 扩展 |
+
+### 2.2 显式排除
+
+| 排除项 | 原因 | 替代 |
+|---|---|---|
+| 把 MCP SDK 类型放入 `engine.spi` | 会绑定具体 SDK 和框架，破坏中立 SPI | `McpToolSpec` / `McpToolResult` 保留标准字段 |
+| 复用 A2A remote interrupt rail | MCP 是 tool call，不是远程 Agent task | 使用 OpenJiuwen 原生 `Tool` wrapper |
+| stdio server 进程托管 | 涉及进程生命周期、日志、安全策略 | 后续单独设计 |
+| MCP marketplace 管理后台 | 属于平台管理能力 | 后续由平台层或 SkillHub/Registry 处理 |
+
+### 2.3 接口契约
+
+#### McpProvider
+
+```java
+public interface McpProvider {
+    List<McpToolSpec> listTools(AgentExecutionContext context);
+
+    McpToolResult callTool(AgentExecutionContext context, String serverId,
+            String name, Map<String, Object> arguments);
+}
+```
+
+行为承诺：
+
+- `listTools(...)` 返回当前执行上下文可见的工具。Provider 可以缓存，但必须保证 `serverId` 和 `name` 能用于后续调用。
+- `callTool(...)` 调用指定 MCP tool。工具级错误应尽量返回 `McpToolResult.isError=true`，让模型有机会处理；协议级错误可映射为明确错误码。
+- 生产环境如果需要租户级鉴权、动态 Header 或工具过滤，应通过自定义 `McpProvider` 实现。
+
+#### McpToolSpec
+
+`McpToolSpec` 对齐 MCP `Tool`：
+
+| 字段 | 说明 |
+|---|---|
+| `serverId` | runtime 侧 MCP Server 标识 |
+| `name` | MCP tool 原始名称 |
+| `title` | 标题，可为空 |
+| `description` | 工具描述 |
+| `inputSchema` | MCP input schema |
+| `outputSchema` | MCP output schema |
+| `annotations` | MCP tool annotations |
+| `meta` | MCP `_meta` |
+| `metadata` | runtime 自定义元数据 |
+
+#### McpToolResult
+
+`McpToolResult` 对齐 MCP `ToolResult`：
+
+| 字段 | 说明 |
+|---|---|
+| `content` | MCP 标准 content 列表 |
+| `structuredContent` | 结构化结果 |
+| `isError` | MCP 标准错误标记 |
+| `errorCode` / `message` | runtime 可观测增强 |
+| `meta` | MCP `_meta` |
+| `metadata` | runtime 自定义元数据 |
+
+---
+
+## 3. 模块结构
+
+```text
+engine/spi/
+├── McpProvider.java
+├── McpToolSpec.java
+└── McpToolResult.java
+
+engine/mcp/
+├── McpProperties.java
+├── HttpMcpProvider.java
+└── McpAutoConfiguration.java
+
+engine/openjiuwen/
+└── OpenJiuwenMcpToolInstaller.java
+```
+
+---
+
+## 4. 核心流程
+
+### 4.1 自动装配流程
+
+```text
+应用启动
+  │
+  ├─ 检测 agent-runtime.mcp.servers[0].url
+  ├─ 创建 HttpMcpProvider
+  ├─ 检测 OpenJiuwen classpath 与 McpProvider bean
+  └─ 创建 OpenJiuwenMcpToolInstaller 并注入 OpenJiuwenAgentRuntimeHandler
+```
+
+### 4.2 执行期工具安装与调用
+
+```text
+A2A 请求
+  │
+  ├─ OpenJiuwenAgentRuntimeHandler.createOpenJiuwenAgent(context)
+  ├─ installRuntimeTools(agent, context)
+  │     └─ OpenJiuwenMcpToolInstaller.install(agent, context)
+  │          ├─ mcpProvider.listTools(context)
+  │          ├─ ToolCard 映射
+  │          └─ Runner.resourceMgr().addTool(...)
+  ├─ OpenJiuwen Runner 执行
+  ├─ 模型选择 MCP tool
+  └─ RuntimeMcpTool.invoke(...)
+        └─ mcpProvider.callTool(context, serverId, name, arguments)
+```
+
+### 4.3 命名冲突处理
+
+MCP 只保证单个 server 内 tool name 唯一。多个 server 聚合后，如果存在同名工具：
+
+```text
+原始: serverId=weather, name=query
+框架内: mcp_weather_query
+```
+
+如果没有冲突，框架内名称保持原始 name，减少模型可见名称噪声。ToolCard properties 会保留 `runtime.mcp.serverId` 和 `runtime.mcp.toolName`。
+
+---
+
+## 5. 错误与可观测性
+
+| 场景 | 行为 |
+|---|---|
+| Server 不可达 | discovery 阶段记录 warn；tool call 返回 `MCP_SERVER_UNAVAILABLE` |
+| 鉴权失败 | 返回 `MCP_AUTH_FAILED` |
+| 非法响应 | 返回 `MCP_BAD_RESPONSE` |
+| 未配置 serverId | 返回 `MCP_SERVER_NOT_CONFIGURED` |
+| 工具执行错误 | 返回 `McpToolResult.isError=true` 和错误内容 |
+
+日志应至少包含 `serverId`、`toolName`、latency 和 `isError`，便于定位外部 MCP Server 问题。
+
+---
+
+## 6. 示例与验证
+
+| Example | 用途 |
+|---|---|
+| `examples/agent-runtime-middleware-mcp-localtime` | 本地真实 date/time MCP Server，验证 tools/list 与 tools/call |
+| `examples/agent-runtime-middleware-mcp-remote-json` | 从 JSON 文件接入远端 HTTP/SSE MCP Server |
+
+验证入口：
+
+```bash
+./mvnw -f examples/agent-runtime-middleware-mcp-localtime/pom.xml verify
+./mvnw -f examples/agent-runtime-middleware-mcp-remote-json/pom.xml verify
+```
+
+手工 curl 级验证步骤见各 example 的 `README.md` 和 `TUTORIAL.cn.md`。
+
+---
+
+## 7. 相关文档
+
+- 开发指南：`agent-runtime/docs/guides/mcp-tools.md`
+- Proposal：`docs/logs/reviews/2026-06-16-agent-runtime-mcp-middleware-proposal.cn.md`
+- Example：`examples/agent-runtime-middleware-mcp-localtime/`

--- a/architecture/docs/L2/agent-runtime/skillhub-runtime-middleware-design.md
+++ b/architecture/docs/L2/agent-runtime/skillhub-runtime-middleware-design.md
@@ -1,0 +1,186 @@
+# SkillHub Runtime Middleware — 设计文档
+
+> 适用目录：`architecture/docs/L2/agent-runtime/`
+> 目标模块：`agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/spi/`、`agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/openjiuwen/`
+> 最后更新：2026-06-22
+
+---
+
+## 1. 概述
+
+### 1.1 特性定位
+
+agent-runtime 的 SkillHub 接入定位为 **渐进式技能加载中间件**。SkillHub 先暴露轻量技能摘要，只有在具体框架需要安装或使用某个技能时，才加载完整技能定义或技能包。
+
+SkillHub 和 MCP 是解耦能力：
+
+- MCP 负责工具发现和工具调用。
+- SkillHub 负责技能目录、说明、参考资料和可选包加载。
+- 一个 skill 可以声明推荐工具依赖，例如某个 MCP tool，但 SkillHub 本身不执行工具调用。
+
+### 1.2 核心设计原则
+
+1. **渐进式加载** — `SkillSummary` 用于发现，`SkillDefinition` 用于完整说明，`SkillPackage` 用于可选下载/安装。
+2. **公共 SPI 中立** — `SkillHubProvider` 不绑定 OpenJiuwen、AgentScope、MCP 或 Nacos 包名。
+3. **框架本地安装** — OpenJiuwen 使用 `BaseAgent.registerSkill(...)`；其他框架未来使用自己的 skill/knowledge 机制。
+4. **无 Provider 不影响启动** — 没有 `SkillHubProvider` 时，不创建 installer，Agent 正常执行。
+
+### 1.3 子特性全景
+
+| 子特性 | 职责 | 关键抽象 | 状态 |
+|---|---|---|---|
+| SkillHub Provider SPI | 技能摘要、完整定义、可选包加载 | `SkillHubProvider` | ✅ |
+| 技能摘要模型 | 首屏轻量发现 | `SkillSummary` | ✅ |
+| 技能完整定义 | instructions、referenceUris、toolDependencies | `SkillDefinition` | ✅ |
+| 技能包模型 | 可下载/安装 payload | `SkillPackage` | ✅ |
+| OpenJiuwen 安装 | 读取 metadata 中的本地路径并注册技能 | `OpenJiuwenSkillHubInstaller` | ✅ |
+| 自动装配 | 有 `SkillHubProvider` 时自动注入 OpenJiuwen handler | `OpenJiuwenSkillHubAutoConfiguration` | ✅ |
+| Nacos Skill Registry | 远端注册中心实现 | — | ⬜ |
+| 动态技能热更新 | 运行中刷新技能目录 | — | ⬜ |
+
+---
+
+## 2. 功能规格
+
+### 2.1 能力清单
+
+| 能力 | 状态 | 说明 |
+|---|---|---|
+| 列出技能摘要 | ✅ | `listSkills(context)` 返回 compact summary |
+| 加载完整技能 | ✅ | `loadSkill(context, skillId)` 返回 instructions 等完整定义 |
+| 加载技能包 | ✅ | `loadSkillPackage(context, skillId)` 是可选能力 |
+| OpenJiuwen 本地技能安装 | ✅ | 通过 `openjiuwen.skill.path(s)` metadata 调用 `registerSkill(...)` |
+| 本地目录样例 | ✅ | 从本地 `SKILL.md` 目录加载 |
+| 远端 JSON 目录样例 | ✅ | 通过 JSON catalog 模拟远端 SkillHub |
+| 工具依赖声明 | ✅ | `SkillToolDependency` 描述推荐工具，不负责执行 |
+| Nacos Registry | ⬜ | 后续单独调研和实现 |
+
+### 2.2 显式排除
+
+| 排除项 | 原因 | 替代 |
+|---|---|---|
+| 把 SkillHub 建模成 MCP tool | SkillHub 是技能加载，不是工具调用协议 | Skill 可以声明 MCP tool 依赖 |
+| 在公共 SPI 暴露 OpenJiuwen skill 类型 | 会破坏多框架接入 | 通过 metadata 表达 OpenJiuwen 本地路径 |
+| 企业级权限模型 | 依赖租户、用户、组织和平台策略 | 由业务自定义 `SkillHubProvider` 过滤 |
+| 动态热更新 | 需要处理模型上下文和已安装技能一致性 | 后续独立设计 |
+
+### 2.3 接口契约
+
+#### SkillHubProvider
+
+```java
+public interface SkillHubProvider {
+    List<SkillSummary> listSkills(AgentExecutionContext context);
+
+    SkillDefinition loadSkill(AgentExecutionContext context, String skillId);
+
+    default SkillPackage loadSkillPackage(AgentExecutionContext context, String skillId);
+}
+```
+
+行为承诺：
+
+- `listSkills(...)` 应返回当前上下文可见的轻量摘要，不应包含大量 instructions。
+- `loadSkill(...)` 按 `skillId` 返回完整定义。Provider 可以基于 tenant、user、agentId 做过滤。
+- `loadSkillPackage(...)` 是可选能力，不支持时可以抛出 `UnsupportedOperationException`。
+
+#### SkillDefinition metadata
+
+OpenJiuwen Wave 1 使用以下 metadata key：
+
+| key | 类型 | 说明 |
+|---|---|---|
+| `openjiuwen.skill.path` | `String` | 单个本地 skill 目录 |
+| `openjiuwen.skill.paths` | `List<String>` 或单个 `String` | 多个本地 skill 目录 |
+
+这些 key 是 OpenJiuwen adapter 本地约定，不是公共 SkillHub 协议的必填字段。
+
+---
+
+## 3. 模块结构
+
+```text
+engine/spi/
+├── SkillHubProvider.java
+├── SkillSummary.java
+├── SkillDefinition.java
+├── SkillToolDependency.java
+└── SkillPackage.java
+
+engine/openjiuwen/
+├── OpenJiuwenSkillHubInstaller.java
+└── OpenJiuwenSkillHubAutoConfiguration.java
+```
+
+---
+
+## 4. 核心流程
+
+### 4.1 自动装配流程
+
+```text
+应用启动
+  │
+  ├─ 业务或 example 创建 SkillHubProvider bean
+  ├─ 检测 OpenJiuwen classpath
+  ├─ 创建 OpenJiuwenSkillHubInstaller
+  └─ 注入所有 OpenJiuwenAgentRuntimeHandler
+```
+
+### 4.2 执行期技能安装
+
+```text
+A2A 请求
+  │
+  ├─ OpenJiuwenAgentRuntimeHandler.createOpenJiuwenAgent(context)
+  ├─ installRuntimeTools(agent, context)
+  │     └─ OpenJiuwenSkillHubInstaller.install(agent, context)
+  │          ├─ skillHubProvider.listSkills(context)
+  │          ├─ skillHubProvider.loadSkill(context, skillId)
+  │          ├─ 读取 openjiuwen.skill.path(s)
+  │          └─ agent.registerSkill(path)
+  └─ OpenJiuwen Runner 执行
+```
+
+SkillHub installer 当前每次执行前安装技能。Provider 可以自行缓存 summary/definition，业务也可以根据上下文返回不同技能集合。
+
+---
+
+## 5. SkillHub 与 MCP 的关系
+
+| 维度 | SkillHub | MCP |
+|---|---|---|
+| 核心对象 | Skill summary / definition / package | Tool / ToolResult |
+| 主要用途 | 渐进式加载任务说明和参考资料 | 发现和调用外部工具 |
+| 调用时机 | Agent 执行前安装/加载 | 模型推理中触发 tool call |
+| 公共 SPI | `SkillHubProvider` | `McpProvider` |
+| OpenJiuwen 接入 | `registerSkill(path)` | `Tool` wrapper + `Runner.resourceMgr()` |
+
+一个 skill 可以通过 `toolDependencies` 声明它依赖某个 MCP tool，但这只是提示和依赖描述，不代表 SkillHub 自己调用工具。
+
+---
+
+## 6. 示例与验证
+
+| Example | 用途 |
+|---|---|
+| `examples/agent-runtime-middleware-skillhub-local` | 本地 `skills/` 目录作为 SkillHub |
+| `examples/agent-runtime-middleware-skillhub-remote-json` | 远端 HTTP JSON catalog 作为 SkillHub |
+
+验证入口：
+
+```bash
+./mvnw -f examples/agent-runtime-middleware-skillhub-local/pom.xml verify
+./mvnw -f examples/agent-runtime-middleware-skillhub-remote-json/pom.xml verify
+```
+
+手工 curl 级验证步骤见各 example 的 `README.md` 和 `TUTORIAL.cn.md`。
+
+---
+
+## 7. 相关文档
+
+- 开发指南：`agent-runtime/docs/guides/skillhub.md`
+- Proposal：`docs/logs/reviews/2026-06-17-agent-runtime-skill-hub-middleware-proposal.cn.md`
+- 测试设计：`architecture/docs/L1/agent-runtime/features/skillhub-middleware-test-design.cn.md`
+- Example：`examples/agent-runtime-middleware-skillhub-local/`


### PR DESCRIPTION
﻿## Why

MCP and SkillHub already have examples, but they were missing the same documentation shape used by other agent-runtime features: an L2 design document plus an `agent-runtime` guide. Reviewers and test teams need those two entry points before treating the features as complete.

## What Changed

- Added `architecture/docs/L2/agent-runtime/mcp-runtime-tool-middleware-design.md`.
- Added `agent-runtime/docs/guides/mcp-tools.md`.
- Added `architecture/docs/L2/agent-runtime/skillhub-runtime-middleware-design.md`.
- Added `agent-runtime/docs/guides/skillhub.md`.
- Linked the two new guides from `agent-runtime/docs/guides/README.md`.

## Verification

- `git diff --cached --check` before commit.
