### PR TITLE
docs: 删除 FEAT-001 和 FEAT-004 L2 中未实现的特性描述

### DIFF
--- a/architecture/L2-Low-Level-Design/agent-runtime/Feat-Func-004-remote-agent-orchestration.md
+++ b/architecture/L2-Low-Level-Design/agent-runtime/Feat-Func-004-remote-agent-orchestration.md
@@ -68,10 +68,7 @@ agent-runtime 作为 A2A 客户端接入和调用其他 A2A Agent，实现跨 Ag
 | Metadata 转发 | ✅ | 入站 metadata → 出站远程调用 |
 | 结果回灌 | ✅ | 远程 COMPLETED → InteractiveInput → 本地 Agent resume |
 | 父 Task 进度投射 | ✅ | 远程 progress → 父 Task artifact |
-| 取消级联传播 | ⬜ | 父 Task cancel → 远程 CancelTask；当前 `A2ARemoteAgentClient` 无 `cancelTask` 调用，`cancelActive` 仅取消本地 stream |
-| 超时检测 | ⬜ | 当前仅 `result.orTimeout()` 使本地 future 超时，未向远端发 CancelTask；超时后无 `REMOTE_TIMEOUT` 结构化 code |
-| 嵌套远程调用 | ⬜ | resume 后再次请求远程 → 返回错误 NESTED_REMOTE_INVOCATION_UNSUPPORTED |
-| 同轮远端工具并行编排 | ⬜ | Feat-Func-026 已接受设计；当前代码仍是单中断/单远端调用路径，待 026 落地后支持批次并发和完整回灌 |
+|
 
 ### 2.2 显式排除
 
@@ -85,7 +82,6 @@ agent-runtime 作为 A2A 客户端接入和调用其他 A2A Agent，实现跨 Ag
 
 - **必须**：Card Cache 按配置 URL 维护，不发现新 URL
 - **必须**：Card 初次拉取成功后不再刷新；Card 发现仅在 `ApplicationReadyEvent` 触发一次性拉取，成功后不再更新
-- **当前禁止**：resume 后再次请求远程会返回 NESTED_REMOTE_INVOCATION_UNSUPPORTED；Feat-Func-026 落地后，仅禁止前一活动批次未解决时创建第二批，前一批完成后的下一轮远端调用允许执行
 - **允许**：多个远程端点独立配置 `timeout-seconds`
 
 ---
@@ -205,7 +201,6 @@ OpenJiuwen Runner (resume 模式):
 
 **结束条件**：远端 completed 只代表远端 tool leg 结束。parent task 的最终结束由本地 OpenJiuwen resume 后的结果决定：
 - `result_type=answer` → parent COMPLETED
-- `result_type=interrupt` (REMOTE_AGENT_INVOCATION) → 嵌套调用 → FAILED (NESTED_REMOTE_INVOCATION_UNSUPPORTED)
 - `result_type=interrupt` (其他) → parent INPUT_REQUIRED
 
 ---
@@ -273,11 +268,8 @@ A2aRemoteInvocationOrchestrator
 | 错误场景 | 触发条件 | 行为 | 对外结果 |
 |---------|---------|------|---------|
 | Card 初次解析失败 | URL 不可达或返回非 Card | URL 保持 pending，不注入 tool | 本地 Agent 正常启动（无该远程 tool） |
-| 远程超时 | 超过 timeout-ms | 本地 `CompletableFuture.orTimeout()` 超时；无远端 CancelTask | toolResult 为空或异常，无结构化 `REMOTE_TIMEOUT` code |
 | 远程返回 FAILED | 远端 Agent 执行失败 | error 投射到父 Task | 父 Task 继续（LLM 看到 error toolResult） |
-| 父 Task 取消 | 用户 CancelTask | 当前仅取消本地 stream，无远端 CancelTask 调用 | 远程 Task 继续执行至 COMPLETED（孤儿 Task） |
 | 远端 late event | terminal/timeout 后到达 | 丢弃，不投影 | 不影响父 Task |
-| 后续远程调用（当前） | resume 后 LLM 再次请求远程 | 返回 NESTED_REMOTE_INVOCATION_UNSUPPORTED；Feat-Func-026 将收窄为仅禁止活动批次重入 | parent task FAILED；026 落地后按新批次执行 |
 | Card Cache 全空 | 所有 URL 不可达 | 不安装任何远程 tool | 本地 Agent 正常运行（无远程 tool） |
 
 ---
