### PR TITLE
docs(l2): 添加 Feat-015 注册发现中心意图识别特性文档

### DIFF
--- a/architecture/L2-Low-Level-Design/agent-bus/Feat-Func-015-agent-card-registration-and-discovery.md
+++ b/architecture/L2-Low-Level-Design/agent-bus/Feat-Func-015-agent-card-registration-and-discovery.md
@@ -1,0 +1,684 @@
+---
+level: L2
+module: agent-bus
+feature: Feat-Func-015
+feature_name: Agent Card 注册与发现
+status: draft
+updated: 2026-07-14
+authority:
+  - ../../../version-scope/Feat-015-agent-card-registration-and-discovery.md
+  - ../L0-Top-Level-Design/boundaries.md
+  - ../L1-High-Level-Design/agent-bus/logical.md
+  - ../L1-High-Level-Design/agent-bus/process.md
+  - ./registry-discovery-runtime-design.cn.md
+implementation_ref:
+  - /home/zhongyiwei/git/agent-solution/common/agent-rdc
+covers_contract: ICD-Agent-Registry-Discovery
+---
+
+# Agent Card 注册与发现 — L2 低层设计
+
+> 本文档把 `version-scope/Feat-015-agent-card-registration-and-discovery.md` 的框架级能力要求落地为 `agent-bus` registry-discovery-center 单元的低层设计。MVP 实现基线参考 `agent-solution/common/agent-rdc`（下文简称 **agent-rdc**），运行态技术基线见 [registry-discovery-runtime-design.cn.md](./registry-discovery-runtime-design.cn.md)。本文不重复该文档已固化的 SQL / 心跳 / RLS 细节，只聚焦 Feat-015 特性视角下的字段映射、接口契约、查询语义、失败码与阶段边界。
+
+## 1. 概述
+
+### 1.1 特性定位
+
+- **是什么**：`agent-bus` registry-discovery-center 单元对外提供框架级 Agent Card 注册与发现能力。下游 AgentLoop / workflow / 异构 Agent / adapter 通过 Agent Card 声明身份、能力、调用契约、治理属性与可发现元数据；注册中心负责接收注册并按租户、agent / service / capability 维度查询可执行能力集合，可选 `contractVersion` 强制过滤。
+- **解决什么**：before——下游能力没有统一注册入口，调用方只能硬编码目标地址或私有能力目录；after——所有可执行能力经统一 Agent Card 注册后可被按多维度查询，并返回 opaque `route_handle` 供转发层寻址，调用方不接触物理地址。
+- **适用场景**：框架级能力目录建设、意图识别场景下的动态能力匹配（作为基础能力的一个使用场景，自由文本 / 语义检索属阶段一）、异构 Agent 框架统一接入。
+
+### 1.2 核心设计原则
+
+| 原则 | 理由 |
+|------|------|
+| **注册中心只拥有 runtime route index / discovery view，不拥有 agent 业务定义、不写 Task 状态** | L0 边界约束（HD3-001）；避免 registry 成为业务事实源。 |
+| **Agent Card 是注册中心的视图，不是 A2A 标准 AgentCard 的复制品** | A2A `/.well-known/agent-card.json` 是 runtime 对外卡片；registry card 增补路由 / 契约 / 治理字段，两者字段重叠但不等价。参考实现已用 `AgentRegistryEntry` vs `a2aAgentCard` 字段分离体现这一原则。 |
+| **`route_handle` opaque，物理地址只对转发层可见** | HD3-006；让 route handle 编码格式可演进（`v2:` 6 字段）而不破坏跨模块消费者。 |
+| **租户强制、禁止跨 tenant fallback** | HD3-003；RLS 作为防御深度，应用层 `WHERE tenant_id` 为主路径。 |
+| **两阶段演进：MVP 纯 PostgreSQL + SQL 过滤排序 → 生产引入 大模型语义检索** | MVP 阶段已跑通 agent / service / capability 三维精确查询 + contractVersion 过滤；阶段一引入 大模型语义检索，迁移对 Agent 服务侧零改动、对上层 Orchestrator 零改动。 |
+
+### 1.3 子特性全景
+
+| 子特性 | 职责 | 关键抽象 | 状态 |
+|--------|------|---------|------|
+| Agent Card 注册 | 接收、校验、upsert Agent Card | `AgentRegistryEntry`、`POST /api/registry/register`、`InstanceIdCodec` / `ServiceIdCodec` | ✅ MVP |
+| Agent Card 更新与失效 | 重注册 upsert、deregister、DRAINING 保留 | `DELETE /api/registry/deregister/...`、`ON CONFLICT` 保留 DRAINING | ✅ MVP |
+| Agent Card 查询（已知目标 agent 维度） | 按 `tenantId + agentId` 列举可路由实例 | `AgentDiscoveryService#searchInstancesByAgentId` | ✅ MVP |
+| Agent Card 查询（service 维度） | 按 `tenantId + serviceId` 列举同一逻辑服务下所有实例 | `AgentDiscoveryService#searchByServiceId` | ✅ FEAT-016 |
+| Agent Card 查询（capability 维度） | 按 `tenantId + capability` 精确匹配 `capabilities[]` 数组 | `AgentDiscoveryService#searchByCapability` + GIN 索引 | ✅ FEAT-016 |
+| Agent Card 查询（自由文本 / 语义维度） | 按 `description` / `tags` / `domain` / `query_text` / 执行约束查询 | （scope §3-§4） | ⬜ 阶段一（大模型语义检索） |
+| 推荐首选与证据 | 返回 `recommended_agent_card` / `score` / `evidence` | （scope §4） | ⬜ 阶段一 |
+| 意图识别动态能力匹配 | `IntentRouteRequest` + `route_query` + `runtime_facts` 驱动查询 | （scope §6） | ⬜ 阶段一 |
+| 健康与版本可用性过滤 | `status` / `contractVersion` 过滤不可调用能力 | discovery SQL `status IN ('ONLINE','DEGRADED','DRAINING')` + 可选 `contractVersion` 强制过滤 | ✅ MVP |
+
+> 状态对齐 [registry-discovery-runtime-design.cn.md](./registry-discovery-runtime-design.cn.md) 两阶段计划：MVP 阶段纯 PG + SQL，已覆盖 agent / service / capability 三维精确查询 + contractVersion 过滤；阶段一引入 大模型语义检索 + 推荐排序。scope §11 已显式将语义检索、学习排序、历史效果反馈列为「开发设计待细化事项」。
+
+## 2. 功能规格
+
+### 2.1 能力清单
+
+| 能力 | 状态 | 说明 |
+|------|------|------|
+| Agent Card 注册（push） | ✅ | `POST /api/registry/register` upsert `AgentRegistryEntry`；必填字段校验 + `instanceId` 服务端派生（host-port）；`serviceId` caller-overridable，缺省由 `ServiceIdCodec` 从 `endpointUrl` host 派生。 |
+| Agent Card 注册（pull） | ✅ | `rdc.pull-registration.enabled=true` 时 `PullRegistrationBootstrap` 拉取 `/.well-known/agent-card.json` 构造 entry upsert；单实例失败跳过，不阻塞启动。 |
+| Agent Card 校验 | ✅ | registry key（`tenantId + agentId`）必填、`frameworkType` 枚举非空、`endpointUrl` 可派生 `instanceId`；缺字段 400 `invalid_request`。`capability_type` / 执行约束校验仍属阶段一（自由文本维度未建索引）。 |
+| Agent Card 更新 / 下线 | ✅ | 重注册 upsert（DRAINING 保留）、`deregister/{tenantId}/{agentId}` 批量删 agent、`deregister/{tenantId}/{agentId}/{serviceId}` 批量删 service、`deregister/{tenantId}/{agentId}/{serviceId}/{instanceId}` 单实例删。 |
+| 租户与调用方边界 | ✅ | `tenantId` 强制；RLS + 应用层 `WHERE tenant_id`；跨 tenant 抛 `TenantIsolationViolationException`。`caller_ref` 调用方维度可见性未实现，见 §8。 |
+| 已知目标查询（agent 维度） | ✅ | `searchInstancesByAgentId(tenantId, agentId, contractVersion) → List<AgentCardDto>`，返回 ONLINE/DEGRADED/DRAINING 实例。 |
+| 已知目标查询（service 维度） | ✅ | `searchByServiceId(tenantId, serviceId, contractVersion) → List<AgentCardDto>`，按逻辑服务标识查询（FEAT-016 新增）。 |
+| 能力维度查询（capability 精确匹配） | ✅ | `searchByCapability(tenantId, capability, contractVersion) → List<AgentCardDto>`，`capabilities @> ARRAY[:capability]` 数组包含查询，GIN 索引加速（FEAT-016 重建）。 |
+| 能力维度查询（自由文本 / 语义） | ⬜ | 按 `description` / `tags` / `domain` / `query_text` / `execution_constraints` 查询——阶段一 大模型语义检索。 |
+| 可用性过滤 | ✅ | discovery SQL `status IN ('ONLINE','DEGRADED','DRAINING')`（DRAINING 作为有限可用状态可见，FEAT-016 反转）；可选 `contractVersion` 非空时 SQL `AND contract_version = :contractVersion` 强制过滤；`capabilityVersion` 在 DTO 中返回，调用方自行判断。 |
+| 推荐首选 + 证据 | ⬜ | `recommended_agent_card` / `score` / `evidence` 阶段一引入。 |
+| opaque route handle | ✅ | `v2:` + base64(JSON{tenantId, agentId, serviceId, instanceId, routeKey, contractVersion}) 6 字段；DTO 不带物理地址。 |
+| 无能力结果 | ✅ | 三维查询返回空 List = `agent_not_found` / `NO_CAPABILITY_MATCH` 语义；`resolveRouteHandle` 找不到 entry 抛 `NoSuchElementException` → 404 `entry_not_found`。 |
+| 可查询扩展元数据 | ⚠️ | `capabilities VARCHAR(64)[]` 列 + GIN 索引已支持精确匹配查询；`a2a_agent_card` JSONB 列存原始 A2A 卡片，但未建立按 `intent_match_metadata` / `tags` / `description` 的查询索引——阶段一大模型语义检索重建。 |
+
+### 2.2 显式排除
+
+| 排除项 | 原因 | 替代 |
+|--------|------|------|
+| Agent 业务定义源 | 属于 agent-runtime / agent-core 职责 | registry 只存路由 / 契约 / 治理字段 + A2A 卡片 JSONB 元数据 |
+| Task execution state | L0 边界——bus 不拥有 Task 生命周期 | 见 L1 logical §4 |
+| 候选发现面向 agent/client | Feat-016 明确：agent/client 只看路由可用性投影，不看候选 | 见 [Feat-Func-016-runtime-instance-route-query.md](./Feat-Func-016-runtime-instance-route-query.md) |
+| 语义检索 / 学习排序 | scope §11 列为后续增强 | 阶段一大模型语义检索 |
+| 自然语言意图库 / 文档召回 | scope §1 显式排除——注册中心返回可执行能力集合，不是知识检索 | 业务侧自建 |
+
+### 2.3 接口契约（Logical View）
+
+#### 2.3.1 SPI 声明
+
+注册中心对外暴露的核心 SPI（agent-rdc `com.openjiuwen.rdc.spi.registry`）：
+
+```java
+/**
+ * agent-bus 拥有的运行时路由索引查询入口（HD3-001）。上层 Orchestrator / Gateway
+ * 仅依赖此接口；对调用方不可见。
+ *
+ * 当前版本覆盖三个查询维度：agent 维度、service 维度、capability 维度，
+ * 均返回 ONLINE/DEGRADED/DRAINING 实例列表（FEAT-016: DRAINING 作为有限可用
+ * 状态可见，调用方自行决定是否路由）。所有查询方法均接受 nullable contractVersion
+ * 过滤参数。推荐首选 / 证据保留属阶段一 SHOULD 目标，尚未在此 SPI 上提供方法。
+ */
+public interface AgentDiscoveryService {
+
+    /**
+     * 列出给定 (tenantId, agentId) 下所有 ONLINE/DEGRADED/DRAINING 运行时实例。
+     * 每个实例携带独立的 opaque routeHandle（编码 instanceId）。
+     *
+     * 状态过滤：返回 ONLINE / DEGRADED / DRAINING；OFFLINE 排除。
+     * 排序：weight DESC, last_heartbeat DESC。
+     *
+     * @param tenantId        registry key 强制维度；与 TenantContext 不一致抛
+     *                        TenantIsolationViolationException
+     * @param agentId         registry key 强制维度
+     * @param contractVersion 可选契约版本过滤；null = 不过滤，非 null = SQL
+     *                        AND contract_version = :contractVersion
+     * @return 不可变列表，无匹配返回空 List（永不 null）
+     */
+    List<AgentCardDto> searchInstancesByAgentId(String tenantId, String agentId, String contractVersion);
+
+    /**
+     * 列出给定 (tenantId, serviceId) 下所有 ONLINE/DEGRADED/DRAINING 运行时实例。
+     * FEAT-016 新增维度——按逻辑服务标识查询同一服务下所有实例。
+     */
+    List<AgentCardDto> searchByServiceId(String tenantId, String serviceId, String contractVersion);
+
+    /**
+     * 列出 capabilities[] 数组包含给定 capability 的所有 ONLINE/DEGRADED/DRAINING 实例。
+     * FEAT-016 新增维度——精确匹配数组包含查询，GIN 索引加速。
+     */
+    List<AgentCardDto> searchByCapability(String tenantId, String capability, String contractVersion);
+
+    /**
+     * 解析 opaque routeHandle 为转发层可用的 RouteResolution。
+     * Orchestrator 业务逻辑永不调用此方法——只有转发层调用（HD3-006）。
+     *
+     * @throws IllegalArgumentException           handle 畸形（含旧 4 字段及 `v1:` 5 字段格式）
+     * @throws TenantIsolationViolationException  tenantId 与 handle 内编码不一致
+     * @throws NoSuchElementException              handle 指向的 entry 不存在
+     */
+    RouteResolution resolveRouteHandle(String routeHandle, String tenantId);
+}
+```
+
+> **阶段一扩展预留**：当 大模型语义检索落地后，本 SPI 将新增自由文本 / 语义查询方法（按 `description` / `tags` / `domain` / `query_text` 检索），返回 `DiscoveryResult`（含 `agent_cards` / `recommended_agent_card` / `score` / `evidence`）。该方法的方法签名、分页、排序规则在阶段一 ADR 中固化，不在本文预先钉死。当前 `searchByCapability` 仅支持精确数组包含查询，不覆盖 scope §4 的 `query_text` 自由文本语义。
+
+#### 2.3.2 数据类型
+
+##### AgentRegistryEntry（注册请求体 / 表行 ORM）
+
+| 字段 | scope §3 对应字段 | 必填 | 含义 / 约束 |
+|------|------------------|------|------------|
+| `tenantId` | `tenant_scope` | 是 | 租户边界；registry key 维度；跨 tenant fallback 禁止。 |
+| `agentId` | `agent_id` | 是 | 下游 Agent 逻辑标识；registry key 维度；多实例可共享同一 `agentId`（FEAT-016 §2 多实例候选 MUST）。 |
+| `serviceId` | `service_id` | caller-overridable | 逻辑服务标识（host only）。FEAT-016 后 setter 为 public——caller 可显式传入覆盖默认派生；caller 未提供时由 `ServiceIdCodec.derive(endpointUrl)` 取 host 小写派生。多实例共享同一 `serviceId`（FEAT-016 §2 "serviceId 是逻辑服务标识，可被多实例共享"）。 |
+| `instanceId` | `instance_id` | 服务端派生 | 从 `endpointUrl` 经 `InstanceIdCodec.derive` 派生（`host-port`）；setter 包级私有，HTTP 调用方不可伪造；区分同一 `serviceId` 下的不同运行时实例（FEAT-016 §2 "具体实例应有独立的运行时实例标识" MUST）。 |
+| `agentName` | `capability_name`（近似） | 是 | 展示名；A2A 卡片的 `name` 字段。 |
+| `frameworkType` | `framework_type` | 是 | 枚举 `JIUWEN` / `AGENTSCOPE` / `VERSATILE` / `PROXY_SERVICE`；替代 scope §3 的 `framework_type` 字符串。 |
+| `routeKey` | （路由索引源） | 是 | 逻辑路由键，封装进 route handle。 |
+| `contractVersion` | `contract_version` | 是 | HD3-005 版本约束。 |
+| `capabilityVersion` | `capability_version` | 是 | 能力版本。 |
+| `endpointUrl` | （路由索引源） | 是 | 逻辑目标；不直接暴露给 discover 调用方，封装进 route handle。 |
+| `maxConcurrency` | （selectionHint） | 否 | 默认 10；NOT NULL 列，缺省由 controller `applyDefaults` 物化。 |
+| `weight` | `priority`（近似） | 否 | 默认 100；NOT NULL 列；排序提示。 |
+| `region` | （selectionHint） | 否 | 部署区域提示。 |
+| `capabilities` | `capability_type`（近似，数组化） | 否 | `List<String>`，FEAT-016 重建为多值数组（替代 REQ-2026-004 移除的标量 `capability` 列）；持久化为 `VARCHAR(64)[]`，GIN 索引加速 `@>` 包含查询；caller 传入直通，无派生。 |
+| `a2aAgentCard` | （扩展元数据） | 否 | A2A 标准 `AgentCard` 对象，序列化为 JSONB 存 `a2a_agent_card` 列。 |
+
+##### scope §3 字段在 MVP + FEAT-016 的覆盖情况
+
+| scope §3 字段 | 覆盖 | 说明 |
+|---------------|---------|------|
+| `tenant_scope` | ✅ `tenantId` | 单租户边界，不支持多租户可见性声明。 |
+| `agent_id` | ✅ | 逻辑 Agent 标识，多实例可共享。 |
+| `service_id` | ✅ | 逻辑服务标识（host only），caller-overridable；多实例共享（FEAT-016 §2 MUST）。 |
+| `instance_id`（FEAT-016 §2 新增 MUST） | ✅ | server-derived `host-port`；区分具体实例。 |
+| `capability_id` | ⬜ | 未实现；FEAT-016 用 `capabilities[]` 数组替代标量 `capability_id`，不区分同一 Agent 的多个能力 ID。 |
+| `capability_name` | ⚠️ `agentName` 近似覆盖 | `agentName` 部分覆盖展示名；无独立能力名。 |
+| `capability_type` | ⚠️ 数组化近似 | FEAT-016 重建为 `capabilities VARCHAR(64)[]`，支持精确匹配查询；但 scope §3 定义的枚举值域（`agent_loop` / `workflow` / `external_agent` / `external_workflow`）未强制约束，caller 可传任意字符串。 |
+| `description` / `intent_match_metadata` / `tags` / `domain` | ⚠️ | A2A 卡片 JSONB 保留原始信息，但未建立查询索引；阶段一大模型语义检索重建。 |
+| `framework_type` | ✅ | 枚举化（替代字符串）。 |
+| `contract_version` / `capability_version` | ✅ | `contractVersion` 支持查询时强制过滤（FEAT-016）。 |
+| `route_handle` | ✅ | 输出字段，由 `RouteHandleCodec` 生成。 |
+| `health_status` | ⚠️ 值域偏离 | scope §3 = `healthy` / `degraded` / `unhealthy`；L2 实现 = `ONLINE` / `DEGRADED` / `DRAINING` / `OFFLINE`。值域不一致，调用方需做映射；见 §8 偏离声明。 |
+| `supports_streaming` / `supports_hitl` / `requires_idempotency_key` | ⬜ | 未实现；阶段一随执行约束查询引入。 |
+| `priority` | ⚠️ 重命名 | scope §3 = `priority`；L2 = `weight`。字段名变更，语义近似。 |
+| `risk_hint` / `cancelable_hint` | ⬜ | 未实现。 |
+| `caller_ref`（scope §4 查询输入） | ⬜ | 未实现；MVP 仅 `tenantId` 边界，无调用方维度可见性。见 §8 偏离声明。 |
+
+##### AgentCardDto（discovery 结果）
+
+| 字段 | 可空 | 含义 |
+|------|------|------|
+| `serviceId` | 否 | 逻辑服务标识（host only），FEAT-016 新增；调用方可按逻辑服务分组实例。 |
+| `routeHandle` | 否 | opaque 路由引用（HD3-006） |
+| `health` | 否 | `status` 字符串（`ONLINE` / `DEGRADED` / `DRAINING`） |
+| `contractVersion` / `capabilityVersion` | 否 | 版本信息 |
+| `weight` / `region` / `maxConcurrency` | 否 | selectionHint，调用方做加权负载均衡 |
+| `agentName` / `frameworkType` | 是 | 业务定义字段，`searchInstancesByAgentId` / `searchByServiceId` / `searchByCapability` 填充 |
+
+##### RouteResolution（转发层专用）
+
+| 字段 | 含义 |
+|------|------|
+| `instanceId` | FEAT-016 新增第一字段；从 route handle 解码（非 DB 读取）；转发层用于寻址同一 `serviceId` 下具体副本；对 agent / client 不可见。 |
+| `endpointUrl` | 物理端点——仅转发层可见 |
+| `routeKey` | 逻辑路由键 |
+| `contractVersion` | 注册时钉定的契约版本 |
+
+#### 2.3.3 行为承诺
+
+- **必须**：注册时校验 `tenantId + agentId` registry key；`serviceId` 为 caller-overridable——caller 显式传入时保留，未传入时由 `ServiceIdCodec.derive(endpointUrl)` 取 host 小写派生；`instanceId` 始终由服务端从 `endpointUrl` 经 `InstanceIdCodec.derive` 派生（`host-port`），`InstanceIdCodec.applyTo` 覆写任何 caller 注入值（setter 包级私有 + Jackson 无法绑定）。
+- **必须**：discovery 返回的 `AgentCardDto` 不携带 `endpointUrl` / `routeKey` / `instanceId` 明文——只有 opaque `routeHandle`；`serviceId` 作为逻辑服务标识在 DTO 中返回（FEAT-016 §5.1.4 系统路由视图可见）。
+- **必须**：route handle 编码为 `v2:` + base64(JSON{tenantId, agentId, serviceId, instanceId, routeKey, contractVersion}) 6 字段；旧 `v1:` 5 字段格式（无 `instanceId`）不兼容，见 §7。
+- **必须**：`resolveRouteHandle` 仅由转发层调用；`RouteHandleCodec` 不离开 `registry.runtime.discovery` 包。
+- **必须**：所有写操作（upsert / delete / updateStatus）在事务内 `set_config('app.tenant_id', :tenantId, true)`，RLS 作为防御深度。
+- **必须**：重注册时若原状态为 `DRAINING`（运维发起的优雅下线），新状态保持 `DRAINING` 而非重置为 `ONLINE`——避免重启把流量重新打到正在下线的实例（PR #389 #7）。
+- **必须**：PK 为 `(tenant_id, agent_id, service_id, instance_id)`——同 `agentId` 多实例通过不同 `instanceId` 区分；同 `serviceId` 多实例通过不同 `instanceId` 区分（FEAT-016 §2 多实例候选 MUST）。
+- **必须**：三维 discovery 查询（`searchInstancesByAgentId` / `searchByServiceId` / `searchByCapability`）均返回 `status IN ('ONLINE','DEGRADED','DRAINING')` 实例——FEAT-016 反转 REQ-2026-006 的 DRAINING 排除策略，DRAINING 作为有限可用状态对调用方可见，调用方自行决定是否路由。OFFLINE 始终排除。
+- **必须**：三维 discovery 查询均接受 nullable `contractVersion` 参数——null 时不过滤，非 null 时 SQL `AND contract_version = :contractVersion` 强制过滤（FEAT-016）。
+- **必须**：`capabilities` 字段 caller 传入直通，无派生 / 无规范化；repository 持久化为 `VARCHAR(64)[]`，空值落库为空数组。
+- **禁止**：跨 tenant 查询、缓存复用、降级或 fallback。
+- **禁止**：向 discover 调用方返回 `endpointUrl` / `routeKey` / `instanceId` 明文。
+- **允许**：MVP 不实现推荐首选、语义检索（SHOULD 项，列为阶段一目标）；`description` / `tags` / `domain` / `query_text` 自由文本查询、执行约束校验、`caller_ref` 调用方可见性属阶段一目标。
+
+## 3. 模块结构（Development View）
+
+### 3.1 包结构
+
+```
+com.openjiuwen.rdc/
+├── AgentRdcApplication.java              # @SpringBootApplication 入口
+├── spi/registry/                         # 纯 Java SPI（ADR-0160 decision 1：无 Spring/JDBC/Jackson）
+│   ├── AgentDiscoveryService.java        # 发现 SPI（searchInstancesByAgentId / searchByServiceId / searchByCapability / resolveRouteHandle）
+│   ├── AgentRegistryEntry.java           # 注册请求体 / 表行 ORM
+│   ├── AgentCardDto.java                 # discovery 结果 DTO
+│   ├── RouteResolution.java              # route handle 解析结果（4 字段 record，转发层专用）
+│   ├── InstanceIdCodec.java              # instanceId 派生（host-port），setter 包级私有
+│   ├── ServiceIdCodec.java               # serviceId 默认派生（host only），caller-overridable
+│   ├── FrameworkType.java                # 枚举：JIUWEN/AGENTSCOPE/VERSATILE/PROXY_SERVICE
+│   ├── TenantContext.java                # 租户上下文接口
+│   ├── TenantIsolationViolationException.java
+│   └── Nullable.java                     # 注解，标记可空字段
+├── registry/runtime/
+│   ├── api/MvpRegistryController.java    # HTTP 入口（Spring Web，8 个端点）
+│   ├── discovery/
+│   │   ├── PgMvpDiscoveryServiceImpl.java # AgentDiscoveryService 实现（@Primary @Service）
+│   │   └── RouteHandleCodec.java          # v2: 6 字段编解码（包内私有）
+│   ├── persistence/jdbc/
+│   │   ├── AgentRegistryRepository.java   # 仓储端口接口
+│   │   └── JdbcAgentRegistryRepository.java # 唯一允许 import java.sql 的类
+│   ├── health/MvpHealthProbeScheduler.java # 5s pull 探活
+│   ├── pull/PullRegistrationBootstrap.java # pull 模式注册（ApplicationReadyEvent）
+│   ├── tenant/ThreadLocalTenantContext.java # 后台调度租户绑定
+│   ├── RegistryRuntimeBeanConfig.java
+│   ├── RegistryObservabilityConfig.java   # 审计 / 指标
+│   └── RegistrySchedulingConfig.java      # 探活线程池隔离
+└── resources/db/migration/
+    ├── V2__create_agent_registry_mvp.sql   # 建表（含 RLS）
+    ├── V3__refactor_agent_registry_mvp_drop_legacy_fields.sql
+    ├── V4__refactor_agent_registry_drop_capability_search_tsv_rename_framework_type.sql
+    ├── V5__multi_instance_service_id_pk.sql # PK → (tenant_id, agent_id, service_id)
+    └── V6__feat_016_service_instance_capability.sql # FEAT-016：service_id(host-port) 重命名为 instance_id；新增 service_id(host only) 列 + backfill；新增 capabilities VARCHAR(64)[] 列 + GIN 索引；PK → (tenant_id, agent_id, service_id, instance_id)；route handle v1→v2
+```
+
+### 3.2 核心类静态关系
+
+```
+«interface»                      «concrete»
+AgentDiscoveryService            PgMvpDiscoveryServiceImpl
+     ▲                                 │ implements (@Primary)
+     │                                 │
+     │ delegates                       │ uses (package-private)
+     │                                 ▼
+     │                          RouteHandleCodec ──encode/decode──► v2: base64 JSON (6 字段)
+     │                                 │
+     │                                 │ delegates
+     │                                 ▼
+«interface»                   «concrete»
+AgentRegistryRepository ───implements──► JdbcAgentRegistryRepository
+                                          │ (only class with java.sql imports)
+                                          ▼
+                                     agent_registry_mvp (PG, RLS, capabilities GIN)
+
+«POJO»          «DTO»            «record»
+AgentRegistryEntry  AgentCardDto     RouteResolution
+   │                  │                  ▲
+   │ InstanceIdCodec  │                  │
+   │ ServiceIdCodec   │                  │
+   └────applyTo──────►│                  │
+                                        │ returned by
+                                        │
+                              AgentDiscoveryService.resolveRouteHandle
+```
+
+## 4. 核心设计（Logical + Process View）
+
+### 4.1 Agent Card 注册（push）
+
+#### 4.1.1 关键处理流程
+
+```
+Agent 服务           MvpRegistryController       ServiceIdCodec  InstanceIdCodec   JdbcAgentRegistryRepository
+   │                       │                          │               │                     │
+   │── POST /register ─────►│                          │               │                     │
+   │   body: AgentRegistryEntry (含可选 serviceId / capabilities)       │                     │
+   │   header: traceparent? │                          │               │                     │
+   │                       │── hasRegistryKey()? ── no ──► 400 invalid_request               │
+   │                       │── applyDefaults (maxConcurrency=10, weight=100)                  │
+   │                       │── serviceId 为空? ── yes ─► ServiceIdCodec.applyTo(card)         │
+   │                       │                              ─► derive host only, lowercase       │
+   │                       │── InstanceIdCodec.applyTo(card) ─► derive host-port from          │
+   │                       │                              endpointUrl, overwrite instanceId     │
+   │                       │                              (包级私有 setter, 覆写任何 caller 注入)│
+   │                       │── capabilities 直通（无派生 / 无规范化）                          │
+   │                       │── serializeA2aCard → JSON                                      │
+   │                       │── repository.upsert(card, a2aJson) ─────────────────────────────►│
+   │                       │                          │               │                     │── BEGIN TX
+   │                       │                          │               │                     │── set_config('app.tenant_id')
+   │                       │                          │               │                     │── INSERT ... ON CONFLICT
+   │                       │                          │               │                     │   (tenant_id,agent_id,service_id,instance_id)
+   │                       │                          │               │                     │   DO UPDATE; preserve DRAINING
+   │                       │                          │               │                     │── COMMIT
+   │                       │── observeRegister (audit/metrics)                              │
+   │◄── 200 OK ────────────│                          │               │                     │
+```
+
+#### 4.1.2 边界条件
+
+| 条件 | 行为 |
+|------|------|
+| body 缺 `tenantId` / `agentId` | 400 `invalid_request`（registry key = tenantId + agentId） |
+| body 缺 `serviceId` | controller 调 `ServiceIdCodec.applyTo` 从 `endpointUrl` host 派生默认值（host only, lowercase） |
+| body 提供 `serviceId` | caller-overridable，controller 保留原值不覆盖 |
+| body 提供 `instanceId` | 忽略——`InstanceIdCodec.applyTo` 覆写为 server-derived host-port（setter 包级私有 + Jackson 无法绑定） |
+| `endpointUrl` 无 host / 畸形 | `InstanceIdCodec.derive` / `ServiceIdCodec.derive` 抛 `IllegalArgumentException` → 400 |
+| `frameworkType` 为 null | 400（`AgentRdcRegistrySpiPurityTest` 断言） |
+| `capabilities` 为 null / 空数组 | repository 持久化为空数组 `{}`（DB 列默认值） |
+| 原 entry 状态为 `DRAINING` | upsert 保留 `DRAINING`，不重置为 `ONLINE` |
+| 原 entry 状态为 `ONLINE`/`DEGRADED`/`OFFLINE` | upsert 重置为 `ONLINE`，刷新 `last_heartbeat` |
+
+### 4.2 Agent Card 注册（pull）
+
+`PullRegistrationBootstrap` 监听 `ApplicationReadyEvent`，串行 HTTP GET 每个 `rdc.pull-registration.runtimes[]` 配置的 runtime 的 `/.well-known/agent-card.json`，构造 `AgentRegistryEntry` 并 upsert。
+
+- **激活**：`rdc.pull-registration.enabled=true`（默认 false）。
+- **失败隔离**：单 runtime 失败记录 WARN 日志并跳过，不阻塞启动。
+- **bootstrap-only**：无定时重拉、无刷新；agent 重启时由 push 重注册或运维重触发。
+- **operator-pinned 字段**：`tenantId` / `agentId` / `frameworkType` / `routeKey` / `contractVersion` / `capabilityVersion` 由配置钉定（A2A AgentCard 无这些字段）；`agentName` 从卡片 `name` 字段提取；`a2aAgentCard` 留 null，原始 JSON 直接作为 `a2aAgentCardJson` 入库（避免 17 字段 record 反序列化）。
+
+### 4.3 Agent Card 更新与失效
+
+| 触发 | 路径 | 行为 |
+|------|------|------|
+| 重注册 | `POST /register` | upsert，DRAINING 保留 |
+| 批量下线 agent | `DELETE /deregister/{tenantId}/{agentId}` | 删除该 agent 下所有 serviceId / instanceId |
+| 批量下线 service | `DELETE /deregister/{tenantId}/{agentId}/{serviceId}` | 删除该逻辑服务下所有实例（多实例一起下线） |
+| 单实例下线 | `DELETE /deregister/{tenantId}/{agentId}/{serviceId}/{instanceId}` | 滚动发布单副本下线不影响其他副本 |
+| 心跳过期 | `MvpHealthProbeScheduler` | ONLINE/DEGRADED 且 `last_heartbeat < stale` 被探活；长期 stale 的 ONLINE 降级为 DEGRADED |
+| 优雅下线 | 运维置 `DRAINING` | discovery SQL `status IN ('ONLINE','DEGRADED')` 自动排除；重注册不复活 |
+
+### 4.4 三维 discovery 查询（`searchInstancesByAgentId` / `searchByServiceId` / `searchByCapability`）
+
+```
+Gateway / Orchestrator       PgMvpDiscoveryServiceImpl          JdbcAgentRegistryRepository
+   │                                │                                  │
+   │── searchInstancesByAgentId ───►│                                  │
+   │   (tenantId, agentId,          │                                  │
+   │    contractVersion?)           │                                  │
+   │  或 searchByServiceId          │                                  │
+   │   (tenantId, serviceId,        │                                  │
+   │    contractVersion?)           │                                  │
+   │  或 searchByCapability         │                                  │
+   │   (tenantId, capability,       │                                  │
+   │    contractVersion?)           │                                  │
+   │                                │── verifyTenant (可选交叉校验)    │
+   │                                │── repository.listBy* ───────────►│
+   │                                │                                  │── BEGIN TX
+   │                                │                                  │── set_config('app.tenant_id')
+   │                                │                                  │── SELECT ... WHERE tenant_id
+   │                                │                                  │   AND <维度列> = :dimValue
+   │                                │                                  │   AND status IN ('ONLINE','DEGRADED','DRAINING')
+   │                                │                                  │   [AND contract_version = :cv]  ← 非空时
+   │                                │                                  │   ORDER BY weight DESC, last_heartbeat DESC
+   │                                │                                  │── COMMIT
+   │                                │◄── List<RegistryRow> ────────────│
+   │                                │── toDto: RouteHandleCodec.encode │
+   │                                │   (tenantId, agentId, serviceId, │
+   │                                │    instanceId, routeKey,         │
+   │                                │    contractVersion)              │
+   │                                │   → opaque v2: handle            │
+   │◄── List<AgentCardDto> ─────────│                                  │
+```
+
+- **三维查询语义**：
+  - `searchInstancesByAgentId`：`WHERE tenant_id AND agent_id`——列出该 agent 下所有实例。
+  - `searchByServiceId`：`WHERE tenant_id AND service_id`——列出同一逻辑服务下所有实例（跨 agentId）。
+  - `searchByCapability`：`WHERE tenant_id AND capabilities @> ARRAY[:capability]::varchar[]`——列出声明该 capability 标签的所有实例，GIN 索引加速。
+- **DRAINING 可见性**：FEAT-016 反转 REQ-2026-006 的排除策略，DRAINING 作为有限可用状态对调用方可见，调用方自行决定是否路由。OFFLINE 始终排除。
+- **contractVersion 过滤**：参数非 null 时 SQL `AND contract_version = :contractVersion` 强制过滤；null 时不过滤。
+- **空结果**：返回空 List（`agent_not_found` / `NO_CAPABILITY_MATCH` 语义），不抛异常。
+- **排序**：三维查询共享 `weight DESC, last_heartbeat DESC`——调用方 naive pick-first 落在高权重、新鲜心跳实例。
+- **DTO 不含物理地址**：`endpointUrl` / `routeKey` / `instanceId` 明文不进 DTO；只有 opaque `routeHandle`；`serviceId` 作为逻辑服务标识在 DTO 中返回。
+
+### 4.5 route handle 解析（`resolveRouteHandle`）
+
+```
+转发层                    PgMvpDiscoveryServiceImpl        RouteHandleCodec        Repository
+   │                            │                                │                      │
+   │── resolveRouteHandle ─────►│                                │                      │
+   │   (handle, tenantId)       │                                │                      │
+   │                            │── decode(handle) ─────────────►│                      │
+   │                            │                                │── stripPrefix v2:    │
+   │                            │                                │── base64 decode       │
+   │                            │                                │── JSON parse 6 fields │
+   │                            │◄── DecodedHandle ──────────────│                      │
+   │                            │── decoded.tenantId != tenantId?                       │
+   │                            │   yes ──► TenantIsolationViolationException (400)     │
+   │                            │── verifyTenant                                        │
+   │                            │── repository.findEndpoint ───────────────────────────►│
+   │                            │   (tenantId, agentId, serviceId, instanceId)          │
+   │                            │◄── Optional<EndpointEntry> ───────────────────────────│
+   │                            │── empty? ──► NoSuchElementException (404 entry_not_found)
+   │◄── RouteResolution ────────│                                                      │
+   │   (instanceId, endpointUrl, routeKey, contractVersion)                              │
+   │   instanceId 从 handle 解码（非 DB 读取），仅转发层可见                              │
+```
+
+失败码映射见 §7。
+
+### 4.6 健康探活状态机
+
+| 当前状态 | 事件 | 下一状态 | 附加行为 |
+|---------|------|---------|---------|
+| ONLINE | 探活 2xx | ONLINE | `updateStatus(refreshHeartbeat=true)` |
+| ONLINE | 探活 5xx / 超时 / 连接异常 | DEGRADED | `updateStatus(refreshHeartbeat=false)` |
+| DEGRADED | 探活 2xx | ONLINE | 恢复（PR #389 #4） |
+| DEGRADED | 探活 5xx / 超时 | DEGRADED | 心跳不刷新；discovery 仍可见（有限可用） |
+| DRAINING | （任何探活） | DRAINING | 运维发起；FEAT-016 起在 discovery 中**可见**（有限可用状态），调用方自行决定是否路由；重注册不复活 |
+| OFFLINE | （手动） | OFFLINE | 终态；discovery 始终排除；需重注册回 ONLINE |
+| ONLINE | `last_heartbeat` 长期 stale 且未被探活调度扫到 | DEGRADED | 调度器兜底降级 |
+
+> **FEAT-016 DRAINING 可见性反转说明**：REQ-2026-006 时期 discovery SQL 为 `status IN ('ONLINE','DEGRADED')` 排除 DRAINING；FEAT-016 改为 `status IN ('ONLINE','DEGRADED','DRAINING')` 包含 DRAINING，让调用方看到正在下线的实例作为有限可用候选，由调用方自行决定是否路由（例如优先路由到 ONLINE，DRAINING 作为降级备选）。OFFLINE 始终排除。
+
+## 5. 配置模型（Physical View）
+
+### 5.1 完整配置示例
+
+```yaml
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/agent_rdc}
+    username: ${SPRING_DATASOURCE_USERNAME:agent_rdc}
+    password: ${SPRING_DATASOURCE_PASSWORD:agent_rdc}
+    driver-class-name: org.postgresql.Driver
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+server:
+  port: 8092
+
+# pull 模式注册（opt-in）
+rdc:
+  pull-registration:
+    enabled: false
+    runtimes: []
+      # - base-url: http://localhost:8090
+      #   tenant-id: tenant-A
+      #   agent-id: demo-runtime-8090
+      #   framework-type: JIUWEN
+      #   card-path: /.well-known/agent-card.json
+      #   route-key: /v1/query
+      #   region: cn-east-1
+      #   max-concurrency: 10
+      #   weight: 100
+      #   headers:
+      #     Authorization: Bearer ${RUNTIME_TOKEN:placeholder}
+
+# 健康探活调度
+agent-bus:
+  registry:
+    mvp:
+      probe-interval-ms: 5000
+      probe-stale-before-ms: 5000
+      probe-scan-limit: 200
+      probe-connect-timeout-ms: 2000
+      probe-read-timeout-ms: 2000
+```
+
+### 5.2 配置属性表
+
+| 属性路径 | 类型 | 默认值 | 必填 | 说明 |
+|---------|------|--------|------|------|
+| `server.port` | int | 8092 | 否 | agent-rdc HTTP 端口；避开 8080 与其他模块冲突。 |
+| `spring.datasource.url` | String | `jdbc:postgresql://localhost:5432/agent_rdc` | 是 | PG 连接串；生产用环境变量覆盖。 |
+| `spring.flyway.enabled` | bool | true | 否 | 启动时跑 V2..V5 migration 建表。 |
+| `rdc.pull-registration.enabled` | bool | false | 否 | pull 模式开关；关闭时不实例化 `PullRegistrationBootstrap`。 |
+| `rdc.pull-registration.runtimes[]` | list | `[]` | 否 | pull 模式 runtime 列表；每项需 `base-url` / `tenant-id` / `agent-id` / `framework-type`。 |
+| `agent-bus.registry.mvp.probe-interval-ms` | long | 5000 | 否 | 探活调度固定延迟。 |
+| `agent-bus.registry.mvp.probe-stale-before-ms` | long | 5000 | 否 | 心跳过期阈值。 |
+| `agent-bus.registry.mvp.probe-scan-limit` | int | 200 | 否 | 单次扫描上限。 |
+| `agent-bus.registry.mvp.probe-connect-timeout-ms` | int | 2000 | 否 | 探活连接超时。 |
+| `agent-bus.registry.mvp.probe-read-timeout-ms` | int | 2000 | 否 | 探活读超时。 |
+
+## 6. 对外呈现 / 用户场景（Scenario View）
+
+### 6.1 外部接口
+
+| 端点 | 方法 | 说明 |
+|------|------|------|
+| `POST /api/registry/register` | HTTP POST | push 模式注册 / 重注册；`serviceId` caller-overridable，`instanceId` server-derived，`capabilities` 直通 |
+| `DELETE /api/registry/deregister/{tenantId}/{agentId}` | HTTP DELETE | 批量下线该 agent 下所有 serviceId / instanceId |
+| `DELETE /api/registry/deregister/{tenantId}/{agentId}/{serviceId}` | HTTP DELETE | 批量下线该逻辑服务下所有实例 |
+| `DELETE /api/registry/deregister/{tenantId}/{agentId}/{serviceId}/{instanceId}` | HTTP DELETE | 单实例下线（4-field PK，FEAT-016 新增） |
+| `GET /api/registry/instances/{tenantId}/{agentId}` | HTTP GET | 列举 ONLINE/DEGRADED/DRAINING 实例（携带 opaque routeHandle）；可选 `?contractVersion=` 过滤 |
+| `GET /api/registry/instances/by-service/{tenantId}/{serviceId}` | HTTP GET | 按逻辑服务标识列举实例（FEAT-016 新增）；可选 `?contractVersion=` 过滤 |
+| `GET /api/registry/instances/by-capability/{tenantId}/{capability}` | HTTP GET | 按 capability 标签精确匹配 `capabilities[]` 数组列举实例（FEAT-016 新增）；可选 `?contractVersion=` 过滤 |
+| `POST /api/registry/route-handle/resolve` | HTTP POST | 转发层解析 routeHandle 为 `RouteResolution`（含 instanceId / endpointUrl / routeKey / contractVersion） |
+
+请求 / 响应遵循 `traceparent`（W3C）/ `X-Trace-Id` header 透传，缺失时生成 UUID。
+
+### 6.2 用户示例
+
+#### 6.2.1 注册一个 Agent 能力
+
+```bash
+curl -s -X POST http://localhost:8092/api/registry/register \
+  -H "Content-Type: application/json" \
+  -H "X-Trace-Id: req-001" \
+  -d '{
+    "tenantId": "tenant-wealth-01",
+    "agentId": "wealth-expert-01",
+    "serviceId": "wealth-svc",
+    "agentName": "理财专家智能体",
+    "frameworkType": "JIUWEN",
+    "routeKey": "wealth/v1",
+    "contractVersion": "1",
+    "capabilityVersion": "1.0.0",
+    "endpointUrl": "http://192.168.1.50:8000",
+    "maxConcurrency": 10,
+    "weight": 100,
+    "region": "cn-east-1",
+    "capabilities": ["wealth-query", "wealth-advisor"]
+  }'
+# 预期：200 OK
+# - serviceId: caller 传入 "wealth-svc" 保留（若省略则派生为 "192.168.1.50"）
+# - instanceId: server-derived 为 "192.168.1.50-8000"（host-port）
+# - capabilities: 直通持久化为 VARCHAR(64)[] {"wealth-query","wealth-advisor"}
+```
+
+#### 6.2.2 查询已知 agent 的可路由实例
+
+```bash
+curl -s "http://localhost:8092/api/registry/instances/tenant-wealth-01/wealth-expert-01?contractVersion=1" \
+  -H "X-Trace-Id: req-002"
+# 预期：
+# [
+#   {
+#     "serviceId": "wealth-svc",
+#     "routeHandle": "v2:eyJ0ZW5hbnRJZCI6...==",
+#     "health": "ONLINE",
+#     "contractVersion": "1",
+#     "capabilityVersion": "1.0.0",
+#     "weight": 100,
+#     "region": "cn-east-1",
+#     "maxConcurrency": 10,
+#     "agentName": "理财专家智能体",
+#     "frameworkType": "JIUWEN"
+#   }
+# ]
+# 注意：响应不含 endpointUrl / routeKey / instanceId 明文；serviceId 作为逻辑服务标识可见
+# health 值域含 DRAINING（有限可用状态，调用方自行决定是否路由）
+# contractVersion=1 非空时 SQL 强制过滤；省略则不过滤
+```
+
+#### 6.2.3 按逻辑服务或 capability 查询
+
+```bash
+# 按逻辑服务标识查询同一服务下所有实例（跨 agentId）
+curl -s "http://localhost:8092/api/registry/instances/by-service/tenant-wealth-01/wealth-svc" \
+  -H "X-Trace-Id: req-003"
+
+# 按 capability 标签精确匹配
+curl -s "http://localhost:8092/api/registry/instances/by-capability/tenant-wealth-01/wealth-query" \
+  -H "X-Trace-Id: req-004"
+# 预期：返回所有 capabilities[] 包含 "wealth-query" 的 ONLINE/DEGRADED/DRAINING 实例
+```
+
+#### 6.2.4 转发层解析 route handle
+
+```bash
+curl -s -X POST http://localhost:8092/api/registry/route-handle/resolve \
+  -H "Content-Type: application/json" \
+  -d '{"routeHandle": "v2:eyJ0ZW5hbnRJZCI6...==", "tenantId": "tenant-wealth-01"}'
+# 预期：
+# {"instanceId": "192.168.1.50-8000", "endpointUrl": "http://192.168.1.50:8000", "routeKey": "wealth/v1", "contractVersion": "1"}
+# instanceId 从 route handle 解码（非 DB 读取），仅转发层可见
+```
+
+### 6.3 E2E 流程
+
+```
+Agent 服务启动          registry-center              健康探活调度器        转发层（Orchestrator）
+   │                        │                            │                       │
+   │── POST /register ─────►│                            │                       │
+   │                        │── upsert (ONLINE)          │                       │
+   │◄── 200 ────────────────│                            │                       │
+   │                        │                            │                       │
+   │                        │◄── scanDueForProbe ────────│                       │
+   │                        │    (5s 周期)               │                       │
+   │◄── GET /health ────────────────────────────────────│                       │
+   │── 200 ────────────────────────────────────────────►│                       │
+   │                        │◄── updateStatus(ONLINE) ───│                       │
+   │                        │                            │                       │
+   │                        │◄── GET /instances ─────────────────────────────────│
+   │                        │── List<AgentCardDto> ─────────────────────────────►│
+   │                        │                            │                       │
+   │                        │◄── POST /route-handle/resolve ─────────────────────│
+   │                        │── RouteResolution ────────────────────────────────►│
+   │                        │                            │                       │
+   │◄── 实际业务调用 ─────────────────────────────────────────────────────────────│
+```
+
+## 7. 错误处理（Process View）
+
+| 错误场景 | 触发条件 | HTTP | error code | 行为 |
+|---------|---------|------|-----------|------|
+| registry key 缺失 | body 缺 `tenantId` / `agentId` | 400 | `invalid_request` | fail-fast |
+| `endpointUrl` 畸形 | 无 host / 不可解析 | 400 | `invalid_request` | `InstanceIdCodec.derive` / `ServiceIdCodec.derive` 抛 IAE |
+| `frameworkType` 为 null | push body 或 pull config 缺失 | 400 | `invalid_request` | |
+| route handle 畸形 | 缺 `v2:` 前缀 / base64 损坏 / JSON 缺字段 / 旧 4 字段或 `v1:` 5 字段格式 | 400 | `malformed_handle` | baseline-breaking，不兼容旧格式 |
+| 跨 tenant 解析 | `resolveRouteHandle` 调用方 tenant 与 handle 内 tenant 不一致 | 400 | `tenant_isolation_violation` | |
+| TenantContext 交叉校验失败 | 后台调度路径 bound tenant 与参数不一致 | 400 | `tenant_isolation_violation` | |
+| entry 不存在 | handle 指向的 `(tenantId, agentId, serviceId, instanceId)` 无记录 | 404 | `entry_not_found` | |
+| 已知目标无实例 | 三维 discovery 查询无 ONLINE/DEGRADED/DRAINING 行 | 200 | （空 List） | 空数组语义 = `agent_not_found` / `NO_CAPABILITY_MATCH` |
+| contractVersion 不匹配 | 调用方传入 `contractVersion` 且无匹配行 | 200 | （空 List） | SQL `AND contract_version = :cv` 强制过滤后无行 |
+
+scope §10 失败语义映射：
+
+| scope 失败语义 | L2 实现 |
+|---------------|---------|
+| `NO_CAPABILITY_MATCH` | `searchByCapability` 返回空 List（FEAT-016 已实现） |
+| `NO_AVAILABLE_AGENT` | `searchInstancesByAgentId` / `searchByServiceId` 返回空 List |
+| `CONTRACT_VERSION_MISMATCH` | 调用方传入 `contractVersion` 时 SQL 强制过滤，不匹配行不返回（空 List 语义）；未传入时由调用方按 DTO `contractVersion` 自行判断 |
+| `TENANT_SCOPE_DENIED` | `TenantIsolationViolationException` → 400 |
+| `AGENT_CARD_INVALID` | 400 `invalid_request` |
+| `ROUTE_CONFIDENCE_LOW` | 阶段一（推荐分未实现） |
+
+## 8. 限制与待补
+
+| 限制 | 影响范围 | 临时方案 / 阶段规划 |
+|------|---------|-------------------|
+| 仅支持 agent / service / capability 三维精确查询，不支持按 `description` / `tags` / `domain` / `query_text` 自由文本查询 | 意图识别动态能力匹配场景无法直接使用 registry 的自由文本检索 | 阶段一引入 大模型语义检索 SPI 方法（scope §11 已列为后续增强） |
+| 无推荐首选 / 分数 / 证据 | 自动调度场景需调用方自排 | 阶段一（scope §2 SHOULD，可延后） |
+| `supports_streaming` / `supports_hitl` / `requires_idempotency_key` 等执行约束字段未实现 | 执行约束查询无法下推到 registry | 阶段一随 Agent Card 字段扩展 |
+| `capabilities` 为自由字符串数组，未强制 scope §3 的 `capability_type` 枚举值域 | caller 可传任意字符串，无 `agent_loop` / `workflow` / `external_agent` / `external_workflow` 枚举校验 | 阶段一评估是否引入枚举约束或在投影层校验 |
+| `caller_ref` 查询输入未实现 | 仅 `tenantId` 边界，无调用方维度可见性 | 阶段一评估是否引入调用方可见性模型 |
+| `health_status` 值域偏离 | scope §3 = `healthy` / `degraded` / `unhealthy`（3 态）；L2 = `ONLINE` / `DEGRADED` / `DRAINING` / `OFFLINE`（4 态，含 DRAINING / OFFLINE 治理态）。映射关系：`healthy`↔`ONLINE`、`degraded`↔`DEGRADED`、`unhealthy`↔`OFFLINE`；`DRAINING` 在 scope 中无对应（FEAT-016 新增的优雅下线态）。调用方需做值域映射 | 阶段一统一值域或在投影层做映射 |
+| `priority` → `weight` 字段重命名 | scope §3 字段名 `priority`；L2 = `weight`；调用方需做字段名映射 | 阶段一评估是否回归 `priority` 命名 |
+| pull 注册无定时刷新 | agent 卡片变更需重启或重触发 | bootstrap-only 设计；刷新需求由阶段一定时拉取或 push 模式覆盖 |
+| route handle 旧 4 字段及 `v1:` 5 字段格式不兼容 | REQ-2026-006 + serviceId/instanceId 分离升级后旧 handle 立即失效 | handle 生命周期短（一个探活周期），迁移后调用方重新 `GET /instances` |
+
+## 9. 与 scope 文档的对齐矩阵
+
+| scope 要求 | L2 落地 | 备注 |
+|-----------|---------|------|
+| §2 Agent Card 注册 MUST | §4.1 / §4.2 | push + pull 双模式；serviceId caller-overridable，instanceId server-derived |
+| §2 Agent Card 校验 MUST | §4.1.2 / §7 | registry key + frameworkType + endpointUrl 派生；**capability_type 枚举值域校验、执行约束校验属阶段一（见 §8）** |
+| §2 更新与失效 MUST | §4.3 | upsert + deregister(pair/triple/quad) + DRAINING 保留 |
+| §2 租户与调用方边界 MUST | §2.3.3 / §4.4 / §7 | RLS + 应用层 WHERE + TenantContext 交叉校验；**caller_ref 未实现，见 §8** |
+| §2 Agent Card 查询 MUST | §4.4 | agent / service / capability 三维已实现（FEAT-016）；自由文本 / 语义维度（description / tags / domain / query_text / 执行约束）阶段一实现 |
+| §2 可用性过滤 MUST | §4.4 / §4.6 | status 过滤（含 DRAINING 可见性）+ contractVersion 强制过滤（FEAT-016）+ capabilityVersion 在 DTO 由调用方判断 |
+| §2 推荐首选 SHOULD | §8 | 阶段一 |
+| §2 候选与证据保留 SHOULD | §8 | 阶段一 |
+| §2 opaque route handle MUST | §4.4 / §4.5 | v2: 6 字段 base64（tenantId / agentId / serviceId / instanceId / routeKey / contractVersion） |
+| §2 无能力结果 MUST | §7 | 空 List / 404 |
+| §2 可查询扩展元数据 SHOULD | §2.3.2 | capabilities GIN 索引已支持精确匹配（FEAT-016）；A2A JSONB 保留，自由文本索引阶段一 |
+| §3 Agent Card 最小字段 | §2.3.2 | 覆盖矩阵见 §2.3.2；**health_status 值域偏离（含映射）、priority→weight 重命名、caller_ref 缺失、capability_type 枚举未强制，见 §8** |
+| §4 查询输入与输出 | §2.3.1 / §2.3.2 | agent / service / capability / contractVersion 输入已实现；**caller_ref / query_text / tags / domain / execution_constraints / health_requirement / page / sort 输入未实现，见 §8** |
+| §6 意图识别场景协作边界 | §2.2 / §8 | 阶段一；当前不实现动态能力匹配 |
+| §10 失败语义 | §7 | `NO_CAPABILITY_MATCH` / `NO_AVAILABLE_AGENT` / `CONTRACT_VERSION_MISMATCH` / `TENANT_SCOPE_DENIED` / `AGENT_CARD_INVALID` 已实现；`ROUTE_CONFIDENCE_LOW` 阶段一 |
+| §11 开发设计待细化事项 | §8 | 对齐——均标记为阶段一 |


