### PR TITLE
docs: define FEAT-019 parallel downstream tasks

### DIFF
--- a/version-scope/FEAT-004-remote-agent-orchestration.md
+++ b/version-scope/FEAT-004-remote-agent-orchestration.md
@@ -13,14 +13,23 @@ dependency:
 
 ## 1. 特性定位
 
-agent-runtime 作为 A2A 客户端接入和调用其他 A2A Agent，实现跨 Agent 协作。远程 Agent 通过 YAML 配置静态接入，runtime 自动拉取 Agent Card、缓存维护本地目录、生成工具描述、安装为本地 Agent 可调用的 Tool。当 LLM 调用远程 Tool 时，走中断-续接流水线：本地 Agent 挂起 → 远程调用 → 等待结果 → 回灌本地 Agent 继续推理。
+agent-runtime 作为 A2A 客户端接入和调用其他 A2A Agent，实现跨 Agent 协作。远程 Agent 通过 YAML 配置静态接入，runtime 自动拉取 Agent Card、缓存维护本地目录、生成工具描述，并将其安装为本地 Agent 可调用的 Tool。
 
-- **解决的问题**：单个 Agent 能力有限，需要将专业任务委托给其他 Agent。A2A 协议提供了标准的跨 Agent 通信方式，无需 Agent 之间共享代码或状态。
-- **适用场景**：多 Agent 协作（旅行助手调用天气/酒店/航班 Agent）、企业 Agent 生态（主 Agent 调用部门级子 Agent）。如果只需要单一 Agent 完成所有任务，不需要此特性。
+本特性同时纳入两种远程调用方式：
+
+1. **单任务工具调用**：LLM 调用一个远程 Tool，runtime 通过中断—续接流水线执行一个远程 A2A Task，并将结果回灌本地 Agent。
+2. **任务驱动的并行子任务**：上游 Agent 或任务规划器一次提交多个彼此独立的远程 Agent 子任务，runtime 将每个子任务物化为可独立追踪的远程 A2A Task，在并发预算内 fan-out 并行执行，待结果 fan-in 后一次性回灌本地 Agent。
+
+并行子任务在当前版本采用**同步父级等待（模式二）**：父 Task 保持运行 / 等待状态，child Task 并行执行并实时投射轨迹，all-settled 后父 Agent 恢复。父 Task 创建子任务后立即返回、依赖异步回调聚合和断线重连的模式一不属于本次 FEAT-004 更新范围。
+
+- **解决的问题**：单个 Agent 能力有限；复杂任务需要拆成多个相互独立的专业子任务，并发委托给一个或多个下游 Agent，在保持 Task 可追踪、可取消、可恢复的同时缩短端到端时延。
+- **适用场景**：旅行助手并行查询天气、酒店和航班；研究 Agent 并行收集不同信息源；企业主 Agent 并行调用多个部门级 Agent。存在严格前后依赖的子任务仍应串行执行或交由工作流 / DAG 编排能力处理。
 
 ## 2. 对外能力边界
 
 ### 2.1 能力清单
+
+状态说明：`✅` 表示已有实现事实；`🟡` 表示已纳入当前版本范围、需要设计实现和验收对齐；`⬜` 表示当前版本不承诺。
 
 | 能力 | 状态 | 说明 |
 |------|------|------|
@@ -30,96 +39,214 @@ agent-runtime 作为 A2A 客户端接入和调用其他 A2A Agent，实现跨 Ag
 | RemoteAgentToolSpec 生成 | ✅ | 从 Card skills 生成，开放 JSON schema；**无 skills 的 Agent Card 不会被注入为 Tool** |
 | OpenJiuwen Tool 安装 | ✅ | Placeholder Tool + Interrupt Rail |
 | 远程 A2A 调用 | ✅ | `SendStreamingMessage`，独立 streaming |
-| 中断-续接 | ✅ | 远程 INPUT_REQUIRED → 父 Task 挂起 → 用户输入 → 续写 |
+| 单任务中断—续接 | ✅ | 远程 INPUT_REQUIRED → 父 Task 挂起 → 用户输入 → 续写 |
 | Metadata 转发 | ✅ | 入站 metadata → 出站远程调用 |
-| 结果回灌 | ✅ | 远程 COMPLETED → InteractiveInput → 本地 Agent resume |
+| 单任务结果回灌 | ✅ | 远程 COMPLETED → InteractiveInput → 本地 Agent resume |
 | 父 Task 进度投射 | ✅ | 远程 progress → 父 Task artifact |
 | 取消级联传播 | ✅ | 父 Task cancel → 远程 CancelTask |
 | 超时检测 | ✅ | REMOTE_TIMEOUT + 孤儿 Task cancel |
-| 嵌套远程调用 | ⬜ | resume 后再次请求远程 → 返回错误 NESTED_REMOTE_INVOCATION_UNSUPPORTED |
-| Graph/Parallel 编排 | ⬜ | 仅支持单层远程调用 |
+| 任务驱动的并行子任务 | 🟡 | 一次接收多个独立子任务，物化为多个 child Task，在并发预算内 fan-out / fan-in |
+| 子任务独立状态与关联 | 🟡 | 每个 child Task 有稳定标识、目标 Agent、序号、状态、deadline 和父子关联 |
+| 并行结果汇聚与回灌 | 🟡 | 默认 all-settled；按子任务稳定序号形成结构化结果集，一次性恢复父 Agent |
+| 并行取消、超时与部分失败 | 🟡 | 父取消向未终态子任务级联；失败和超时保留为可编程结果，不吞掉成功结果 |
+| 并行 INPUT_REQUIRED | 🟡 | 等待输入的 child Task 可挂起，其他独立 child Task 继续；输入必须定向到具体 child Task |
+| 任意依赖图 / DAG 编排 | ⬜ | 当前只承诺单层独立子任务 fan-out / fan-in，不解析子任务依赖图 |
+| 嵌套远程调用 | ⬜ | 当前不承诺 child Task 内再次发起并行远程调用 |
 
 ### 2.2 显式排除
 
 | 排除项 | 原因 | 替代 |
 |--------|------|------|
-| 动态服务发现 | 远程端点必须通过 YAML 配置声明，不自动扫描网络 | — |
-| 远程 Agent 负载均衡 | 不属于 agent-runtime 职责 | 在反向代理层实现 |
-| 远程调用的认证 | A2A 认证属于协议层，不属于编排层 | 通过 A2A SDK 认证扩展 |
+| 动态服务发现 | 远程端点必须通过 YAML 配置声明，不自动扫描网络 | 使用当前配置目录；后续由注册发现特性扩展 |
+| 远程 Agent 负载均衡 | 不属于本特性的编排语义 | 在反向代理、路由或平台调度层实现 |
+| 远程调用的认证 | A2A 认证属于协议和接入层，不属于编排层 | 通过 A2A SDK 认证扩展 |
+| 有依赖子任务的自动排序 | 依赖图需要独立的验证、调度和恢复语义 | 由工作流 / DAG 编排能力处理 |
+| 下游 Agent 内部工具 / 工作流并行 | A2A child Task 与下游内部 Tool Call / workflow instance 的状态所有者不同 | 由下游 Agent 自己实现，不属于远程 Agent 编排 |
+| 无界并发 | 会导致下游过载、连接耗尽和成本失控 | runtime 按配置的并发预算排队和限流 |
 
 ## 3. 外部行为与用户场景
 
 ### 3.1 外部接口
 