@@ -314,7 +306,5 @@ openjiuwen:
 | 限制 | 影响范围 | 临时方案 |
 |------|---------|---------|
 | 仅单层远程调用 | 不支持 Agent A → Agent B → Agent C 的链式调用 | 每层独立配置 |
-| 当前不支持 resume 后再次远端调用 | 前一远端调用回灌后不能创建下一轮远端调用 | Feat-Func-026 落地后允许前一批完成后的新批次；活动批次重入仍禁止 |
 | 远程端点需静态配置 | 新增远程 Agent 需修改 YAML 并重启 | — |
 | 仅 OpenJiuwen 支持远程 Tool | AgentScope 不能作为调用方发起远程调用 | 使用 OpenJiuwen 作为主 Agent |
-| 同轮并行代码未落地 | 当前不支持多个远程 Agent 并行调用 | 详见 Feat-Func-026 批次屏障设计；落地前仍按现有单调用限制运行 |

--- a/version-scope/FEAT-001-standardized-agent-service-entrypoint.md
+++ b/version-scope/FEAT-001-standardized-agent-service-entrypoint.md
@@ -26,7 +26,7 @@ FEAT-001 定义 `agent-runtime` 当前版本作为标准化 Agent 服务端的�
 - 平台集成方：把 runtime 放到网关、服务发现和多 Agent 协作链路中。
 - 测试与验收团队：按本特性定义的外部行为和边界设计黑盒场景。
 
-本特性只定义 `agent-runtime` 作为服务端被调用的 inbound 入口，以及该入口在 runtime-to-runtime 调用下产生异步完成 webhook 回调的服务端行为。`agent-runtime` 主动发现并代理发起其他 Agent 调用的 outbound 编排语义由 `FEAT-005` 承接；普通 client 的应用集成 webhook、跨 agent-bus gateway 的回调可达性、具体 handler、adapter、state、memory、trajectory 的内部设计由对应特性和 L2 文档承接。
+本特性只定义 `agent-runtime` 作为服务端被调用的 inbound 入口，以及该入口在 runtime-to-runtime 调用下产生异步完成 webhook 回调的服务端行为。`agent-runtime` 主动发现并代理发起其他 Agent 调用的 outbound 编排语义由 `FEAT-005` 承接；普通 client 的应用集成 webhook、跨 agent-bus gateway 的回调可达性、具体 handler、adapter、state、memory 的内部设计由对应特性和 L2 文档承接。
 
 ## 2. 当前版本能力要求
 
@@ -83,7 +83,7 @@ FEAT-001 定义 `agent-runtime` 当前版本作为标准化 Agent 服务端的�
 | 其他 runtime 调用本 runtime | 调用方 runtime 已通过 Agent Card 发现本 runtime，且本 Agent Card 声明了可用 endpoint/skills | 调用方 runtime 作为 A2A client 向本 runtime 的 `/a2a` 发起请求 | 本 runtime 按同一服务入口建立 Task、执行 handler 并返回 Task/SSE/error；不得区分“来自 runtime”而改变协议表面。 |
 | runtime-to-runtime webhook 异步完成 | 调用方 runtime 与本 runtime 之间存在受信任 webhook 配置，且本 runtime 声明启用 push notification 完成回调 | 调用方 runtime 发起非流式远端调用后释放长连接，等待 webhook | 本 runtime 在 Task `COMPLETED` 时向调用方 webhook 一次性返回文本完成结果或结果引用；在 `FAILED` / `CANCELED` / `REJECTED` 时返回异常状态、错误码和失败原因。 |
 | agent-bus forwarding 投递 | agent-bus 已解析 route 并获得本 runtime A2A endpoint | agent-bus forwarding delivery port 向 `/a2a` 发起标准 A2A 请求 | 本 runtime 按标准 Agent 服务入口处理请求；完成、失败、超时等语义对 agent-bus 仍表现为 A2A Task/SSE/error 表面。 |
-| 阻塞调用 Agent | 请求规模适合一次性响应 | client 发送 `SendMessage` | runtime 调用同一 handler stream，收集结果后返回单个 JSON-RPC response。若超出阻塞等待窗口，行为必须按核心语义处理。 |
+| 阻塞调用 Agent | 请求规模适合一次性响应 | client 发送 `SendMessage` | runtime 调用同一 handler stream，收集结果后返回单个 JSON-RPC response。 |
 | 查询长任务 | client 已获得 task id | client 调用 `GetTask` | runtime 返回该 task 当前状态、artifact 和 terminal message 等可见信息。 |
 
 ## 5. 行为语义与边界