### PR DESCRIPTION
## Summary

L2 文档 `architecture/L2-Low-Level-Design/agent-bus/Feat-Func-015-agent-card-registration-and-discovery.md` 此前停留在 REQ-2026-006 时期 MVP 描述，与 FEAT-016 实现严重不符。本 PR 按 `agent-solution/common/agent-rdc` 实现现状重写，仅含该单个文件变更。

### 与实现的 8 项硬冲突（修订前）

| # | L2 原文 | 实际实现 |
|---|---------|---------|
| 1 | SPI 仅 `searchInstancesByAgentId(String, String)`，`searchByCapability` 标「阶段一未实现」 | 三方法已实现：`searchInstancesByAgentId(tenantId, agentId, contractVersion)` + `searchByServiceId` + `searchByCapability` |
| 2 | discovery SQL `status IN ('ONLINE','DEGRADED')` 排除 DRAINING | SPI javadoc 明确 DRAINING 已包含（FEAT-016 反转） |
| 3 | `capability_type` ⚠️「MVP 已移除，阶段一随 searchByCapability 引入」 | `capabilities List<String>` 已存在；V6 已建 `VARCHAR(64)[]` 列 + GIN 索引；SPI + 端点已实现 |
| 4 | `contractVersion` 不在 discovery 层强制过滤，调用方自行判断 | 三查询方法均接受 nullable `contractVersion`，非空时 SQL `AND contract_version = :cv` 强制过滤 |
| 5 | migration `V6__separate_service_id_instance_id.sql` | 实际 `V6__feat_016_service_instance_capability.sql`，且含 capabilities 列 + GIN 索引 |
| 6 | 包结构只列 `InstanceIdCodec` | 还有 `ServiceIdCodec` 类（host-only 派生） |
| 7 | `RouteResolution` 3 字段 | 实际 4 字段 record，新增 `instanceId` 第一字段 |
| 8 | §6.1 列 6 个 HTTP 端点 | 实际 8 个：缺 `GET /instances/by-service/{tenantId}/{serviceId}` 和 `GET /instances/by-capability/{tenantId}/{capability}` |