-| API | 说明 |
+| API / 行为表面 | 说明 |
 |-----|------|
-| `agent-runtime.remote-agents` YAML | 配置远程端点 |
-| RemoteAgentToolSpec | 被 LLM 看到的工具描述 |
-| 父 Task artifact / status | 外部客户端通过 A2A stream 看到的进度和结果 |
+| `agent-runtime.remote-agents` YAML | 配置远程端点和单次远程调用参数 |
+| RemoteAgentToolSpec | 被 LLM 看到的远程能力描述 |
+| 单个 RemoteInvocation | 表达一个远程 Agent 工具调用 |
+| ParallelChildTaskSet | 表达同一父 Task 下的一组独立下游子任务；稳定字段由 L2 详细设计固化 |
+| 父 Task artifact / status | 外部客户端通过 A2A stream 看到各 child Task 的接受、进度、等待输入和终态投影 |
+| 结构化并行结果集 | fan-in 后按稳定子任务序号返回每个 child Task 的结果或错误，并回灌父 Agent |
 
 ### 3.2 用户示例
 
 #### 3.2.1 配置远程 Agent
 
 ```yaml
-# 主 Agent (8080) 配置两个远程 Agent
+# 主 Agent (8080) 配置三个远程 Agent
 agent-runtime:
   remote-agents:
     - url: http://weather-agent:18081
     - url: http://hotel-agent:18082
+    - url: http://flight-agent:18083
 ```
 
-前置条件：远程 Agent 已启动在对应端口，Agent Card 可访问。预期结果：主 Agent 的 LLM 工具列表中出现 `query_weather` 和 `search_hotels` 两个远程工具。
+前置条件：远程 Agent 已启动在对应端口，Agent Card 可访问且至少声明一个 skill。预期结果：主 Agent 的 LLM 工具列表中出现天气、酒店和航班三个远程能力。
 
-#### 3.2.2 多 Agent 协作
+#### 3.2.2 单个远程 Agent 调用
 
-```bash
-# 终端 1: 天气 Agent
-java -jar weather-agent.jar --server.port=18081
-
-# 终端 2: 酒店 Agent
-java -jar hotel-agent.jar --server.port=18082
-
-# 终端 3: 主 Agent（配置了上述两个远程）
-java -jar main-agent.jar --server.port=8080
-
-# 调用：用户只需对主 Agent 说话
-curl -s -X POST http://localhost:8080/a2a \
-  -H "Content-Type: application/json" \
-  -H "Accept: text/event-stream" \
-  -d '{
-    "jsonrpc": "2.0",
-    "method": "SendStreamingMessage",
-    "params": {
-      "message": {
-        "role": "ROLE_USER",
-        "messageId": "msg-001",
-        "parts": [{"text": "帮我查北京天气并订个酒店"}]
-      }
-    }
-  }'
-
-# 预期结果：主 Agent 的 LLM 自动依次调用 query_weather 和 search_hotels，汇总返回
+```text
+用户：查北京天气
+主 Agent：调用 query_weather(city="北京")
+runtime：创建一个远程 A2A Task，投射进度，完成后回灌结果
+主 Agent：继续推理并给出最终回答
 ```
 
-### 3.3 E2E 流程
+#### 3.2.3 多个下游子任务并行执行
 
+```text
+用户：帮我规划周末去上海的行程，同时查天气、酒店和往返航班
+
+主 Agent / 任务规划器一次生成三个独立远程 Agent 子任务：
+  1. 查询上海周末天气       → weather-agent
+  2. 查询预算内酒店         → hotel-agent
+  3. 查询往返航班           → flight-agent
+
+runtime：
+  - 为三个请求分别创建 child Task
+  - 在并发预算内并行派发
+  - 持续把 child Task 进度投射到父 Task
+  - 等待三个 child Task 全部进入结果性终态
+  - 按 1、2、3 的稳定顺序汇聚结果并一次性回灌
+
+主 Agent：基于完整结果集生成统一行程建议
 ```
-用户: "查北京天气"
+
+并行执行不保证完成顺序；对父 Agent 可见的汇聚结果必须保持生成时的稳定序号，不能因网络返回先后而改变语义。
+
+### 3.3 单任务 E2E 流程
+
+```text
+用户："查北京天气"
   │
   ▼ 主 Agent
-  ├─ LLM 看到 tool: query_weather (来自 weather-agent)
-  ├─ LLM 调用: query_weather(city="北京")
+  ├─ LLM 看到 tool: query_weather
+  └─ LLM 调用: query_weather(city="北京")
   │
-  ▼ Interrupt Rail 拦截 → RemoteInvocation
-  ├─ POST /a2a SendStreamingMessage → weather-agent:18081
-  ├─ weather-agent 返回: ArtifactUpdate("晴 22°C") → 父 Task 进度
-  └─ weather-agent 返回: COMPLETED → toolResult = "晴 22°C"
+  ▼ Interrupt Rail → RemoteInvocation
+  ├─ SendStreamingMessage → weather-agent
+  ├─ 远程 progress → 父 Task artifact
+  └─ 远程 COMPLETED → toolResult
   │
   ▼ 回灌主 Agent
