### PR TITLE
examples/deep-research: drop MCP workarounds from search-agent

### DIFF
--- a/examples/deep-research/agent-search-a2a/src/main/java/com/huawei/ascend/examples/deepresearch/search/a2a/SearchAgentConfiguration.java
+++ b/examples/deep-research/agent-search-a2a/src/main/java/com/huawei/ascend/examples/deepresearch/search/a2a/SearchAgentConfiguration.java
@@ -1,14 +1,9 @@
 package com.huawei.ascend.examples.deepresearch.search.a2a;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.huawei.ascend.runtime.engine.mcp.HttpMcpProvider;
-import com.huawei.ascend.runtime.engine.mcp.McpProperties;
 import com.huawei.ascend.runtime.engine.spi.AgentRuntimeHandler;
-import com.huawei.ascend.runtime.engine.spi.McpProvider;
 import com.huawei.ascend.runtime.engine.spi.SkillHubProvider;
 import java.nio.file.Path;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,20 +19,8 @@ import org.springframework.context.annotation.Configuration;
  * {@code @ConditionalOnBean(SkillHubProvider.class)}). All directories under
  * {@code search-agent.skillhub.root} containing a {@code SKILL.md} file are
  * exposed as skills and installed into the ReActAgent on every execution.
- *
- * <p>An {@link McpProvider} bean is declared explicitly here as a workaround
- * for a Spring ordering bug in agent-runtime's {@code McpAutoConfiguration}:
- * its nested {@code OpenJiuwenMcpToolConfiguration} declares
- * {@code @ConditionalOnBean(McpProvider.class)} against the sibling
- * {@code @Bean httpMcpProvider} method in the same outer class, but
- * {@code @ConditionalOnBean} is evaluated at parse time before the outer
- * class's {@code @Bean} methods register, so the nested config never sees
- * the provider and the MCP tool installer is never attached. Filed upstream;
- * remove this bean once {@code OpenJiuwenMcpToolConfiguration} is hoisted
- * into its own auto-configuration ordered after {@code McpAutoConfiguration}.
  */
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(McpProperties.class)
 public class SearchAgentConfiguration {
 
     @Bean
@@ -54,24 +37,5 @@ public class SearchAgentConfiguration {
     SkillHubProvider searchAgentSkillHubProvider(
             @Value("${search-agent.skillhub.root:skills}") String skillRoot) {
         return new LocalDirectorySkillHubProvider(Path.of(skillRoot));
-    }
-
-    /**
-     * Workaround for agent-runtime's MCP auto-config requiring a Jackson 2
-     * {@code com.fasterxml.jackson.databind.ObjectMapper} bean. Spring Boot 4
-     * only auto-publishes the Jackson 3 ({@code tools.jackson.databind})
-     * ObjectMapper, so {@link com.huawei.ascend.runtime.engine.mcp.McpAutoConfiguration}
-     * fails to start with "No qualifying bean of type 'ObjectMapper'". Filed as
-     * an upstream issue; remove this bean once agent-runtime migrates to
-     * Jackson 3 or its MCP auto-config gates on the legacy ObjectMapper bean.
-     */
-    @Bean
-    ObjectMapper mcpJackson2ObjectMapper() {
-        return new ObjectMapper();
-    }
-
-    @Bean
-    McpProvider httpMcpProvider(McpProperties properties, ObjectMapper mcpJackson2ObjectMapper) {
-        return new HttpMcpProvider(properties, mcpJackson2ObjectMapper);
     }
 }


### PR DESCRIPTION
## Summary
- Removes the two MCP workarounds (`mcpJackson2ObjectMapper`, explicit `httpMcpProvider`) and the related `@EnableConfigurationProperties(McpProperties.class)` from `SearchAgentConfiguration` in `examples/deep-research/agent-search-a2a`.
- The example now relies on agent-runtime's auto-config — Jackson 2 ObjectMapper fallback + the hoisted top-level `OpenJiuwenMcpToolAutoConfiguration` — both shipped in #367.

## Why now
Without this change the example still injects its own `ObjectMapper` and `McpProvider` beans, so `@ConditionalOnMissingBean` in `McpAutoConfiguration` yields to the example. The framework's repaired auto-config path is never exercised, defeating the purpose of #367 for this demo.

## Test plan
- [x] Built `agent-runtime` (rc1 + #367) into local m2; packaged `examples/deep-research/mcp-server` and `examples/deep-research/agent-search-a2a` against it.
- [x] Deployed both fat jars to a Linux server and issued an A2A request.
- [x] Confirmed framework auto-config kicks in:
  - `OpenJiuwenMcpToolAutoConfiguration - installed MCP tool installer into openjiuwen handler agentId=search-agent`
- [x] Confirmed end-to-end MCP tool discovery + invocation:
  - `OpenJiuwenMcpToolInstaller - installed MCP tool into openjiuwen agent=search-agent serverId=deep-research-mcp toolName=fetch_url`
  - Two `tools/call` requests observed in `mcp-server.log` (id=3, id=4) — LLM actually invoked the tool.
