### PR TITLE
examples/deep-research: make Tavily endpoint env-injectable

### DIFF
--- a/examples/deep-research/agent-search/src/main/java/com/huawei/ascend/examples/deepresearch/search/TavilyWebSearchProvider.java
+++ b/examples/deep-research/agent-search/src/main/java/com/huawei/ascend/examples/deepresearch/search/TavilyWebSearchProvider.java
@@ -37,6 +37,10 @@ public final class TavilyWebSearchProvider implements WebSearchProvider {
         this(apiKey, DEFAULT_ENDPOINT, defaultHttpClient());
     }
 
+    public TavilyWebSearchProvider(String apiKey, String endpoint) {
+        this(apiKey, endpoint, defaultHttpClient());
+    }
+
     TavilyWebSearchProvider(String apiKey, String endpoint, HttpClient httpClient) {
         this.apiKey = Objects.requireNonNull(apiKey, "apiKey");
         this.endpoint = URI.create(endpoint);

--- a/examples/deep-research/agent-search/src/main/java/com/huawei/ascend/examples/deepresearch/search/WebSearchTool.java
+++ b/examples/deep-research/agent-search/src/main/java/com/huawei/ascend/examples/deepresearch/search/WebSearchTool.java
@@ -24,6 +24,7 @@ import java.util.Map;
 public final class WebSearchTool {
 
     private static final String API_KEY_ENV = "TAVILY_API_KEY";
+    private static final String API_URL_ENV = "TAVILY_API_URL";
 
     private static volatile WebSearchProvider provider;
 
@@ -64,7 +65,11 @@ public final class WebSearchTool {
                 if (key == null || key.isBlank()) {
                     throw new IllegalStateException(API_KEY_ENV + " env var is required for prod search-agent");
                 }
-                provider = new TavilyWebSearchProvider(key);
+                String endpoint = System.getenv(API_URL_ENV);
+                if (endpoint == null || endpoint.isBlank()) {
+                    endpoint = TavilyWebSearchProvider.DEFAULT_ENDPOINT;
+                }
+                provider = new TavilyWebSearchProvider(key, endpoint);
             }
             return provider;
         }

--- a/examples/deep-research/agent-search/src/main/resources/agent/agent.prod.yaml
+++ b/examples/deep-research/agent-search/src/main/resources/agent/agent.prod.yaml
@@ -72,6 +72,8 @@ tools:
       Search the public web via Tavily, apply vendor-official-host reranking,
       and return the contract-shaped result list. Tavily API key is read
       from the TAVILY_API_KEY env var on first call (process-level cache).
+      The Tavily endpoint defaults to https://api.tavily.com/search; override
+      with TAVILY_API_URL when calling a proxied or regional endpoint.
     inputSchema:
       type: object
       properties:


### PR DESCRIPTION
## Summary
- Adds a `TAVILY_API_URL` env var override so deployments behind a regional or proxied Tavily endpoint no longer need to rebuild the jar to change the URL.
- Falls back to the existing `https://api.tavily.com/search` default when the env var is unset, so current deployments are unaffected.

## Changes
- `TavilyWebSearchProvider`: add public `(apiKey, endpoint)` constructor that reuses `defaultHttpClient()`.
- `WebSearchTool.provider()`: read `TAVILY_API_URL` when initialising the provider; fall back to `TavilyWebSearchProvider.DEFAULT_ENDPOINT` when unset/blank.
- `agent.prod.yaml`: document the new override knob alongside `TAVILY_API_KEY` in the `web_search` tool description.

## Test plan
- [x] `./mvnw test -f examples/deep-research/pom.xml -pl agent-search` — green.
- [ ] Deploy with `TAVILY_API_URL` set to a proxied endpoint and confirm Tavily traffic hits the override.
- [ ] Deploy without `TAVILY_API_URL` and confirm default endpoint still works (backward compat).
