### PR TITLE
fix: make skillhub examples register native skills

### DIFF
--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/boot/RuntimeSkillHubAutoConfigurationTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/boot/RuntimeSkillHubAutoConfigurationTest.java
@@ -56,7 +56,8 @@ class RuntimeSkillHubAutoConfigurationTest {
     void skillHubProviderWiresInstallerIntoDeepAgentHandlers(@TempDir Path tempDir) throws IOException {
         Path skillDir = tempDir.resolve("hotel");
         Files.createDirectories(skillDir);
-        Files.writeString(skillDir.resolve("SKILL.md"), "---\ndescription: Hotel booking memory\n---\n# Hotel");
+        Files.writeString(skillDir.resolve("SKILL.md"),
+                "---\nname: hotel\ndescription: Hotel booking memory\n---\n# Hotel");
 
         contextRunner
                 .withBean("skillPath", String.class, skillDir::toString)

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenDeepAgentRuntimeHandlerTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenDeepAgentRuntimeHandlerTest.java
@@ -125,7 +125,8 @@ class OpenJiuwenDeepAgentRuntimeHandlerTest {
         TestDeepAgentHandler handler = new SkillRuntimeDeepAgentHandler();
         Path skillDir = tempDir.resolve("hotel");
         Files.createDirectories(skillDir);
-        Files.writeString(skillDir.resolve("SKILL.md"), "---\ndescription: Hotel booking memory\n---\n# Hotel");
+        Files.writeString(skillDir.resolve("SKILL.md"),
+                "---\nname: hotel\ndescription: Hotel booking memory\n---\n# Hotel");
         handler.setSkillHubInstaller(new OpenJiuwenSkillHubInstaller(new FakeSkillHubProvider(skillDir)));
 
         handler.execute(context()).toList();

--- a/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenSkillHubInstallerTest.java
+++ b/agent-runtime/src/test/java/com/huawei/ascend/runtime/engine/openjiuwen/OpenJiuwenSkillHubInstallerTest.java
@@ -57,7 +57,8 @@ class OpenJiuwenSkillHubInstallerTest {
         DeepAgent agent = deepAgent("deep-skillhub-installer-test");
         Path skillDir = tempDir.resolve("hotel");
         Files.createDirectories(skillDir);
-        Files.writeString(skillDir.resolve("SKILL.md"), "---\ndescription: Hotel booking memory\n---\n# Hotel");
+        Files.writeString(skillDir.resolve("SKILL.md"),
+                "---\nname: hotel\ndescription: Hotel booking memory\n---\n# Hotel");
         SkillHubProvider provider = new FakeSkillHubProvider(List.of(
                 new SkillDefinition(
                         "hotel",
@@ -80,7 +81,8 @@ class OpenJiuwenSkillHubInstallerTest {
         configureInnerSkillRuntime(agent);
         Path skillDir = tempDir.resolve("hotel");
         Files.createDirectories(skillDir);
-        Files.writeString(skillDir.resolve("SKILL.md"), "---\ndescription: Hotel booking memory\n---\n# Hotel");
+        Files.writeString(skillDir.resolve("SKILL.md"),
+                "---\nname: hotel\ndescription: Hotel booking memory\n---\n# Hotel");
         SkillHubProvider provider = new FakeSkillHubProvider(List.of(
                 new SkillDefinition(
                         "hotel",
@@ -134,6 +136,7 @@ class OpenJiuwenSkillHubInstallerTest {
         Files.writeString(skillDir.resolve("SKILL.md"),
                 """
                 ---
+                name: date-helper
                 description: Date helper skill.
                 ---
 

--- a/examples/agent-runtime-middleware-skillhub-local/skills/date-helper/SKILL.md
+++ b/examples/agent-runtime-middleware-skillhub-local/skills/date-helper/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: date-helper
+description: Date helper skill for date, calendar, and deadline wording.
+---
+
 # Date Helper
 
 Use this skill when the user asks for date, calendar, or deadline wording.

--- a/examples/agent-runtime-middleware-skillhub-local/src/main/java/com/huawei/ascend/examples/runtime/middleware/skillhub/local/SkillHubLocalApplication.java
+++ b/examples/agent-runtime-middleware-skillhub-local/src/main/java/com/huawei/ascend/examples/runtime/middleware/skillhub/local/SkillHubLocalApplication.java
@@ -165,7 +165,8 @@ final class LocalDirectorySkillHubProvider implements SkillHubProvider {
             throw new IllegalArgumentException("Unknown skill: " + skillId);
         }
         try {
-            String instructions = Files.readString(skillFile, StandardCharsets.UTF_8);
+            String skillFileContent = Files.readString(skillFile, StandardCharsets.UTF_8);
+            String instructions = stripYamlFrontmatter(skillFileContent);
             return new SkillDefinition(
                     skillId,
                     title(instructions, skillId),
@@ -202,7 +203,8 @@ final class LocalDirectorySkillHubProvider implements SkillHubProvider {
     private SkillSummary toSummary(Path skillDir) {
         String skillId = skillDir.getFileName().toString();
         try {
-            String instructions = Files.readString(skillDir.resolve(SKILL_FILE), StandardCharsets.UTF_8);
+            String instructions = stripYamlFrontmatter(
+                    Files.readString(skillDir.resolve(SKILL_FILE), StandardCharsets.UTF_8));
             return new SkillSummary(
                     skillId,
                     title(instructions, skillId),
@@ -256,6 +258,24 @@ final class LocalDirectorySkillHubProvider implements SkillHubProvider {
                 .filter(line -> !line.startsWith("#"))
                 .findFirst()
                 .orElse("");
+    }
+
+    private static String stripYamlFrontmatter(String markdown) {
+        if (markdown == null || !markdown.startsWith("---")) {
+            return markdown == null ? "" : markdown;
+        }
+        int frontmatterEnd = markdown.indexOf("\n---", 3);
+        if (frontmatterEnd < 0) {
+            return markdown;
+        }
+        int bodyStart = frontmatterEnd + "\n---".length();
+        if (bodyStart < markdown.length() && markdown.charAt(bodyStart) == '\r') {
+            bodyStart++;
+        }
+        if (bodyStart < markdown.length() && markdown.charAt(bodyStart) == '\n') {
+            bodyStart++;
+        }
+        return markdown.substring(bodyStart);
     }
 }
 

--- a/examples/agent-runtime-middleware-skillhub-local/src/test/java/com/huawei/ascend/examples/runtime/middleware/skillhub/local/LocalDirectorySkillHubProviderTest.java
+++ b/examples/agent-runtime-middleware-skillhub-local/src/test/java/com/huawei/ascend/examples/runtime/middleware/skillhub/local/LocalDirectorySkillHubProviderTest.java
@@ -23,6 +23,11 @@ class LocalDirectorySkillHubProviderTest {
         Path skillDir = tempDir.resolve("date-helper");
         Files.createDirectories(skillDir);
         Files.writeString(skillDir.resolve("SKILL.md"), """
+                ---
+                name: date-helper
+                description: Date helper skill.
+                ---
+
                 # Date Helper
 
                 Answer date questions with the provided business calendar rules.
@@ -43,6 +48,7 @@ class LocalDirectorySkillHubProviderTest {
                     assertThat(summary.description()).contains("date questions");
                 });
         assertThat(definition.instructions()).contains("Date Helper");
+        assertThat(definition.instructions()).doesNotContain("---");
         assertThat(definition.metadata()).containsKey("openjiuwen.skill.path");
         assertThat(skillPackage.mediaType()).isEqualTo("application/zip");
         assertThat(zipEntryNames(skillPackage.content())).contains("SKILL.md");

--- a/examples/agent-runtime-middleware-skillhub-remote-json/skills/date-helper/SKILL.md
+++ b/examples/agent-runtime-middleware-skillhub-remote-json/skills/date-helper/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: date-helper
+description: Date helper skill for date, calendar, and deadline wording.
+---
+
 # Date Helper
 
 Use this skill when the user asks for date, calendar, or deadline wording.

--- a/examples/agent-runtime-middleware-skillhub-remote-json/skills/travel-note/SKILL.md
+++ b/examples/agent-runtime-middleware-skillhub-remote-json/skills/travel-note/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: travel-note
+description: Travel note skill for summarizing travel constraints.
+---
+
 # Travel Note
 
 Use this skill when the user asks to turn travel constraints into a concise plan.

--- a/examples/agent-runtime-middleware-skillhub-remote-json/src/main/java/com/huawei/ascend/examples/runtime/middleware/skillhub/remotejson/SkillHubRemoteJsonApplication.java
+++ b/examples/agent-runtime-middleware-skillhub-remote-json/src/main/java/com/huawei/ascend/examples/runtime/middleware/skillhub/remotejson/SkillHubRemoteJsonApplication.java
@@ -211,7 +211,7 @@ final class JsonCatalogSkillHubProvider implements SkillHubProvider {
         }
         Path skillFile = skillDir.resolve(SKILL_FILE);
         try {
-            String instructions = Files.readString(skillFile, StandardCharsets.UTF_8);
+            String instructions = SkillMarkdown.stripYamlFrontmatter(Files.readString(skillFile, StandardCharsets.UTF_8));
             return new SkillDefinition(entry.skillId(), entry.name(), entry.description(), instructions,
                     List.of(skillFile.toString()), entry.toolDependencies(),
                     mergeMetadata(entry.metadata(), Map.of(
@@ -365,6 +365,29 @@ final class HttpSkillHubProvider implements SkillHubProvider {
             throw new IllegalArgumentException("baseUrl must not be blank");
         }
         return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+}
+
+final class SkillMarkdown {
+    private SkillMarkdown() {
+    }
+
+    static String stripYamlFrontmatter(String markdown) {
+        if (markdown == null || !markdown.startsWith("---")) {
+            return markdown == null ? "" : markdown;
+        }
+        int frontmatterEnd = markdown.indexOf("\n---", 3);
+        if (frontmatterEnd < 0) {
+            return markdown;
+        }
+        int bodyStart = frontmatterEnd + "\n---".length();
+        if (bodyStart < markdown.length() && markdown.charAt(bodyStart) == '\r') {
+            bodyStart++;
+        }
+        if (bodyStart < markdown.length() && markdown.charAt(bodyStart) == '\n') {
+            bodyStart++;
+        }
+        return markdown.substring(bodyStart);
     }
 }
 

--- a/examples/agent-runtime-middleware-skillhub-remote-json/src/test/java/com/huawei/ascend/examples/runtime/middleware/skillhub/remotejson/RemoteJsonSkillHubProviderTest.java
+++ b/examples/agent-runtime-middleware-skillhub-remote-json/src/test/java/com/huawei/ascend/examples/runtime/middleware/skillhub/remotejson/RemoteJsonSkillHubProviderTest.java
@@ -37,6 +37,11 @@ class RemoteJsonSkillHubProviderTest {
         Path skillsRoot = tempDir.resolve("skills");
         Files.createDirectories(skillsRoot.resolve("date-helper"));
         Files.writeString(skillsRoot.resolve("date-helper").resolve("SKILL.md"), """
+                ---
+                name: date-helper
+                description: Date helper skill.
+                ---
+
                 # Date Helper
 
                 Answer date questions.
@@ -55,6 +60,7 @@ class RemoteJsonSkillHubProviderTest {
             assertThat(summary.description()).isEqualTo("Date skill");
         });
         assertThat(definition.instructions()).contains("Date Helper");
+        assertThat(definition.instructions()).doesNotContain("---");
         assertThat(provider.loadSkillPackage(context(), "date-helper").content()).isNotEmpty();
     }
 

--- a/examples/deep-research/agent-search-a2a/skills/web-search-sop/SKILL.md
+++ b/examples/deep-research/agent-search-a2a/skills/web-search-sop/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: web-search-sop
+description: Web search SOP for official-source focused deep research queries.
+---
+
 # Web Search SOP
 
 Skill for the deep-research search sub-agent: how to issue web_search queries that maximise official-source hit-rate while keeping the call count to one.

--- a/examples/deep-research/agent-search-a2a/src/main/java/com/huawei/ascend/examples/deepresearch/search/a2a/LocalDirectorySkillHubProvider.java
+++ b/examples/deep-research/agent-search-a2a/src/main/java/com/huawei/ascend/examples/deepresearch/search/a2a/LocalDirectorySkillHubProvider.java
@@ -59,7 +59,7 @@ final class LocalDirectorySkillHubProvider implements SkillHubProvider {
             throw new IllegalArgumentException("Unknown skill: " + skillId);
         }
         try {
-            String instructions = Files.readString(skillFile, StandardCharsets.UTF_8);
+            String instructions = stripYamlFrontmatter(Files.readString(skillFile, StandardCharsets.UTF_8));
             return new SkillDefinition(
                     skillId,
                     title(instructions, skillId),
@@ -86,7 +86,8 @@ final class LocalDirectorySkillHubProvider implements SkillHubProvider {
     private SkillSummary toSummary(Path skillDir) {
         String skillId = skillDir.getFileName().toString();
         try {
-            String instructions = Files.readString(skillDir.resolve(SKILL_FILE), StandardCharsets.UTF_8);
+            String instructions = stripYamlFrontmatter(
+                    Files.readString(skillDir.resolve(SKILL_FILE), StandardCharsets.UTF_8));
             return new SkillSummary(
                     skillId,
                     title(instructions, skillId),
@@ -126,5 +127,23 @@ final class LocalDirectorySkillHubProvider implements SkillHubProvider {
                 .filter(line -> !line.startsWith("#"))
                 .findFirst()
                 .orElse("");
+    }
+
+    private static String stripYamlFrontmatter(String markdown) {
+        if (markdown == null || !markdown.startsWith("---")) {
+            return markdown == null ? "" : markdown;
+        }
+        int frontmatterEnd = markdown.indexOf("\n---", 3);
+        if (frontmatterEnd < 0) {
+            return markdown;
+        }
+        int bodyStart = frontmatterEnd + "\n---".length();
+        if (bodyStart < markdown.length() && markdown.charAt(bodyStart) == '\r') {
+            bodyStart++;
+        }
+        if (bodyStart < markdown.length() && markdown.charAt(bodyStart) == '\n') {
+            bodyStart++;
+        }
+        return markdown.substring(bodyStart);
     }
 }


### PR DESCRIPTION
﻿## Why

SkillHub examples currently expose `SKILL.md` files that can be loaded by the runtime provider, but OpenJiuwen native skill registration expects YAML frontmatter with a description. Without that metadata, examples may appear to install SkillHub instructions through the runtime fallback while the native OpenJiuwen skill registry still receives no usable skill.

Refs #363

## What Changed

- Added `name` and `description` YAML frontmatter to the local, remote-json, and deep-research sample `SKILL.md` files.
- Updated local and remote-json SkillHub providers to strip YAML frontmatter before deriving runtime skill instructions, so model-facing instructions stay focused on the Markdown body.
- Updated SkillHub provider and OpenJiuwen adapter tests so temporary `SKILL.md` fixtures also use the `name + description` frontmatter convention.

## Verification

```text
./mvnw -pl agent-runtime "-Dtest=OpenJiuwenSkillHubInstallerTest,OpenJiuwenDeepAgentRuntimeHandlerTest,RuntimeSkillHubAutoConfigurationTest" verify
./mvnw -f examples/agent-runtime-middleware-skillhub-local/pom.xml verify
./mvnw -f examples/agent-runtime-middleware-skillhub-remote-json/pom.xml verify
./mvnw -f examples/deep-research/pom.xml -pl agent-search-a2a -am verify
git diff --check
```

Manual local SkillHub E2E with DeepSeek also confirmed `installed=1 injected=1` and OpenJiuwen `readFile` could read the registered `SKILL.md` path.