### 主要修订

- §1.3 子特性表：能力维度查询 ⬜→✅；新增 service 维度查询行
- §2.1 能力清单：新增 service/capability 查询行；DRAINING 包含 + contractVersion 强制过滤
- §2.3.1 SPI：1 方法 2 参数 → 3 方法 3 参数；阶段一扩展预留改为自由文本/大模型语义检索
- §2.3.2：AgentRegistryEntry 加 `capabilities` + serviceId caller-overridable 语义；RouteResolution 加 `instanceId`；覆盖矩阵更新
- §2.3.3 行为承诺：DRAINING 包含 + contractVersion 强制过滤 + capabilities 直通
- §3.1 包结构：加 `ServiceIdCodec`；V6 文件名修正 + 描述补全；端点数 5→8
- §4.4 三维 discovery 查询合并；DRAINING 包含 + contractVersion 过滤
- §4.6 状态机：DRAINING 可见性反转说明
- §6.1 接口表：6→8 端点
- §7 错误处理：contractVersion 强制过滤；失败语义映射更新
- §8 限制表：移除已实现项；health_status 补映射表
- §9 对齐矩阵：全部落地状态更新

### 仍未实现项（标记为阶段一目标）

自由文本/大模型语义检索、推荐首选 + 证据、执行约束校验、`caller_ref` 调用方可见性、`capability_type` 枚举值域强制、`health_status` 值域统一、`priority` 命名回归。

## Test plan

- [ ] 文档评审：核对 §2.3.1 SPI 签名与 `agent-solution/common/agent-rdc` 实现一致
- [ ] 文档评审：核对 §6.1 端点表与 `MvpRegistryController` 实际端点一致
- [ ] 文档评审：核对 §3.1 V6 migration 文件名与实际文件一致
- [ ] 文档评审：确认 §8 未实现项与 §9 对齐矩阵无遗漏

🤖 Generated with [Claude Code](https://claude.com/claude-code)