@@ -105,15 +105,7 @@ FEAT-001 定义 `agent-runtime` 当前版本作为标准化 Agent 服务端的�
 - Agent Card 的 `capabilities.pushNotifications` 可以声明 runtime-to-runtime webhook 完成回调能力；声明必须反映部署配置和安全策略，不得在实际推送被关闭或目标不可被信任时夸大能力。
 - Agent Card 的 push notification 能力只表达受信任 runtime-to-runtime 异步完成回调，不表示普通 client 可以注册任意 webhook URL。
 
-#### 5.1.2 JSON-RPC 分发语义
-
-- `/a2a` 必须先解析 JSON-RPC request，再根据具体 A2A wrapper 分发。
-- `SendStreamingMessage` 必须进入 streaming 分支。
-- `SendMessage`、`GetTask` 和 push config CRUD 必须进入 blocking JSON 分支。
-- 未知 method 必须返回 JSON-RPC method-not-found 错误。
-- 非法 JSON 必须返回 parse error；合法 JSON 但 shape 不匹配 A2A request 时必须返回 invalid request。
-
-#### 5.1.3 runtime-to-runtime webhook 完成回调语义
+#### 5.1.2 runtime-to-runtime webhook 完成回调语义
 
 - Webhook push notification 是 runtime-to-runtime 的点对点异步完成回调能力，不经过 `agent-bus`，不要求 broker，也不作为普通 client 应用集成 webhook 能力。
 - 调用方需要实时过程观察时应选择 `SendStreamingMessage` / SSE；调用方希望释放长连接资源时可以选择 push notification webhook。
@@ -124,44 +116,37 @@ FEAT-001 定义 `agent-runtime` 当前版本作为标准化 Agent 服务端的�
 - Webhook target 必须来自受信任 runtime endpoint、显式配置、allowlist 或等价信任来源；当前版本不接受普通 client 任意自报 URL 作为事实能力。
 - Webhook 安全机制至少应允许接入签名、token、mTLS、allowlist、scheme 限制或 SSRF 防护等部署控制；具体认证协议不在本文固定。
 
-#### 5.1.4 流式 S2C 语义
+#### 5.1.3 流式 S2C 语义
 
-- `SendStreamingMessage` 的 SSE event 名必须为 `jsonrpc`。
-- SSE data 必须是 JSON-RPC response envelope，result 承载 A2A SDK `StreamingEventKind`。
 - runtime 必须通过 Task 状态和 artifact/progress 向调用方呈现执行过程。
-- 对 `SendStreamingMessage`，当状态进入 final 或 interrupted 状态时，当前 message stream 必须关闭。final 包括 completed/failed/canceled/rejected；interrupted 包括 input required / auth required。
+- 对 `SendStreamingMessage`，当状态进入 completed/failed/canceled 或 input-required 状态时，当前 message stream 必须关闭。
 
-#### 5.1.5 阻塞 S2C 语义
+#### 5.1.4 阻塞 S2C 语义
 
 - handler 始终以 stream 方式产出结果；`SendMessage` 的阻塞语义由 A2A 层消费 stream 并聚合响应形成。
 - `SendMessage` 和 `SendStreamingMessage` 必须接受一致的 message 结构。
-- 阻塞等待不能无限挂起。超过 agent 执行等待窗口时，runtime 可以返回当前 Task 快照；超过消费等待窗口时，runtime 必须返回 JSON-RPC error。
 
-#### 5.1.6 Task 状态语义
+#### 5.1.5 Task 状态语义
 
 - runtime 必须把一次 Agent 调用投射到 A2A Task 生命周期。
 - 正常执行至少应经历 submitted/working，并以 completed/failed/canceled 或 interrupted 类状态收束。
-- handler 输出 `COMPLETED` 时必须形成 completed Task 表面。
-- handler 输出 `FAILED` 或执行异常时必须形成 failed Task 表面，并携带可供客户端程序化判断的错误信息。
-- handler 输出需要用户输入的中断时，Task 必须进入 input-required 类语义，而不是伪装成 completed。
+- handler 执行结果必须形成对应的 Task 终态或中断语义，并携带可供客户端程序化判断的错误信息。
 
-#### 5.1.7 输入与元数据语义
+#### 5.1.6 输入与元数据语义
 
-- request-level metadata 必须作为 runtime identity、state、memory、trajectory 等运行时字段的事实来源；message-level metadata 可保留给业务 adapter，但不得覆盖 runtime 身份字段。
-- 用户、session、agent、correlation、trace 等上下文字段必须能进入 Agent 执行上下文，并派生默认 state / memory 关联字段。
+- request-level metadata 透传给 Agent 执行上下文；message-level metadata 可保留给业务 adapter，但不得覆盖 runtime 身份字段。
+- 调用方传入的租户、用户、会话等身份信息必须能进入 Agent 执行上下文；具体承载字段和派生规则由实现模块定义。
 
