### PR TITLE
fix(agent-runtime): reject requests with mismatched agentId instead of silently routing

### DIFF
--- a/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/A2aAgentExecutor.java
+++ b/agent-runtime/src/main/java/com/huawei/ascend/runtime/engine/a2a/A2aAgentExecutor.java
@@ -142,6 +142,23 @@ public final class A2aAgentExecutor implements AgentExecutor {
         MDC.put(MDC_TASK_ID, taskId != null ? taskId : "");
         MDC.put(MDC_TENANT_ID, metadata(ctx, TENANT_STATE_KEY, "default"));
         MDC.put(MDC_AGENT_ID, agentId != null ? agentId : "");
+
+        // Reject when the caller explicitly names an agent that does not match
+        // this handler.  Without this check an unknown agentId silently routes
+        // to the default handler, which can mask protocol-level misconfiguration.
+        // The fallback in toExecutionContext(…) still uses the handler's own id
+        // when the caller omits the field entirely — this check only fires when
+        // the caller supplies a value that disagrees.
+        String callingAgentId = metadata(ctx, "agentId", agentId);
+        if (!agentId.equals(callingAgentId)) {
+            LOG.warn("[A2A] agentId mismatch caller={} handler={} taskId={}",
+                    callingAgentId, agentId, taskId);
+            emitter.reject(failureMessage(emitter, "AGENT_NOT_FOUND",
+                    "agent '" + callingAgentId + "' not found; only '" + agentId + "' is available", false));
+            LOG.info("[A2A] task state=REJECTED taskId={}", taskId);
+            return;
+        }
+
         // Per-task local state (this bean is a shared singleton - never hoist to a field).
         // A continuation leg (task parked on remote INPUT_REQUIRED) re-enters execute with
         // artifacts the first leg already flushed; the SDK replaces an existing artifact on

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/a2a/A2aAgentExecutorTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/a2a/A2aAgentExecutorTest.java
@@ -67,6 +67,58 @@ class A2aAgentExecutorTest {
         assertThat(failureText(emitter)).startsWith("INVALID_INPUT:");
     }
 
+    /** An explicit agentId that does not match the handler must REJECT, not silently route. */
+    @Test
+    void mismatchedAgentIdRejectsTask() {
+        AgentRuntimeHandler handler = mock(AgentRuntimeHandler.class);
+        when(handler.agentId()).thenReturn("agent-x");
+        RequestContext ctx = requestContext();
+        when(ctx.getMetadata()).thenReturn(Map.of("agentId", "agent-unknown"));
+
+        AgentEmitter emitter = newEmitter();
+        new A2aAgentExecutor(handler).execute(ctx, emitter);
+
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(emitter).reject(captor.capture());
+        String text = captor.getValue().parts().stream()
+                .filter(TextPart.class::isInstance)
+                .map(p -> ((TextPart) p).text())
+                .reduce("", String::concat);
+        assertThat(text).contains("AGENT_NOT_FOUND");
+        assertThat(text).contains("agent-unknown");
+        verify(handler, org.mockito.Mockito.never()).execute(any());
+    }
+
+    /** When the caller omits agentId entirely the handler's own id is used, no rejection. */
+    @Test
+    void absentAgentIdExecutesNormally() {
+        AgentRuntimeHandler handler = mock(AgentRuntimeHandler.class);
+        when(handler.agentId()).thenReturn("agent-x");
+        when(handler.execute(any())).thenAnswer(inv -> Stream.of(new Object()));
+        StreamAdapter adapter = raw -> raw.map(o -> AgentExecutionResult.completed("ok"));
+        when(handler.resultAdapter()).thenReturn(adapter);
+        RequestContext ctx = requestContext();
+        when(ctx.getMetadata()).thenReturn(Map.of("userId", "user-a"));
+
+        new A2aAgentExecutor(handler).execute(ctx, newEmitter());
+
+        verify(handler).execute(any());
+    }
+
+    /** A caller-supplied agentId that matches the handler must execute normally. */
+    @Test
+    void matchingAgentIdExecutesNormally() {
+        AgentRuntimeHandler handler = mock(AgentRuntimeHandler.class);
+        when(handler.agentId()).thenReturn("agent-x");
+        when(handler.execute(any())).thenAnswer(inv -> Stream.of(new Object()));
+        StreamAdapter adapter = raw -> raw.map(o -> AgentExecutionResult.completed("ok"));
+        when(handler.resultAdapter()).thenReturn(adapter);
+
+        new A2aAgentExecutor(handler).execute(requestContext(), newEmitter());
+
+        verify(handler).execute(any());
+    }
+
     /**
      * The framework conversation key is derived from tenant + agent + A2A contextId
      * when the caller does not pass an explicit agentStateKey.


### PR DESCRIPTION
## Summary

When a caller supplies an agentId (via `message.metadata.agentId` or `X-Agent-Id` header) that does not match the registered handler, the executor now **REJECTs** the task with `AGENT_NOT_FOUND`. Previously the unknown agentId was silently routed to the default handler, masking protocol-level misconfiguration.

## Root Cause

`A2aAgentExecutor.execute()` unconditionally accepted any caller-supplied agentId and passed it through to `RuntimeIdentity` without validation against `handler.agentId()`.

## Fix

Added a 15-line check in `A2aAgentExecutor.execute()` (after MDC setup, before task submission):

```java
String callingAgentId = metadata(ctx, "agentId", agentId);
if (!agentId.equals(callingAgentId)) {
    LOG.warn("[A2A] agentId mismatch caller={} handler={} taskId={}",
            callingAgentId, agentId, taskId);
    emitter.reject(failureMessage(emitter, "AGENT_NOT_FOUND",
            "agent '" + callingAgentId + "' not found; only '" + agentId + "' is available", false));
    LOG.info("[A2A] task state=REJECTED taskId={}", taskId);
    return;
}
```

- Only fires when caller explicitly provides a **non-matching** agentId
- When agentId is omitted, existing fallback uses `handler.agentId()` — backward compatible
- Uses `reject()` (not `fail()`) to signal caller configuration error

## Tests

3 new unit tests in `A2aAgentExecutorTest`:
- `mismatchedAgentIdRejectsTask` — unknown agentId → REJECT with AGENT_NOT_FOUND
- `absentAgentIdExecutesNormally` — missing agentId → executes normally
- `matchingAgentIdExecutesNormally` — correct agentId → executes normally

Full suite passes with zero regressions.

## Evidence

| Source | Detail |
|--------|--------|
| Black-box test | TC-106 (metadata.agentId="nonexistent...") confirmed silent routing |
| Black-box test | TC-107 (X-Agent-Id header) confirmed same gap |
| Fault library | F-REQ-011: "引用不存在的关联资源 → 应返回错误" |
| Spec | 需求文档: "agentId 全生命周期不变，与 A2A 路由键一致" |

## Files Changed

| File | + | - |
|------|---|---|
| `agent-runtime/.../A2aAgentExecutor.java` | +17 | 0 |
| `agent-runtime/.../A2aAgentExecutorTest.java` | +52 | 0 |

Co-Authored-By: AutoTestFlow <autotestflow@example.com>