-  ├─ InteractiveInput.update("tool-call-1", "晴 22°C")
-  ├─ LLM resume: "北京今天天气晴朗，气温22°C"
-  └─ parent task COMPLETED
+  ├─ InteractiveInput.update(toolCallId, toolResult)
+  ├─ LLM resume
+  └─ parent Task COMPLETED
 ```
+
+### 3.4 并行子任务 E2E 流程
+
+```text
+父 Agent 生成 ParallelChildTaskSet
+  │
+  ├─ child-1 → weather-agent → remote-task-w ─┐
+  ├─ child-2 → hotel-agent   → remote-task-h ─┼─ all-settled join
+  └─ child-3 → flight-agent  → remote-task-f ─┘
+                                               │
+                    StructuredChildTaskResults│
+                                               ▼
+                                      父 Agent 单次 resume
+                                               │
+                                               ▼
+                                      parent Task COMPLETED
+```
+
+## 4. 任务驱动并行行为语义
+
+### 4.1 子任务生成与接受
+
+- 并行批次必须属于一个确定的父 Task，每个子任务必须具有稳定的批次内序号或幂等键。
+- 子任务必须明确目标远程能力和输入；缺少目标、输入不合法或目标不可用的子任务必须形成该子任务自己的拒绝 / 失败结果，不得让整个批次无记录消失。
+- runtime 只并行调度被声明为彼此独立的子任务；当前版本不从自然语言中推断依赖关系，也不自动把有依赖任务改写为 DAG。
+- 接受并行批次不等于所有子任务已经启动。超过并发预算的子任务保持可观察的 pending / queued 状态，并在容量释放后派发。
+
+### 4.2 父子 Task 与关联
+
+- 每个下游调用都必须拥有独立的 child Task 记录和独立的远程 `taskId` / `contextId`（在远端接受后）。
+- 父 Task 必须能够关联批次、child Task、目标 Agent、远程 Task、tool call、trace 和租户上下文。
+- child Task 的状态变化应投射为父 Task 的进度或 artifact，但 child Task 不能直接覆盖父 Task 的最终状态。
+- 重试同一批次时，runtime 必须基于父 Task 与子任务稳定键避免重复创建可见下游任务。
+
+### 4.3 并发与背压
+
+- runtime 必须实施有界并发；并发上限由部署或平台策略确定，不能由 LLM 任意放大。
+- 并行批次中的子任务可以指向不同下游 Agent，也可以在目标容量允许时指向同一下游 Agent。
+- 当并发预算不足时，runtime 应排队剩余子任务，不得退化为不可观察的同步阻塞，也不得直接丢弃。
+- 并发限制、排队时长、实际并行度和被限流结果必须可观测。
+- runtime 的瞬时并发预算只约束已接受 child Task 的启动节奏；上游入口的一次提交批次上限约束本次接受多少项。两者不得混为一个“并发上限”。
+
+### 4.4 结果汇聚与父 Agent 恢复
+
+- 当前版本默认采用 **all-settled**：所有 child Task 都进入 completed、failed、canceled、rejected 或 timed-out 等结果性终态后，才完成 fan-in。
+- 结果集必须逐项包含 child Task 标识、稳定序号、目标 Agent、结果状态、结果 / artifact 引用或结构化错误。
+- 结果集按子任务生成时的稳定序号排列，而不是按完成时间排列。
+- 某个 child Task 失败不得吞掉其他 child Task 的成功结果；父 Agent 必须同时看到成功结果和失败原因。
+- fan-in 完成后只对父 Agent执行一次批次级 resume，避免每完成一个子任务就触发一次父 LLM 推理而产生竞态、重复推理和上下文污染。
+
+### 4.5 INPUT_REQUIRED
+
+- 任一 child Task 进入 `INPUT_REQUIRED` 时，父 Task 必须投射等待输入状态，并明确需要输入的 child Task 标识、目标 Agent 和问题描述。
+- 其他与该 child Task 独立的在途子任务可以继续执行并保留结果，不因一个分支等待输入而被取消。
+- 用户补充输入必须定向到具体 child Task；当多个 child Task 同时等待输入而请求未指定目标时，runtime 必须返回明确的歧义错误，不得猜测路由。
+- 等待输入的 child Task 完成后重新进入原批次 join；已完成兄弟任务不得重复执行。
+
+### 4.6 取消、超时与失败
+
+- 取消父 Task 必须 best-effort 取消所有未进入结果性终态的本地 child Task 和远程 Task，并保留取消轨迹。
+- 单个 child Task 被取消、失败或超时，默认不取消兄弟任务；其结果作为结构化错误参与 all-settled 汇聚。
+- 每个 child Task 必须受单次远程调用 deadline / timeout 约束；并行批次还应受父 Task deadline 和批次 join deadline 约束。
+- 父 deadline 到期后，runtime 必须停止继续派发未启动子任务，取消仍在运行的远程 Task，并以部分结果 + 明确超时项完成汇聚或终止父 Task。
+- 远程不可达、协议错误、限流、超时和业务失败必须可区分，并携带是否可重试语义。
+
+### 4.7 父子状态投射
+
+- child Task 使用 `pending`、`running`、`input_required`、`completed`、`failed`、`canceled`、`timeout` 等状态表达独立下游执行。
+- 父 Task 在 fan-out / fan-in 期间保持 `running`；需要定向补充输入时可投射 `input_required`。
+- 所有 child Task 成功且父 Agent 综合成功时，父 Task 进入 `completed`。
+- 至少一个 child Task 成功、至少一个失败 / 取消 / 拒绝 / 超时，且父 Agent仍形成有效综合结果时，父 Task 进入 `completed_with_partial_failures`。
+- 批次结构、父子关联、权限一致性或父 Agent 综合发生不可恢复失败时，父 Task 进入 `failed`；不得把任一 child Task 普通失败自动扩大为父级失败。
+- `canceled` 与 `timeout` 作为父级结果时，必须保留已完成 child Task 的结果和未完成项明细。
+
+## 5. 行为不变量与验收要点
+
+### 5.1 行为不变量
+
+- **一个下游调用，一个 child Task**：不得用共享状态槽覆盖多个并行调用。
+- **父 Task 是编排所有者**：child Task 进度可投射，父 Task 终态只能由父级 join / 恢复流程决定。
+- **有界并发**：LLM 生成 N 个子任务不等于创建 N 个线程或无条件同时发送 N 个请求。
+- **稳定汇聚**：结果顺序与子任务生成顺序一致，与完成顺序无关。
+- **单次恢复**：一个并行批次默认只触发一次父 Agent resume。
+- **部分失败可见**：成功、失败、取消、拒绝和超时逐项保留。
+- **取消可传播**：父取消后不得继续派发尚未启动的子任务。
+- **租户与权限不扩张**：child Task 继承父 Task 的租户和调用授权上界，不能因委托获得更高权限。
+
+### 5.2 最小验收场景
+
+| 场景 | 验收结果 |
+|---|---|
+| 三个独立子任务均成功 | 三个下游 Task 在并发预算内重叠执行；父 Agent 收到稳定有序的三个成功结果并只恢复一次 |
+| 一个快、一个慢、一个失败 | 快任务结果被保留；父级等待慢任务终态；失败项携带结构化错误；最终结果顺序不受完成先后影响 |
+| 已接受子任务数超过瞬时并发预算 | 只启动预算允许的数量，其余处于可观察排队状态；容量释放后继续派发 |
+| 上游提交超过远程 Agent 批次规模策略 | runtime 明确拒绝整个批次或只接受策略允许的项目并返回剩余项；不得静默丢弃或无界创建远程 Task |
+| 一个 child Task 请求输入 | 父 Task 标识具体等待输入分支；其他分支继续；定向输入后只恢复该分支并最终 join |
+| 两个 child Task 同时请求输入 | 未指定 child Task 的输入被拒绝为歧义；指定后分别续接，不串线 |
+| 父 Task 取消 | 所有 queued 子任务停止派发，running 远程 Task 收到 best-effort cancel，父子状态和轨迹一致 |
+| 父 deadline 到期 | 未启动项标记未执行 / 超时，运行项被取消，已完成项保留，父级得到可解释的部分结果 |
+| 同一批次重复提交 | 不重复创建下游可见 Task，返回或恢复原有 child Task 集合 |
+
+## 6. 与普通工具并行的边界
+
+- `FEAT-004` 定义 runtime 如何把一个或一组下游调用转化为可治理的远程 A2A Task，并处理派发、状态、汇聚、续接、取消和失败。
+- `FEAT-019` 定义 DeepAgent 在同一轮生成多个普通 Tool Call 并并行调用本地函数、REST、MCP、文件、Shell、代码、Web、多模态等工具；它不创建远程 Agent 或 A2A child Task。
+- `RemoteAgentToolSpec` 虽以 Tool 形式暴露给模型，但其真实执行主体是远程 Agent，必须归入 FEAT-004，不能借 FEAT-019 绕过远程 Task、取消、超时和审计语义。
 
 ---

--- a/version-scope/FEAT-019-parallel-downstream-tool-tasks.md
+++ b/version-scope/FEAT-019-parallel-downstream-tool-tasks.md
@@ -1,0 +1,302 @@
+---
+scope: version
+module: agent-runtime
+feature_type: functional
+feature_id: FEAT-019
+status: draft
+dependency:
+  - README.md
+  - FEAT-002-heterogeneous-agent-framework-compatibility.md
+  - DFX-001-trajectory-observability.md
+---
+
+# 智能体生成并行下游任务 — 黑盒行为说明
+
+## 1. 特性定位
+
+FEAT-019 定义 DeepAgent 在一次规划 / 推理决策中生成多个彼此独立的子任务，并以多个 Tool Call 的形式并行调用下游工具。各工具调用拥有独立的 `tool_call_id`、输入、执行上下文、结果和错误；工具批次完成后，结果按稳定映射一次性回灌 DeepAgent，由 DeepAgent继续综合、修正或规划下一步。
+
+```text
+用户任务
+   │
+   ▼
+DeepAgent 一次生成多个独立子任务
+   │
+   ├─ tool-call-1 → Tool A ─┐
+   ├─ tool-call-2 → Tool B ─┼─ all-settled 汇聚
+   └─ tool-call-3 → Tool C ─┘
+                              │
+                              ▼
+                    DeepAgent 单次继续推理
+```
+
+本特性的核心对象是 **Tool Call**，不是下游 Agent：
+
+- 不创建子 Agent、远程 Agent 或 A2A child Task。
+- 不调用 Agent Card，不维护远程 `taskId` / `contextId`，不走 FEAT-004 的远程 Agent 编排链路。
+- openJiuwen 的 `TaskTool`、`SessionsSpawnTool` 等子智能体 / 会话委托工具，以及 SAA 的 `RemoteAgentToolSpec`，即使在接口表面表现为 Tool，也不属于 FEAT-019。
+- 工作流只有被封装为普通 Tool、REST Tool 或 MCP Tool 后，才能作为本特性的下游工具；工作流本身不被解释为 Agent。
+
+### 1.1 解决的问题
+
+DeepAgent 已能在一次模型输出中生成多个 Tool Call。如果这些调用被串行执行，总耗时接近各工具耗时之和；如果简单无界并发，又会造成共享状态冲突、外部副作用重复、后端过载、权限绕过和结果串线。
+
+FEAT-019 将模型的动态拆解能力与确定性的工具并发治理结合起来：
+
+- DeepAgent 负责判断“拆成哪些独立子任务、分别调用什么工具、如何使用结果”。
+- openJiuwen adapter / agent-core 负责把多个 Tool Call 形成同一批次并执行。
+- runtime / 平台策略负责并发预算、权限、超时、冲突控制、审计和可观测性。
+
+### 1.2 openJiuwen 对齐事实
+
+当前 openJiuwen 开源实现已经具备本特性的基础：
+
+- `DeepAgentConfig.parallel_tool_calls` 和 `create_deep_agent(..., parallel_tool_calls=True)` 支持开启并行 Tool Call，默认值为 `True`。
+- ReActAgent 将同一轮生成的多个 Tool Call 一次交给 AbilityManager。
+- AbilityManager 为每个调用创建隔离的 callback context，并以 all-settled 方式并行等待，单项异常不会直接取消其他项。
+- openJiuwen 同时提供统一 Tool / ToolCard 抽象、内置工具、MCP 接入以及本地函数和 REST API 工具封装。
+
+FEAT-019 不重复定义 openJiuwen 的类级实现，而是规定 SAA 当前版本应承诺的外部行为、工具范围、并行安全和验收边界。
+
+## 2. 术语与职责
+
+| 术语 / 角色 | 定义或职责 |
+|---|---|
+| 父执行 / parent invocation | 当前 DeepAgent 的一次 ReAct / task-loop 执行；并行工具调用仍属于同一 Agent 执行。 |
+| 并行工具批次 | DeepAgent 在同一轮输出中生成、且声明为无前置依赖的一组 Tool Call。 |
+| 工具子任务 | 批次中的一个逻辑子任务，与一个确定的 Tool Call 一一对应；不是 Agent Task。 |
+| `tool_call_id` | 工具子任务的稳定关联键，用于输入、结果、错误、轨迹和模型上下文归位。 |
+| DeepAgent | 生成子任务、选择工具、提供参数并消费汇聚结果；不直接管理线程、连接池或全局并发。 |
+| openJiuwen adapter / agent-core | 校验 Tool Call，建立批次，调用 AbilityManager，隔离每个调用上下文并提交结果。 |
+| runtime / 平台策略 | 提供并发预算、权限、deadline、冲突键、取消和可观测约束；不替代模型拆解业务任务。 |
+| Tool provider | 执行本地函数、REST、MCP、文件、Shell、代码、Web、多模态等具体能力。 |
+
+## 3. 支持的工具范围
+
+“支持某类工具”表示该工具能够进入统一的批次校验、并发策略、执行、结果归位、错误和轨迹链路；不表示该类工具在任何情况下都可以无条件并发。
+
+### 3.1 openJiuwen 核心扩展工具
+
+| 工具类别 | openJiuwen 形态 | FEAT-019 范围 |
+|---|---|---|
+| 本地函数工具 | `@tool` / `LocalFunction` / `Tool` | 支持；是否并发取决于函数纯度、线程安全和共享资源声明。 |
+| REST API 工具 | `RestfulApi` / `RestfulApiCard` | 支持；受连接、目标服务限流、鉴权、幂等和副作用策略约束。 |
+| MCP 工具 | `MCPTool` / `McpToolCard` / `McpServerConfig` | 支持；覆盖 stdio、SSE、Streamable HTTP、Playwright / OpenAPI 等客户端形态，实际并发受 MCP server 能力约束。 |
+| 工作流工具 | 通过 Tool / REST / MCP adapter 暴露的 workflow | 支持工具化后的调用；工作流实例仍由工作流引擎拥有，不提升为 Agent Task。 |
+
+### 3.2 openJiuwen DeepAgent 内置工具
+
+| 工具类别 | 代表工具 / 能力 | 默认并行判断 |
+|---|---|---|
+| 文件系统 | Read、Write、Edit、Glob、Grep、ListDir | 只读调用可并行；写入同一路径或目录的调用必须冲突控制。 |
+| Shell | Bash、PowerShell | 仅在工作目录、进程和外部资源互不冲突时并行；否则串行或隔离执行。 |
+| 代码执行 | CodeTool | 使用独立 sandbox / namespace 时可并行；共享解释器、文件或端口时必须限流。 |
+| 图像 | Image OCR、Visual Question Answering | 可按模型服务并发预算并行。 |
+| 音频 | 转录、音频问答、元数据 | 可按模型 / 媒体服务并发预算并行。 |
+| 视频 | Video Understanding | 支持，但受文件大小、GPU / 模型服务配额和超时约束。 |
+| Web | WebFetch、免费搜索、付费搜索 | 只读请求可并行；必须遵守站点、供应商配额和成本预算。 |
+| 浏览器自动化 | Playwright / browser runtime MCP 工具 | 不同隔离浏览器会话可并行；同一页面 / 会话中的有序交互默认串行。 |
+| 移动 GUI | Android emulator / device GUI 工具 | 不同设备会话可并行；同一设备上的动作默认串行。 |
+| Todo | Todo create / list / get / modify | 读取可并行；对同一 Todo 集合的修改必须串行或使用版本 / 冲突控制。 |
+| Skill | ListSkill、SkillTool | 技能检索 / 读取可并行；Skill 是上下文和规则资产，不因并行调用而形成 Agent。 |
+| 工具发现与加载 | SearchTools、LoadTools | 搜索可并行；同一 AbilityManager 的工具注册 / 加载必须保证幂等和一致性。 |
+| 人机交互 | AskUserTool | 独占交互，不与其他 AskUser 或有副作用调用盲目并发。 |
+| 定时任务 | Cron 工具集 | 查询可并行；创建、修改、删除同一计划任务需串行和幂等。 |
+| LSP / 代码智能 | LspTool | 只读查询可并行；依赖同一 mutable workspace 的操作需与文件写入协调。 |
+| Agent 模式 / 计划模式 | SwitchMode、EnterPlanMode、ExitPlanMode | 控制面工具，按父执行串行，不进入普通并行数据面。 |
+| Worktree / Workspace | EnterWorktree、ExitWorktree | 不同隔离 worktree 可并行；同一执行的进入 / 退出和生命周期操作必须串行。 |
+
+### 3.3 明确排除
+
+| 排除项 | 原因 | 归属 |
+|---|---|---|
+| 下游 Agent、远程 Agent | 执行主体和生命周期是 Agent / A2A Task，不是普通 Tool Call | FEAT-004 或独立多 Agent 编排特性 |
+| `TaskTool`、子智能体 task tool | 实质是把任务委托给另一个 Agent | openJiuwen 子 Agent 能力，不属于 FEAT-019 |
+| `SessionsSpawnTool`、`SessionsCancelTool` 等 | 实质是创建和管理子 Agent 会话 | openJiuwen async subagent 能力，不属于 FEAT-019 |
+| `RemoteAgentToolSpec` | 虽以 Tool 暴露，但执行语义是远程 A2A Agent 调用 | FEAT-004 |
+| 任意依赖图 / DAG | 同一批次只接受互相独立的 Tool Call | 工作流 / DAG 编排能力 |
+| 无界并发 | 会造成资源、成本、安全和后端稳定性风险 | runtime 并发与治理策略 |
+
+## 4. 当前版本能力要求
+
+| 能力 | 要求级别 | 外部行为要求 |
+|---|---|---|
+| 单轮生成多个 Tool Call | MUST | DeepAgent 必须能够在一次模型决策中生成两个或以上的 Tool Call，并保持各自工具名、参数和 `tool_call_id`。 |
+| 独立性前提 | MUST | 只有不依赖同批次其他结果的调用可以并行；有依赖调用必须拆成后续 ReAct 轮次。 |
+| 工具范围覆盖 | MUST | 第 3 章所列 openJiuwen 工具均能进入统一调度链路；排除的 Agent 类工具必须被识别并转交其所属特性。 |
+| 批次预检 | MUST | 执行前必须完成工具存在性、输入 schema、权限、deadline、并行安全和资源冲突校验。 |
+| 独立调用上下文 | MUST | 每个 Tool Call 使用独立 callback / rail context，不能共享可被兄弟调用覆盖的 tool name、args、result 或 error 槽。 |
+| 有界并发 | MUST | `parallel_tool_calls=true` 只表示允许并行，不表示无界；实际并发度必须受 Agent、工具类别、provider 和全局预算共同约束。 |
+| 并行安全策略 | MUST | 调度器必须区分只读、隔离写、共享写、外部副作用、交互和控制面工具，并据此并行、分组串行或拒绝。 |
+| 同一工具多次调用 | MUST | 同一工具可以使用不同参数产生多个 Tool Call；只有工具声明可重入、资源不冲突或已隔离时才并行执行。 |
+| all-settled 汇聚 | MUST | 默认等待批次内所有已启动调用完成、失败、取消或超时；单项失败不得自动取消其他独立调用。 |
+| 稳定结果归位 | MUST | 结果通过 `tool_call_id` 与原始调用一一对应，并按模型生成的稳定顺序提交上下文，不依赖完成时间。 |
+| 单次继续推理 | MUST | 一个工具批次汇聚后只触发一次 DeepAgent 后续推理，避免每个结果单独触发模型竞态。 |
+| 部分失败可见 | MUST | 每个失败项返回工具名、`tool_call_id`、错误类型、可重试性和必要诊断；成功结果同时保留。 |
+| 超时 | MUST | 每个 Tool Call 和整个批次都应有 deadline / timeout；一个超时项不能无限阻塞整个批次。 |
+| 取消 | MUST | 用户取消父执行时，尚未启动的调用不再执行，运行中的调用 best-effort 取消；迟到结果不得重新激活已取消执行。 |
+| 权限不扩张 | MUST | 每个并行 Tool Call 独立经过 permission rail / tool policy；批量调用不能共享一次批准来扩大其他调用权限。 |
+| 结果大小治理 | SHOULD | 大文件、多模态和大正文优先返回受控引用或摘要，避免多个并行结果同时冲垮模型上下文。 |
+| 轨迹可观测 | MUST | 按 batch、`tool_call_id`、tool name、类别、状态、排队、耗时和错误记录轨迹，不输出原始 Chain-of-Thought。 |
+| 串行兼容 | MUST | `parallel_tool_calls=false` 时保持原始 Tool Call 顺序串行执行，不改变输入输出契约。 |
+
+## 5. 并行安全与调度语义
+
+### 5.1 并行安全分级
+
+| 等级 | 典型调用 | 调度语义 |
+|---|---|---|
+| P0：纯函数 / 只读 | 计算、本地只读函数、文件读取、搜索、元数据查询 | 在预算内直接并行。 |
+| P1：隔离状态写入 | 不同 sandbox、不同 worktree、不同文件、不同浏览器 / 设备会话 | 校验隔离键后并行。 |
+| P2：共享状态写入 | 同一文件、Todo 集合、workspace、数据库记录 | 按 conflict key 分组串行，或使用锁 / 乐观并发控制。 |
+| P3：外部副作用 | 发消息、提交业务、创建 Cron、执行改变外部状态的 REST / MCP | 独立鉴权、确认和幂等；默认串行，只有明确声明安全时并行。 |
+| P4：交互 / 控制面 | AskUser、模式切换、进入 / 退出 worktree | 按父执行独占串行。 |
+| OUT：Agent 委托 | TaskTool、SessionsSpawn、RemoteAgentTool | 不进入 FEAT-019，路由到 Agent 编排能力。 |
+
+工具未声明并行安全等级时，平台必须采用保守策略：只读工具可按策略判定；无法判断副作用或资源冲突的工具不得被默认无界并行。
+
+### 5.2 批次形成
+
+- 一个批次只包含同一 DeepAgent、同一模型轮次生成的 Tool Call。
+- 每个调用必须有唯一 `tool_call_id`；工具名相同不代表调用相同。
+- DeepAgent 不得把“先读取数据，再根据数据写入结果”放进同一并行批次。
+- 需要逐实体调用同一工具时，每个实体形成独立 Tool Call；是否并行取决于该工具的可重入性和资源冲突键。
+- 超过单批次最大调用数时，平台不得静默丢弃；应拒绝整个批次、只接受策略允许的前 N 项并明确返回剩余项，或要求 DeepAgent 分批生成。具体策略由 L2 固化。
+
+### 5.3 执行与汇聚
+
+- 预检通过后，调度器按安全等级和 conflict key 对调用分组。
+- 可并行组在并发预算内启动；同一冲突组内部串行。
+- 每个调用独立触发 before / after / error rail，不共享可变 callback context。
+- all-settled 结果保持模型生成顺序，并通过 `tool_call_id` 写回对应 ToolMessage。
+- 工具返回先后只影响实时进度，不影响结果身份和最终上下文顺序。
+- 全部结果写入上下文后，DeepAgent 才进入下一次模型推理。
+
+### 5.4 失败与中断
+
+- 工具不存在、参数非法或权限拒绝在预检阶段产生该调用的 `rejected` 结果。
+- 运行异常、provider 限流、网络错误和工具业务错误形成独立 `failed` 结果。
+- `timeout`、`canceled`、`rejected` 和 `failed` 必须可区分。
+- 某一调用要求用户确认或输入时，不得借此授权其他调用；交互型调用按 P4 独占策略处理。
+- 如果某工具无法安全取消，父执行取消后其结果只能进入审计，不得继续驱动 DeepAgent。
+
+## 6. 外部状态与结果
+
+工具子任务只形成**调用级状态**，不形成 A2A Task 状态机：
+
+| 状态 | 含义 |
+|---|---|
+| `pending` | Tool Call 已生成，等待预检或执行槽 |
+| `running` | 工具正在执行 |
+| `completed` | 工具成功返回结果 |
+| `failed` | 工具执行失败 |
+| `rejected` | 工具、参数、权限或并行策略校验未通过，未执行 |
+| `canceled` | 随父执行取消或在启动前被取消 |
+| `timeout` | 单调用 deadline 到期 |
+
+父 Agent 的 A2A Task 仍由现有 runtime 状态机拥有。并行工具批次只是父 Agent 执行过程中的内部阶段：成功与部分失败结果由 DeepAgent 消费，最终父 Task 状态由 DeepAgent 执行结果决定。
+
+每个结果项至少包含：
+
+| 字段语义 | 要求 |
+|---|---|
+| batch reference | 关联本轮工具批次 |
+| `tool_call_id` | 与模型生成调用一一对应 |
+| tool name / category | 标识实际工具和工具类别 |
+| status | completed / failed / rejected / canceled / timeout |
+| result / resultRef | 成功输出、受控引用或摘要 |
+| error | 错误码、消息、阶段和可重试性 |
+| timing | 排队、开始、结束和耗时 |
+
+## 7. 用户场景
+
+### 7.1 多源信息并行读取
+
+```text
+用户：结合项目文件、官网信息和内部 REST 数据生成分析
+
+DeepAgent 同一轮生成：
+  1. ReadFileTool(project.md)
+  2. WebFetchWebpageTool(official_url)
+  3. RestfulApi(query_internal_data)
+
+三个调用均为只读，在预算内并行；all-settled 后按 tool_call_id 回灌，DeepAgent 统一分析。
+```
+
+### 7.2 同一工具处理多个实体
+
+DeepAgent 为 A、B、C 三个实体分别生成一个 REST Tool Call。接口声明幂等且允许并发，三个调用可并行；如果 provider 并发上限为二，则两个运行、一个排队，但结果仍按 A、B、C 的原始顺序归位。
+
+### 7.3 文件读写冲突
+
+DeepAgent 同一轮生成两个文件读取和两个文件写入：读取不同文件可并行；写入同一路径的两个调用必须按路径 conflict key 串行或拒绝，不能因 `parallel_tool_calls=true` 同时覆盖文件。
+
+### 7.4 多模态并行处理
+
+DeepAgent 同时调用图像 OCR、音频转录和视频理解。三个工具使用不同输入资源，可在各自模型服务预算内并行。任一模型服务超时只形成该 Tool Call 的超时结果，其余多模态结果仍被保留。
+
+### 7.5 浏览器与移动设备
+
+两个隔离浏览器会话或两台不同移动设备可以并行；同一浏览器页面中的“点击—输入—提交”以及同一移动设备上的连续动作必须保持顺序，不能拆成盲目并行调用。
+
+### 7.6 部分失败
+
+三个 Web / MCP 调用中一个返回限流错误。批次等待其余调用完成，将两个成功结果和一个可重试失败一并回灌 DeepAgent；DeepAgent 可以基于成功结果降级回答，或在下一轮单独重试失败项。
+
+## 8. 行为不变量
+
+1. **子任务等于 Tool Call，不等于 Agent Task。**
+2. **一个 Tool Call 一个稳定 `tool_call_id`。**
+3. **一次工具批次只触发一次 DeepAgent 后续推理。**
+4. **完成顺序不改变结果身份和上下文提交顺序。**
+5. **单项失败不取消其他独立调用。**
+6. **允许并行不等于无界并发。**
+7. **相同工具名不代表可以安全并行。**
+8. **共享写入、外部副作用、交互和控制工具必须保守调度。**
+9. **每个调用独立通过权限、Rail、超时和审计。**
+10. **Agent proxy 即使包装成 Tool，也不进入 FEAT-019。**
+
+## 9. 最小验收用例
+
+| 用例 | 预期结果 |
+|---|---|
+| 一轮生成三个只读 Tool Call | 三个调用时间窗口重叠；结果按原始顺序和 `tool_call_id` 归位；DeepAgent 只继续推理一次。 |
+| `parallel_tool_calls=false` | 三个调用严格按生成顺序串行，输入输出契约不变。 |
+| 同一 REST Tool 三组参数 | 工具和 provider 允许并发时有界并行；不允许时排队或串行，不串结果。 |
+| 一个调用抛出异常 | 其他独立调用继续；结果集中同时存在成功项和失败项。 |
+| 一个调用超时 | 超时项被标记并停止阻塞；其他成功结果保留。 |
+| 同一路径两个 WriteFile | 不得并行覆盖；按 conflict key 串行或在预检阶段拒绝。 |
+| 不同 worktree 两个代码任务 | workspace 隔离成立时允许并行，文件和进程互不污染。 |
+| 同一浏览器页面多个动作 | 按页面 / 会话串行，保持交互顺序。 |
+| 两个 AskUserTool | 不同时向用户提出竞争问题；按父执行独占串行。 |
+| REST / MCP 外部副作用 | 每项独立鉴权、确认和幂等；不得复用另一项的批准。 |
+| 大型多模态结果 | 返回受控结果或引用，不因多个结果同时内联导致上下文失控。 |
+| TaskTool / RemoteAgentTool | 被识别为 Agent 委托并排除，不进入普通工具并行批次。 |
+| 取消父执行 | 未启动调用停止，运行调用 best-effort 取消，迟到结果不触发新一轮推理。 |
+| 轨迹检查 | 可按 batch 和 `tool_call_id` 查看工具类别、状态、耗时和错误，不包含原始 Chain-of-Thought。 |
+
+在三个无排队、无资源冲突且耗时相近的工具调用场景中，并行性能目标为：
+
+```text
+T_batch <= 1.3 × max(T_tool_1, T_tool_2, T_tool_3)
+```
+
+该目标不适用于 provider 限流、工具串行策略、用户确认、资源冲突、重试或 sandbox 冷启动场景。
+
+## 10. 与其他特性的关系
+
+- **FEAT-002 异构 Agent 框架兼容**：openJiuwen adapter 将 DeepAgent 的多 Tool Call、ToolMessage、Rail 和结果归一到 runtime 可观察语义；框架私有 callback context 不提升为公共 runtime Task。
+- **FEAT-004 远程 Agent 编排**：与本特性并列而非上下游依赖。FEAT-004 处理 Agent / A2A Task；FEAT-019 处理普通 Tool Call。`RemoteAgentToolSpec` 必须按真实 Agent 语义归入 FEAT-004。
+- **DFX-001 轨迹可观测性**：补充 batch、`tool_call_id`、工具类别、并行度、排队、冲突、耗时、错误和取消轨迹。
+- **Skill / 工作流能力**：Skill 是可加载上下文和规则资产；workflow 只有通过 Tool / REST / MCP adapter 暴露后才进入本特性，其实例状态仍由工作流引擎拥有。
+
+## 11. 当前版本不承诺
+
+- 不支持下游 Agent、子 Agent、远程 Agent、Agent Team 或 A2A Task 的并行编排。
+- 不支持把 TaskTool、SessionsSpawnTool 或 RemoteAgentTool 包装成普通工具以绕过 Agent 治理。
+- 不支持 Tool Call 之间的依赖图、条件分支、循环或自动拓扑调度。
+- 不承诺所有 openJiuwen 工具都无条件并行；交互、控制、共享写和外部副作用工具必须按安全策略串行或隔离。
+- 不承诺 exactly-once 外部副作用；需要工具 provider 提供幂等键、查询或补偿能力。
+- 不承诺跨进程恢复尚未完成的普通 Tool Call；如需长任务持久化，应提升为受治理 Task 或由对应工具 / 工作流系统提供恢复语义。
+
+---

--- a/version-scope/README.md
+++ b/version-scope/README.md
@@ -3,9 +3,9 @@ level: L1
 view: version-scope
 module: platform
 status: active
-updated: 2026-07-13
+updated: 2026-07-17
 authority: "current version facts across agent-runtime and agent-bus"
-covers: [标准化Agent服务入口, 异构Agent框架兼容, 智能体任务状态缓存, 智能体中间件请求代理, 远程Agent编排, RESTful Client Facade, 客户端调用路由转发, 客户端调用总线转发, 客户端调用事件转发, A2A调用事件转发, Agent Card注册与发现, 运行时实例路由查询, 订阅消费总线事件消息, 轨迹可观测性]
+covers: [标准化Agent服务入口, 异构Agent框架兼容, 智能体任务状态缓存, 智能体中间件请求代理, 远程Agent编排, RESTful Client Facade, 客户端调用路由转发, 客户端调用总线转发, 客户端调用事件转发, A2A调用事件转发, Agent Card注册与发现, 运行时实例路由查询, 订阅消费总线事件消息, 智能体生成并行下游任务, 轨迹可观测性]
 ---
 
 # version-scope
@@ -44,7 +44,7 @@ covers: [标准化Agent服务入口, 异构Agent框架兼容, 智能体任务状
 | FEAT-001 | agent-runtime | active | 标准化 Agent 服务入口 | runtime 作为标准 Agent 服务端，对普通 client、其他 runtime、agent-bus forwarding 暴露同一 A2A Agent Card、JSON-RPC、SSE、Task、错误和租户上下文入口，并支持受信任 runtime-to-runtime webhook 异步完成回调。 | [FEAT-001-standardized-agent-service-entrypoint.md](./FEAT-001-standardized-agent-service-entrypoint.md) | `architecture/L2-Low-Level-Design/agent-runtime/Feat-Func-001-standardized-agent-service-entrypoint.md` |
 | FEAT-002 | agent-runtime | active | 异构 Agent 框架兼容 | 通过统一 Adapter / Handler / SPI 抽象接入异构 Agent 框架；adapter 只桥接请求、调用和结果，不治理框架私有状态。 | [FEAT-002-heterogeneous-agent-framework-compatibility.md](./FEAT-002-heterogeneous-agent-framework-compatibility.md) | `architecture/L2-Low-Level-Design/agent-runtime/Feat-Func-002-heterogeneous-agent-framework-compatibility.md` |
 | FEAT-003 | agent-runtime | active | 智能体任务状态缓存 | 新增标准化 Redis 缓存 SPI，运行时与开发框架复用 Redis 连接池，支持缓存 A2A Task 与 Agent checkpoint。 | [FEAT-003-agent-task-state-cache.md](./FEAT-003-agent-task-state-cache.md) | `architecture/L2-Low-Level-Design/agent-runtime/Feat-Func-003-agent-task-state-cache.md` |
-| FEAT-004 | agent-runtime | active | 远程 Agent 编排 | runtime 作为 A2A 客户端接入远程 Agent，基于 Agent Card 生成本地工具，并支持远程调用、中断续接、进度投射和取消传播。 | [FEAT-004-remote-agent-orchestration.md](./FEAT-004-remote-agent-orchestration.md) | `architecture/L2-Low-Level-Design/agent-runtime/Feat-Func-004-remote-agent-orchestration.md` |
+| FEAT-004 | agent-runtime | active | 远程 Agent 编排 | runtime 作为 A2A 客户端接入远程 Agent，基于 Agent Card 生成本地工具；除单任务调用外，新增任务驱动的有界并行 child Task、fan-out / fan-in、结构化汇聚、定向续接和取消传播范围。 | [FEAT-004-remote-agent-orchestration.md](./FEAT-004-remote-agent-orchestration.md) | [Feat-Func-004-remote-agent-orchestration.md](../architecture/L2-Low-Level-Design/agent-runtime/Feat-Func-004-remote-agent-orchestration.md)（需按新增并行范围更新） |
 | FEAT-005 | agent-runtime | active | 智能体中间件请求代理 | runtime 在部署或启动阶段通过 Skill Hub SPI 代理访问 Skill Hub，使用 runtime 凭据下载 Agent 声明的 skill 包，并把注册材料移交给 agent-core 或框架适配入口。 | [FEAT-005-agent-middleware-request-proxy.md](./FEAT-005-agent-middleware-request-proxy.md) | 待补充 |
 | FEAT-006 | agent-runtime | proposed | RESTful Client Facade | 面向普通业务 client 提供 REST 风格兼容入口，内部归一到 FEAT-001 的标准 Agent 服务入口语义，不作为 runtime-to-runtime、agent-bus 或事件总线协议。 | [FEAT-006-restful-client-facade.md](./FEAT-006-restful-client-facade.md) | 待补充 |
 | FEAT-011 | agent-bus | active | 客户端调用路由转发 | agent-gateway 按目标 agentId / route 语义把客户端调用转发到目标 runtime，同时保持 runtime Task owner 和 A2A 表面不变。 | [FEAT-011-client-invocation-route-forwarding.md](./FEAT-011-client-invocation-route-forwarding.md) | 待补充 |
@@ -54,14 +54,16 @@ covers: [标准化Agent服务入口, 异构Agent框架兼容, 智能体任务状
 | FEAT-015 / Feat-Func-015 | agent-bus/r-and-d-center | draft | Agent Card 注册与发现 | registry-discovery-center 承载 Agent Card 注册、发现、可见性、版本和能力目录事实，为 gateway、runtime 和平台集成提供发现基础。 | [FEAT-015-agent-card-registration-and-discovery.md](./FEAT-015-agent-card-registration-and-discovery.md) | `architecture/L2-Low-Level-Design/agent-bus/registry-discovery-runtime-design.cn.md` |
 | FEAT-016 | agent-bus | draft | 运行时实例路由查询 | registry-discovery-center 支持已知目标的运行时实例路由查询，向 gateway 或 runtime 提供不暴露物理 endpoint 的路由引用和可用性投影。 | [FEAT-016-runtime-instance-route-query.md](./FEAT-016-runtime-instance-route-query.md) | 待补充 |
 | FEAT-017 | agent-runtime | draft | 订阅消费总线事件消息 | runtime 内嵌订阅并消费客户端调用事件和服务间 A2A 请求事件，复用标准 A2A Task 控制面并发布接受、响应、等待输入、流准备和终态投影。 | [FEAT-017-bus-event-subscription-consumption.md](./FEAT-017-bus-event-subscription-consumption.md) | 待补充 |
+| FEAT-019 | agent-runtime | draft | 智能体生成并行下游任务 | DeepAgent 在一次决策中生成多个独立工具子任务，以多个 Tool Call 有界并行调用 openJiuwen 支持的本地函数、REST、MCP及内置工具，all-settled 后按 `tool_call_id` 汇聚并单次继续推理；不含下游 Agent。 | [FEAT-019-parallel-downstream-tool-tasks.md](./FEAT-019-parallel-downstream-tool-tasks.md) | 待补充 |
 
 ## 4. 阅读顺序
 
 1. 先阅读本入口，确认当前版本事实范围和文档关系。
 2. 如果关注 runtime 对外服务入口，先读 `FEAT-001`，再读 `FEAT-002`、`FEAT-003`、`FEAT-004`、`FEAT-005`、`FEAT-006`、`FEAT-017` 和 `DFX-001`。
-3. 如果关注 agent-bus 调用转发链路，按 `FEAT-011`、`FEAT-012`、`FEAT-013`、`FEAT-014`、`FEAT-017` 的顺序阅读。
-4. 如果关注注册发现和路由，阅读 `FEAT-015` 与 `FEAT-016`，再回到调用转发特性确认 route handle、Agent Card 和 Task owner 边界。
-5. 进入 `architecture/L1-High-Level-Design/` 和 `architecture/L2-Low-Level-Design/` 阅读对应架构和详细设计，确认内部设计如何满足这些事实要求。
+3. 如果关注 DeepAgent 在单轮中生成多个工具子任务并并行调用下游工具，阅读 `FEAT-019`；如果关注远程 Agent / A2A Task 并行，阅读 `FEAT-004`。两者不得因 Agent 被包装成 Tool 而混用。
+4. 如果关注 agent-bus 调用转发链路，按 `FEAT-011`、`FEAT-012`、`FEAT-013`、`FEAT-014`、`FEAT-017` 的顺序阅读。
+5. 如果关注注册发现和路由，阅读 `FEAT-015` 与 `FEAT-016`，再回到调用转发特性确认 route handle、Agent Card 和 Task owner 边界。
+6. 进入 `architecture/L1-High-Level-Design/` 和 `architecture/L2-Low-Level-Design/` 阅读对应架构和详细设计，确认内部设计如何满足这些事实要求。
 
 ## 5. 维护规则
 


### PR DESCRIPTION
## What changed

- expand FEAT-004 with bounded parallel remote Agent child-task orchestration semantics
- add FEAT-019 for bounded parallel execution of ordinary downstream tool calls
- update the version-scope index and reading guidance to distinguish remote Agent tasks from ordinary tool tasks

## Why

The version-scope documentation needs explicit, non-overlapping contracts for parallel remote A2A child tasks and parallel local or integrated tool calls. This change defines their boundaries, lifecycle semantics, result aggregation, cancellation, timeout, and acceptance expectations.

## Impact

Documentation and subsequent design work can now align on stable FEAT-004 and FEAT-019 behavior without conflating an Agent exposed as a tool with an ordinary tool invocation.

## Validation

- applied the supplied patch and resolved its documentation-context conflicts
- `git apply --check --reverse spring-ai-ascend-FEAT-019.patch`
- `git diff --check`
- verified no merge-conflict markers or patch reject files remain