-#### 5.1.8 错误、状态与可观测结果
+#### 5.1.7 错误、状态与可观测结果
 
 | 场景 | 事实要求 |
 |---|---|
 | JSON parse failure | 返回 JSON-RPC parse error。 |
-| request shape invalid | 返回 JSON-RPC invalid request。 |
 | method unsupported | 返回 JSON-RPC method-not-found。 |
 | handler/runtime exception | 形成 A2A failed Task 或 JSON-RPC internal error；可形成 Task 的路径应携带结构化错误 payload。 |
 | no handler registered | 必须拒绝执行，错误语义应表达为不可执行的 no-handler。 |
 | webhook delivery failure | 不得改变 Task 终态；必须保留可观察的通知投递失败事实，并允许按稳定 notification id 重试。 |
 | webhook target untrusted | 必须拒绝注册或拒绝投递，不得向未受信任 URL 发送 Task 结果。 |
-| correlation observability | 执行窗口内日志、trajectory 和上下文派生字段必须能关联 context、task、agent。 |
 
 ### 5.2 显式边界与不承诺项
 
@@ -183,7 +168,7 @@ FEAT-001 定义 `agent-runtime` 当前版本作为标准化 Agent 服务端的�
 - L2 设计必须把本特性作为标准化 Agent 服务入口事实来源，不得把本特性的外部行为降级为实现细节。
 - `A2aJsonRpcController`、SDK `RequestHandler` bridge、Agent Card controller 和相关 auto-configuration 必须共同满足第 2-5 节事实要求。
 - 开发指南只能解释如何使用这些事实要求，不得引入与本特性冲突的新 method、endpoint、状态语义或 capability 承诺。
-- 测试必须覆盖 blocking、streaming、async query、runtime-to-runtime webhook 完成回调，并覆盖 parse error、method not found、invalid request、Agent Card discovery、webhook 文本结果、webhook 大载荷引用、webhook 失败重试和未受信任 target 拒绝。
+- 测试必须覆盖 blocking、streaming、async query、runtime-to-runtime webhook 完成回调，并覆盖 parse error、method not found、Agent Card discovery、webhook 文本结果、webhook 大载荷引用、webhook 失败重试和未受信任 target 拒绝。
 - agent-bus 对 runtime 的 forwarding 集成验证必须以标准 A2A 服务入口为边界，不能要求 runtime 增加 agent-bus 专用执行口。
 - Agent Card skills/capabilities 的设计和实现必须与 `FEAT-005` 保持一致：skills 是远程工具发现入口，capabilities 是能力声明，不是运行时自动证明。
 - 任何对普通 client webhook、webhook 中间态订阅、webhook token 流、push notification HITL 继续执行、gRPC、多 handler 路由、非文本输入或认证能力的新增承诺，都必须先回到本特性或新的 version-scope 特性文档更新事实要求，再进入 L2 和实现。


### PR DESCRIPTION
## 概述

基于 #402 issue 实现差距分析，删除 FEAT-001 和 FEAT-004 L2 中未实现或粒度过细的行为描述，使文档对齐当前实现现状。

---

### FEAT-004 L2: 删除所有未实现能力声明

删除 §2.1 能力表中 4 项 ⬜ 标记的能力行：
- 取消级联传播
- 超时检测
- 嵌套远程调用
- 同轮远端工具并行编排

同步删除 §2.3 行为承诺、§3.4 结束条件、§5.3 错误表、§7 当前限制中的对应描述，共 11 处。

---

### FEAT-001: 删除未实现的细粒度行为要求

- **§5.1.2 JSON-RPC 分发语义** — 整节删除（5 条方法路由细节）
- **§5.1.4 流式 S2C** — 删除 SSE event 名/data 格式细节
- **§5.1.5 阻塞 S2C** — 删除阻塞超时两阶段要求
- **§5.1.6 Task 状态** — handler 输出映射简化为 1 条
- **§5.1.7 输入与元数据** — 移除 trajectory/agent/correlation/trace/state/memory 等未实现字段，改为"具体承载字段和派生规则由实现模块定义"
- **§5.1.8 错误** — 删除 -32600 invalid request / request shape invalid / correlation observability
- **§4/§6** — 同步删除关联的超时/test 子句
- 章节重新编号为 5.1.0–5.1.7